### PR TITLE
feat: 自动发布排行榜并修复 leaderboard_id undefined 问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,53 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.15] - 2025-10-14
+
+### Fixed
+- 🐛 **Fix leaderboard_id undefined bug** - Corrected API response field mapping
+  - API returns `id` and `leaderboard_open_id`, not `leaderboard_id` and `open_id`
+  - Updated `CreateLeaderboardResponse` interface to match actual API response
+  - Fixed: `leaderboard_id` → `id` (排行榜数据库 ID)
+  - Fixed: `open_id` → `leaderboard_open_id` (客户端使用的开放 ID)
+  - Now returns correct IDs when creating leaderboards
+
+### Changed
+- 🚀 **Auto-publish leaderboards** - Simplified user experience by removing whitelist mode complexity
+  - Leaderboards are now automatically published after creation
+  - Removed all whitelist status indicators from UI
+  - Removed whitelist-related user prompts and guidance
+  - Users no longer need to manually publish leaderboards
+  - `publish_leaderboard` tool still available for special use cases
+
+### Improved
+- ✨ **Simplified workflow** - Streamlined leaderboard creation and integration process
+  - Updated creation success message to show auto-publish status
+  - Removed "发布排行榜上线" option from integration workflow
+  - Cleaner leaderboard list display without status badges
+  - Better user experience with fewer manual steps
+
+## [1.0.14] - 2025-10-14
+
+### Added
+- 🚀 **New publish_leaderboard tool** - Control leaderboard visibility
+  - Publish leaderboard to production (visible to all users)
+  - Set to whitelist-only mode (visible to whitelist users only)
+  - Auto-fetches developer_id and app_id
+  - Comprehensive error handling and user guidance
+
+### Improved
+- 💡 **Enhanced integration workflow** - Smart status detection and guidance
+  - Display leaderboard publish status (🚀 published / 🔒 whitelist-only)
+  - Auto-detect whitelist mode and prompt for publishing
+  - Show publish reminders for leaderboards in testing mode
+  - Added "发布排行榜上线" to feature list
+
+### Changed
+- 📝 **Updated create_leaderboard messages** - Inform users about default whitelist mode
+  - Explain new leaderboards start in whitelist-only mode
+  - Provide clear steps for testing and publishing
+  - Guide users through complete workflow
+
 ## [1.0.13] - 2025-10-10
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mikoto_zero/minigame-open-mcp",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "type": "module",
   "description": "TapTap Minigame Open API MCP Server - Documentation and Management APIs for TapTap minigame (Leaderboard, and more features coming)",
   "main": "dist/server.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mikoto_zero/minigame-open-mcp",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "type": "module",
   "description": "TapTap Minigame Open API MCP Server - Documentation and Management APIs for TapTap minigame (Leaderboard, and more features coming)",
   "main": "dist/server.js",

--- a/src/config/toolDefinitions.ts
+++ b/src/config/toolDefinitions.ts
@@ -266,6 +266,44 @@ Auto-fetches developer_id and app_id if not provided. Returns leaderboard_id for
         }
       }
     },
+    {
+      name: 'publish_leaderboard',
+      description: `Publish a leaderboard or set it to whitelist-only mode. Use this when user wants to publish a leaderboard to production or restrict it to whitelist users only.
+
+Usage scenarios:
+- Publish leaderboard to production: set publish=true (makes it visible to all users)
+- Set to whitelist-only mode: set publish=false (only whitelist users can see it)
+- Switch between public and whitelist modes
+
+This is typically used:
+1. After creating a new leaderboard to make it live
+2. During beta testing to limit access to specific users
+3. To temporarily disable public access without deleting the leaderboard
+
+Auto-fetches developer_id and app_id if not provided. Requires leaderboard ID (get from list_leaderboards).`,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          developer_id: {
+            type: 'number',
+            description: 'Developer ID (optional, will be auto-fetched if not provided)'
+          },
+          app_id: {
+            type: 'number',
+            description: 'Application/Game ID (optional, will be auto-fetched if not provided)'
+          },
+          id: {
+            type: 'number',
+            description: 'Leaderboard ID (REQUIRED, get from list_leaderboards tool)'
+          },
+          publish: {
+            type: 'boolean',
+            description: 'true = publish to production (visible to all users), false = whitelist-only mode (visible to whitelist users only) (REQUIRED)'
+          }
+        },
+        required: ['id', 'publish']
+      }
+    },
 
     // 🔑 User Data Tools (requires TDS_MCP_MAC_TOKEN)
     {

--- a/src/handlers/leaderboardHandlers.ts
+++ b/src/handlers/leaderboardHandlers.ts
@@ -91,49 +91,25 @@ export async function startLeaderboardIntegration(
     if (leaderboardsResult.list.length === 1) {
       // Only one leaderboard - recommend using it
       const lb = leaderboardsResult.list[0];
-      const statusEmoji = lb.whitelist_only ? '🔒' : '🚀';
-      const statusText = lb.whitelist_only ? '仅白名单可见（内测模式）' : '已公开发布';
 
       output += `**推荐使用现有排行榜：**\n`;
       output += `- 名称: ${lb.title}\n`;
       output += `- ID: ${lb.leaderboard_open_id}\n`;
       output += `- 周期: ${lb.period}\n`;
-      output += `- 默认: ${lb.is_default ? '是' : '否'}\n`;
-      output += `- 状态: ${statusEmoji} ${statusText}\n\n`;
-
-      // Add publish reminder if still in whitelist mode
-      if (lb.whitelist_only) {
-        output += `💡 **提示：** 此排行榜当前处于内测模式（仅白名单可见）。\n`;
-        output += `完成测试后，可以使用 publish_leaderboard 工具将其发布上线，让所有用户可见。\n\n`;
-      }
+      output += `- 默认: ${lb.is_default ? '是' : '否'}\n\n`;
 
       output += `**下一步：选择要实现的功能**\n`;
       output += `请告诉我您想实现以下哪个功能，我会提供相应的代码示例：\n\n`;
     } else {
       // Multiple leaderboards - let AI/user choose
       output += `**现有排行榜列表：**\n\n`;
-      let hasWhitelistOnly = false;
 
       leaderboardsResult.list.forEach((lb, index) => {
-        const statusEmoji = lb.whitelist_only ? '🔒' : '🚀';
-        const statusText = lb.whitelist_only ? '内测' : '已发布';
-
         output += `${index + 1}. **${lb.title}**\n`;
         output += `   - ID: ${lb.leaderboard_open_id}\n`;
         output += `   - 周期: ${lb.period}\n`;
-        output += `   - 默认: ${lb.is_default ? '是' : '否'}\n`;
-        output += `   - 状态: ${statusEmoji} ${statusText}\n\n`;
-
-        if (lb.whitelist_only) {
-          hasWhitelistOnly = true;
-        }
+        output += `   - 默认: ${lb.is_default ? '是' : '否'}\n\n`;
       });
-
-      // Add publish reminder if any leaderboard is in whitelist mode
-      if (hasWhitelistOnly) {
-        output += `💡 **提示：** 检测到有排行榜处于内测模式（🔒 标记）。\n`;
-        output += `完成测试后，可以使用 publish_leaderboard 工具将其发布上线。\n\n`;
-      }
 
       output += `**下一步：**\n`;
       output += `请选择要使用的排行榜 (通过 leaderboard_open_id)，或者告诉我您想创建新的排行榜。\n\n`;
@@ -145,7 +121,6 @@ export async function startLeaderboardIntegration(
     output += `3. 📥 **查询排行榜数据** - 使用 load_leaderboard_scores 工具查看文档\n`;
     output += `4. 🎯 **查询玩家排名** - 使用 load_current_player_score 工具查看文档\n`;
     output += `5. 👥 **查询周围玩家** - 使用 load_player_centered_scores 工具查看文档\n`;
-    output += `6. 🚀 **发布排行榜上线** - 使用 publish_leaderboard 工具（完成测试后）\n`;
 
     return output;
   } catch (error) {
@@ -229,24 +204,45 @@ export async function createLeaderboard(
       score_unit: args.score_unit
     });
 
-    return `✅ 排行榜创建成功!\n\n` +
+    // 自动发布排行榜（将白名单模式设置为 false，使其对所有用户可见）
+    try {
+      await publishLeaderboardApi({
+        developer_id: developerId,
+        app_id: appId,
+        id: result.id,
+        whitelist_only: false  // 发布上线，所有用户可见
+      }, context.projectPath);
+    } catch (publishError) {
+      // 如果发布失败，记录警告但不阻止创建流程
+      const publishErrorMsg = publishError instanceof Error ? publishError.message : String(publishError);
+      return `✅ 排行榜创建成功!\n\n` +
+             `📊 排行榜信息:\n` +
+             `- Leaderboard ID: ${result.id}\n` +
+             `- Open ID: ${result.leaderboard_open_id}\n` +
+             `- Title: ${result.title}\n\n` +
+             `📝 应用信息（已缓存）:\n` +
+             `- Developer ID: ${developerId}\n` +
+             `- App ID: ${appId}\n\n` +
+             `⚠️ **注意：** 排行榜创建成功，但自动发布失败。\n` +
+             `错误信息: ${publishErrorMsg}\n` +
+             `排行榜当前处于白名单模式，您可以稍后使用 publish_leaderboard 工具手动发布。\n\n` +
+             `🎮 使用方法:\n` +
+             `在小游戏中使用 leaderboardId "${result.leaderboard_open_id}" 来调用排行榜 API`;
+    }
+
+    return `✅ 排行榜创建成功并已自动发布上线!\n\n` +
            `📊 排行榜信息:\n` +
-           `- Leaderboard ID: ${result.leaderboard_id}\n` +
-           `- Open ID: ${result.open_id}\n` +
+           `- Leaderboard ID: ${result.id}\n` +
+           `- Open ID: ${result.leaderboard_open_id}\n` +
            `- Title: ${result.title}\n` +
-           `- Status: ${result.default_status}\n\n` +
+           `- 状态: 🚀 已发布（所有用户可见）\n\n` +
            `📝 应用信息（已缓存）:\n` +
            `- Developer ID: ${developerId}\n` +
            `- App ID: ${appId}\n\n` +
            `🎮 使用方法:\n` +
-           `在小游戏中使用 leaderboardId "${result.leaderboard_id}" 来调用排行榜 API\n\n` +
-           `🔒 **重要提示：**\n` +
-           `新创建的排行榜默认为 **仅白名单可见** 状态（内测模式）。\n` +
-           `这样您可以先进行测试，确认功能正常后再发布上线。\n\n` +
-           `**完成测试后的步骤：**\n` +
-           `1. 在客户端实现排行榜相关功能并测试\n` +
-           `2. 确认一切正常后，使用 publish_leaderboard 工具发布上线\n` +
-           `3. 发布后，所有用户都可以看到该排行榜`;
+           `在小游戏中使用 leaderboardId "${result.leaderboard_open_id}" 来调用排行榜 API\n\n` +
+           `💡 **提示：**\n` +
+           `排行榜已自动发布上线，所有用户都可以看到和使用此排行榜。`;
   } catch (error) {
     const errorMsg = error instanceof Error ? error.message : String(error);
 
@@ -309,21 +305,13 @@ export async function listLeaderboards(
     }
 
     let output = `📋 排行榜列表 (共 ${result.total} 个)\n\n`;
-    let hasWhitelistOnly = false;
 
     result.list.forEach((item, index) => {
-      const statusEmoji = item.whitelist_only ? '🔒' : '🚀';
-      const statusText = item.whitelist_only ? '内测中' : '已发布';
-
-      output += `${index + 1}. **${item.title}** ${statusEmoji} ${statusText}\n`;
+      output += `${index + 1}. **${item.title}**\n`;
       output += `   - ID: ${item.id}\n`;
       output += `   - Open ID: ${item.leaderboard_open_id}\n`;
       output += `   - Period: ${item.period}\n`;
       output += `   - Default: ${item.is_default ? 'Yes' : 'No'}\n\n`;
-
-      if (item.whitelist_only) {
-        hasWhitelistOnly = true;
-      }
     });
 
     const currentPage = args.page || 1;
@@ -335,13 +323,6 @@ export async function listLeaderboards(
       if (currentPage < totalPages) {
         output += `Use page=${currentPage + 1} to see more results.\n`;
       }
-    }
-
-    // Add publish reminder if any leaderboard is in whitelist mode
-    if (hasWhitelistOnly) {
-      output += `\n💡 **提示：** 有排行榜处于内测模式（🔒 标记）。\n`;
-      output += `完成测试后，可以使用 publish_leaderboard 工具发布上线。\n`;
-      output += `示例：将 ID 为 123 的排行榜发布上线，使用参数 { "id": 123, "publish": true }`;
     }
 
     return output;

--- a/src/handlers/leaderboardHandlers.ts
+++ b/src/handlers/leaderboardHandlers.ts
@@ -6,6 +6,7 @@
 import {
   createLeaderboard as createLeaderboardApi,
   listLeaderboards as listLeaderboardsApi,
+  publishLeaderboard as publishLeaderboardApi,
   ensureAppInfo,
   SelectionRequiredError,
   PeriodType,
@@ -90,23 +91,50 @@ export async function startLeaderboardIntegration(
     if (leaderboardsResult.list.length === 1) {
       // Only one leaderboard - recommend using it
       const lb = leaderboardsResult.list[0];
+      const statusEmoji = lb.whitelist_only ? '🔒' : '🚀';
+      const statusText = lb.whitelist_only ? '仅白名单可见（内测模式）' : '已公开发布';
+
       output += `**推荐使用现有排行榜：**\n`;
       output += `- 名称: ${lb.title}\n`;
       output += `- ID: ${lb.leaderboard_open_id}\n`;
       output += `- 周期: ${lb.period}\n`;
-      output += `- 默认: ${lb.is_default ? '是' : '否'}\n\n`;
+      output += `- 默认: ${lb.is_default ? '是' : '否'}\n`;
+      output += `- 状态: ${statusEmoji} ${statusText}\n\n`;
+
+      // Add publish reminder if still in whitelist mode
+      if (lb.whitelist_only) {
+        output += `💡 **提示：** 此排行榜当前处于内测模式（仅白名单可见）。\n`;
+        output += `完成测试后，可以使用 publish_leaderboard 工具将其发布上线，让所有用户可见。\n\n`;
+      }
+
       output += `**下一步：选择要实现的功能**\n`;
       output += `请告诉我您想实现以下哪个功能，我会提供相应的代码示例：\n\n`;
     } else {
       // Multiple leaderboards - let AI/user choose
       output += `**现有排行榜列表：**\n\n`;
+      let hasWhitelistOnly = false;
+
       leaderboardsResult.list.forEach((lb, index) => {
+        const statusEmoji = lb.whitelist_only ? '🔒' : '🚀';
+        const statusText = lb.whitelist_only ? '内测' : '已发布';
+
         output += `${index + 1}. **${lb.title}**\n`;
         output += `   - ID: ${lb.leaderboard_open_id}\n`;
         output += `   - 周期: ${lb.period}\n`;
         output += `   - 默认: ${lb.is_default ? '是' : '否'}\n`;
-        output += `   - 白名单: ${lb.whitelist_only ? '是' : '否'}\n\n`;
+        output += `   - 状态: ${statusEmoji} ${statusText}\n\n`;
+
+        if (lb.whitelist_only) {
+          hasWhitelistOnly = true;
+        }
       });
+
+      // Add publish reminder if any leaderboard is in whitelist mode
+      if (hasWhitelistOnly) {
+        output += `💡 **提示：** 检测到有排行榜处于内测模式（🔒 标记）。\n`;
+        output += `完成测试后，可以使用 publish_leaderboard 工具将其发布上线。\n\n`;
+      }
+
       output += `**下一步：**\n`;
       output += `请选择要使用的排行榜 (通过 leaderboard_open_id)，或者告诉我您想创建新的排行榜。\n\n`;
     }
@@ -117,6 +145,7 @@ export async function startLeaderboardIntegration(
     output += `3. 📥 **查询排行榜数据** - 使用 load_leaderboard_scores 工具查看文档\n`;
     output += `4. 🎯 **查询玩家排名** - 使用 load_current_player_score 工具查看文档\n`;
     output += `5. 👥 **查询周围玩家** - 使用 load_player_centered_scores 工具查看文档\n`;
+    output += `6. 🚀 **发布排行榜上线** - 使用 publish_leaderboard 工具（完成测试后）\n`;
 
     return output;
   } catch (error) {
@@ -210,7 +239,14 @@ export async function createLeaderboard(
            `- Developer ID: ${developerId}\n` +
            `- App ID: ${appId}\n\n` +
            `🎮 使用方法:\n` +
-           `在小游戏中使用 leaderboardId "${result.leaderboard_id}" 来调用排行榜 API`;
+           `在小游戏中使用 leaderboardId "${result.leaderboard_id}" 来调用排行榜 API\n\n` +
+           `🔒 **重要提示：**\n` +
+           `新创建的排行榜默认为 **仅白名单可见** 状态（内测模式）。\n` +
+           `这样您可以先进行测试，确认功能正常后再发布上线。\n\n` +
+           `**完成测试后的步骤：**\n` +
+           `1. 在客户端实现排行榜相关功能并测试\n` +
+           `2. 确认一切正常后，使用 publish_leaderboard 工具发布上线\n` +
+           `3. 发布后，所有用户都可以看到该排行榜`;
   } catch (error) {
     const errorMsg = error instanceof Error ? error.message : String(error);
 
@@ -273,14 +309,21 @@ export async function listLeaderboards(
     }
 
     let output = `📋 排行榜列表 (共 ${result.total} 个)\n\n`;
+    let hasWhitelistOnly = false;
 
     result.list.forEach((item, index) => {
-      output += `${index + 1}. **${item.title}**\n`;
+      const statusEmoji = item.whitelist_only ? '🔒' : '🚀';
+      const statusText = item.whitelist_only ? '内测中' : '已发布';
+
+      output += `${index + 1}. **${item.title}** ${statusEmoji} ${statusText}\n`;
       output += `   - ID: ${item.id}\n`;
       output += `   - Open ID: ${item.leaderboard_open_id}\n`;
       output += `   - Period: ${item.period}\n`;
-      output += `   - Default: ${item.is_default ? 'Yes' : 'No'}\n`;
-      output += `   - Whitelist Only: ${item.whitelist_only ? 'Yes' : 'No'}\n\n`;
+      output += `   - Default: ${item.is_default ? 'Yes' : 'No'}\n\n`;
+
+      if (item.whitelist_only) {
+        hasWhitelistOnly = true;
+      }
     });
 
     const currentPage = args.page || 1;
@@ -292,6 +335,13 @@ export async function listLeaderboards(
       if (currentPage < totalPages) {
         output += `Use page=${currentPage + 1} to see more results.\n`;
       }
+    }
+
+    // Add publish reminder if any leaderboard is in whitelist mode
+    if (hasWhitelistOnly) {
+      output += `\n💡 **提示：** 有排行榜处于内测模式（🔒 标记）。\n`;
+      output += `完成测试后，可以使用 publish_leaderboard 工具发布上线。\n`;
+      output += `示例：将 ID 为 123 的排行榜发布上线，使用参数 { "id": 123, "publish": true }`;
     }
 
     return output;
@@ -307,6 +357,111 @@ export async function listLeaderboards(
 
     const errorMsg = error instanceof Error ? error.message : String(error);
     return `❌ 查询排行榜列表失败:\n${errorMsg}`;
+  }
+}
+
+/**
+ * Publish a leaderboard or set it to whitelist-only mode
+ */
+export async function publishLeaderboard(
+  args: {
+    developer_id?: number;
+    app_id?: number;
+    id: number;
+    publish: boolean;  // true = 发布上线, false = 仅白名单可见
+  },
+  context: HandlerContext
+): Promise<string> {
+  try {
+    // Ensure developer_id and app_id are available
+    let developerId = args.developer_id;
+    let appId = args.app_id;
+
+    // If not provided, try to get from cache or API
+    if (!developerId || !appId) {
+      try {
+        const appInfo = await ensureAppInfo(context.projectPath, true);
+
+        if (!developerId) {
+          developerId = appInfo.developer_id;
+        }
+
+        if (!appId) {
+          appId = appInfo.app_id;
+        }
+      } catch (error) {
+        if (error instanceof SelectionRequiredError) {
+          return `❌ 无法发布排行榜：需要选择应用\n\n` +
+                 error.message + `\n\n` +
+                 `**操作步骤：**\n` +
+                 `1. 使用 list_developers_and_apps 查看所有可用的应用\n` +
+                 `2. 使用 select_app 选择要使用的应用\n` +
+                 `3. 再次调用 publish_leaderboard 发布排行榜`;
+        }
+        throw error;
+      }
+
+      if (!developerId || !appId) {
+        return `❌ 无法获取 developer_id 或 app_id\n\n` +
+               `系统会自动从 /level/v1/list 接口获取您的应用信息。\n` +
+               `如果失败，请检查：\n` +
+               `1. 用户是否已创建应用/游戏\n` +
+               `2. TDS_MCP_MAC_TOKEN 是否有效\n` +
+               `3. 您也可以手动指定 developer_id 和 app_id 参数`;
+      }
+    }
+
+    // whitelist_only 的含义：false = 公开发布，true = 仅白名单可见
+    // 所以我们需要反转用户的输入（publish = true 表示要公开发布）
+    const result = await publishLeaderboardApi({
+      developer_id: developerId,
+      app_id: appId,
+      id: args.id,
+      whitelist_only: !args.publish  // 反转：publish=true 时，whitelist_only=false
+    }, context.projectPath);
+
+    const statusText = result.whitelist_only ? '仅白名单可见' : '已公开发布';
+    const emoji = result.whitelist_only ? '🔒' : '🚀';
+
+    return `${emoji} 排行榜状态更新成功!\n\n` +
+           `📊 排行榜信息:\n` +
+           `- Leaderboard ID: ${result.id}\n` +
+           `- 当前状态: ${statusText}\n\n` +
+           `${result.whitelist_only ?
+             '🔒 **仅白名单可见模式**\n' +
+             '只有白名单中的用户可以看到此排行榜。\n' +
+             '适合用于内测或特定用户群体。' :
+             '🚀 **已公开发布**\n' +
+             '所有用户都可以看到此排行榜。\n' +
+             '排行榜已正式上线！'}`;
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+
+    // 解析具体错误，提供更有针对性的建议
+    let specificHelp = '';
+
+    if (errorMsg.includes('Unauthorized') || errorMsg.includes('401')) {
+      specificHelp = `\n🔑 **认证错误：**\n` +
+                     `请检查环境变量:\n` +
+                     `- TDS_MCP_MAC_TOKEN\n` +
+                     `- TDS_MCP_CLIENT_ID\n` +
+                     `- TDS_MCP_CLIENT_TOKEN`;
+    } else if (errorMsg.includes('403') || errorMsg.includes('Forbidden')) {
+      specificHelp = `\n🚫 **权限错误：**\n` +
+                     `当前用户可能没有修改排行榜的权限，请检查开发者账号权限。`;
+    } else if (errorMsg.includes('404') || errorMsg.includes('Not Found')) {
+      specificHelp = `\n🔍 **排行榜不存在：**\n` +
+                     `请检查排行榜 ID (${args.id}) 是否正确。\n` +
+                     `使用 list_leaderboards 查看所有可用的排行榜。`;
+    }
+
+    return `❌ 发布排行榜失败\n\n` +
+           `**错误信息：**\n${errorMsg}\n${specificHelp}\n\n` +
+           `**常见问题检查：**\n` +
+           `1. 排行榜 ID 是否正确\n` +
+           `2. 环境变量是否正确配置\n` +
+           `3. 用户是否有修改排行榜的权限\n` +
+           `4. 是否有多个应用需要选择`;
   }
 }
 

--- a/src/network/leaderboardApi.ts
+++ b/src/network/leaderboardApi.ts
@@ -398,6 +398,72 @@ export async function listLeaderboards(
 }
 
 /**
+ * Publish leaderboard parameters
+ */
+export interface PublishLeaderboardParams {
+  developer_id?: number;
+  app_id?: number;
+  id: number;  // leaderboard_id
+  whitelist_only: boolean;  // false = 发布上线, true = 仅白名单可见
+}
+
+/**
+ * Publish leaderboard response
+ */
+export interface PublishLeaderboardResponse {
+  id: number;
+  whitelist_only: boolean;
+}
+
+/**
+ * Publish a leaderboard or set it to whitelist-only mode
+ * @param params - Publish parameters
+ * @param projectPath - Optional project path for cache lookup
+ * @returns Updated leaderboard status
+ */
+export async function publishLeaderboard(
+  params: PublishLeaderboardParams,
+  projectPath?: string
+): Promise<PublishLeaderboardResponse> {
+  const client = new HttpClient();
+
+  try {
+    // Ensure developer_id and app_id are available
+    let developerId = params.developer_id;
+    let appId = params.app_id;
+
+    if (!developerId || !appId) {
+      const appInfo = await ensureAppInfo(projectPath);
+      if (!developerId) developerId = appInfo.developer_id;
+      if (!appId) appId = appInfo.app_id;
+    }
+
+    if (!developerId || !appId) {
+      throw new Error('developer_id and app_id are required');
+    }
+
+    const response = await client.post<PublishLeaderboardResponse>('/open/leaderboard/v1/set-whitelist-only', {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: {
+        developer_id: developerId,
+        app_id: appId,
+        id: params.id,
+        whitelist_only: params.whitelist_only
+      }
+    });
+
+    return response;
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new Error(`Failed to publish leaderboard: ${error.message}`);
+    }
+    throw new Error(`Failed to publish leaderboard: ${String(error)}`);
+  }
+}
+
+/**
  * Get enum descriptions for user-friendly display
  */
 export const EnumDescriptions = {

--- a/src/network/leaderboardApi.ts
+++ b/src/network/leaderboardApi.ts
@@ -70,10 +70,10 @@ export interface CreateLeaderboardParams {
  * Create leaderboard response
  */
 export interface CreateLeaderboardResponse {
-  leaderboard_id: string;
-  open_id: string;
+  id: number;  // 排行榜 ID (实际的数据库 ID)
+  leaderboard_open_id: string;  // 排行榜开放 ID (用于客户端调用)
   title: string;
-  default_status: number;
+  is_default: boolean;
 }
 
 /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -51,7 +51,7 @@ class TapTapMinigameMCPServer {
     this.server = new Server(
       {
         name: 'taptap-minigame-mcp',
-        version: '1.0.13',
+        version: '1.0.14',
       }
     );
 
@@ -164,6 +164,9 @@ class TapTapMinigameMCPServer {
     }
     if (name === 'list_leaderboards') {
       return leaderboardHandlers.listLeaderboards(args, this.context);
+    }
+    if (name === 'publish_leaderboard') {
+      return leaderboardHandlers.publishLeaderboard(args, this.context);
     }
 
     // User data tools

--- a/src/server.ts
+++ b/src/server.ts
@@ -51,7 +51,7 @@ class TapTapMinigameMCPServer {
     this.server = new Server(
       {
         name: 'taptap-minigame-mcp',
-        version: '1.0.14',
+        version: '1.0.15',
       }
     );
 


### PR DESCRIPTION
## 📋 概述

本 PR 包含两个主要功能更新和一个重要 bug 修复：

### 1. 🐛 修复 leaderboard_id 返回 undefined 的 bug

**问题描述：**
- 创建排行榜时，返回的 `leaderboard_id` 字段为 `undefined`
- 导致用户无法正常使用排行榜 ID

**根本原因：**
- API 实际返回的字段是 `id` 和 `leaderboard_open_id`
- 代码中错误地使用了 `leaderboard_id` 和 `open_id`

**修复方案：**
- 更新 `CreateLeaderboardResponse` 接口定义
- 正确映射 API 返回字段：
  - `leaderboard_id` → `id` (排行榜数据库 ID)
  - `open_id` → `leaderboard_open_id` (客户端使用的开放 ID)

### 2. 🚀 新增排行榜发布功能 (v1.0.14)

**新增工具：**
- `publish_leaderboard` - 控制排行榜可见性
  - 发布到生产环境（所有用户可见）
  - 设置为白名单模式（仅内测用户可见）
  - 自动获取 developer_id 和 app_id
  - 完善的错误处理和用户引导

**工作流优化：**
- 智能检测排行榜发布状态（🚀 已发布 / 🔒 内测中）
- 自动提示需要发布的排行榜
- 完整的测试到发布流程指引

### 3. ✨ 简化白名单流程 - 自动发布 (v1.0.15)

**优化目标：**
- 简化用户体验，移除白名单流程的复杂性
- 用户创建排行榜后立即可用，无需手动操作

**实现方案：**
- 创建排行榜成功后自动调用发布接口
- 设置 `whitelist_only: false` 使其对所有用户可见
- 如果发布失败，返回警告但不影响创建流程

**界面简化：**
- 移除工作流引导中的状态标识和发布提示
- 移除排行榜列表中的白名单状态显示
- 移除功能列表中的"发布排行榜上线"选项

## 📝 修改文件

### 核心修改
- `src/network/leaderboardApi.ts` - 修复接口定义 + 新增发布 API
- `src/handlers/leaderboardHandlers.ts` - 自动发布逻辑 + 简化提示
- `src/config/toolDefinitions.ts` - 新增发布工具定义
- `src/server.ts` - 注册新工具 + 更新版本号

### 文档更新
- `CHANGELOG.md` - 添加 v1.0.14 和 v1.0.15 版本说明
- `package.json` - 更新版本号到 1.0.15

## 🎯 测试验证

- ✅ TypeScript 编译成功
- ✅ 服务器启动正常（17 个工具）
- ✅ 已发布到 npm: `@mikoto_zero/minigame-open-mcp@1.0.15`

## 📊 影响范围

### 用户体验改进
**之前：**
```
✅ 排行榜创建成功!
- Leaderboard ID: undefined  ❌ (bug)
- 状态: 🔒 仅白名单可见

提示: 完成测试后需要手动发布...
```

**现在：**
```
✅ 排行榜创建成功并已自动发布上线!
- Leaderboard ID: 123  ✅
- Open ID: abc123
- 状态: 🚀 已发布（所有用户可见）

💡 提示：排行榜已自动发布上线，所有用户都可以看到和使用此排行榜。
```

### 版本变化
- 1.0.13 → 1.0.14: 新增发布工具和白名单流程
- 1.0.14 → 1.0.15: 修复 ID bug + 简化白名单流程

## 🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>