### PR TITLE
feat: 添加 MCP Resources 和 Prompts 支持 (v1.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2025-10-14
+
+### Added
+- 🎯 **MCP Resources Support** - Added read-only documentation resources
+  - 8 new Resources for LeaderboardManager API documentation
+  - URI scheme: `docs://leaderboard/api/*` for API docs
+  - URI scheme: `docs://leaderboard/overview` for complete overview
+  - URI scheme: `docs://leaderboard/patterns` for best practices
+  - Resources provide structured, cacheable documentation data
+  - Better semantic clarity: "read documentation" vs "call tool"
+  - Improved AI Agent efficiency with direct resource access
+
+- 🎨 **MCP Prompts Support** - Added reusable workflow templates
+  - `leaderboard-integration` - Complete interactive integration guide
+  - `leaderboard-troubleshooting` - Common issues and solutions guide
+  - Support for parameterized prompts (e.g., specific error codes)
+  - User-triggered workflows for standardized tasks
+  - Pre-built templates for consistent user experience
+
+### Improved
+- 📊 **Better MCP Architecture** - Proper separation of concerns
+  - Tools: Only for operations with side effects (5 tools)
+  - Resources: Read-only documentation and data (8 resources)
+  - Prompts: User-triggered workflow templates (2 prompts)
+  - Follows MCP design philosophy and best practices
+  - Enhanced startup messages showing all three capabilities
+
+- 🔄 **Backward Compatible** - All existing Tools still work
+  - Documentation Tools still available for compatibility
+  - Gradual migration path for existing users
+  - No breaking changes to existing integrations
+
+### Changed
+- 🏗️ **Server Architecture** - Enhanced with new handlers
+  - Added `resourceDefinitions.ts` for Resource configuration
+  - Added `promptDefinitions.ts` for Prompt configuration
+  - Added `promptHandlers.ts` for Prompt template logic
+  - New request handlers: `ListResources`, `ReadResource`, `ListPrompts`, `GetPrompt`
+  - Server now declares all three MCP capabilities
+
+- 📈 **Version Bump** - Minor version increase (1.0.16 → 1.1.0)
+  - Follows semantic versioning
+  - New features without breaking changes
+  - Ready for gradual adoption of Resources and Prompts
+
 ## [1.0.16] - 2025-10-14
 
 ### Improved

--- a/MCP-RESOURCES-PROMPTS.md
+++ b/MCP-RESOURCES-PROMPTS.md
@@ -1,0 +1,339 @@
+# MCP Resources 和 Prompts 功能说明
+
+## 📋 概述
+
+在 v1.1.0 版本中，我们添加了完整的 MCP Resources 和 Prompts 支持，使服务器更符合 MCP 的设计理念。
+
+## 🎯 架构变化
+
+### 之前（v1.0.x）- 全部使用 Tools
+```
+Tools (17个):
+├── 文档工具 (9个) - 返回只读文档
+├── 管理工具 (5个) - 执行实际操作
+└── 辅助工具 (3个) - 环境检查等
+```
+
+### 现在（v1.1.0）- 三种类型分离
+```
+Resources (8个) - 只读文档数据:
+├── docs://leaderboard/api/get-manager
+├── docs://leaderboard/api/open
+├── docs://leaderboard/api/submit-scores
+├── docs://leaderboard/api/load-scores
+├── docs://leaderboard/api/load-player-score
+├── docs://leaderboard/api/load-centered-scores
+├── docs://leaderboard/overview
+└── docs://leaderboard/patterns
+
+Prompts (2个) - 工作流模板:
+├── leaderboard-integration (完整接入引导)
+└── leaderboard-troubleshooting (问题排查指南)
+
+Tools (17个) - 实际操作:
+├── 管理工具 (5个)
+│   ├── create_leaderboard
+│   ├── list_leaderboards
+│   ├── publish_leaderboard
+│   ├── get_user_leaderboard_scores
+│   └── check_environment
+├── 工作流工具 (1个)
+│   └── start_leaderboard_integration
+├── 文档工具 (9个) - 保留以兼容旧版本
+└── 辅助工具 (2个)
+```
+
+## 🆕 新增功能
+
+### 1. Resources - 只读文档
+
+**用途**: 提供结构化的、可缓存的文档数据
+
+**URI 格式**:
+- `docs://leaderboard/api/*` - LeaderboardManager API 文档
+- `docs://leaderboard/overview` - 完整概览
+- `docs://leaderboard/patterns` - 最佳实践
+
+**使用示例**:
+```javascript
+// MCP 客户端调用
+const response = await client.readResource({
+  uri: 'docs://leaderboard/api/submit-scores'
+});
+
+console.log(response.contents[0].text);
+// 输出: submitScores() API 的完整文档
+```
+
+**优点**:
+- ✅ 语义清晰 - "读取文档"而不是"调用工具"
+- ✅ 可缓存 - MCP 客户端可以缓存文档内容
+- ✅ 并发读取 - 无副作用，可以并发访问
+- ✅ 符合规范 - 遵循 MCP 设计理念
+
+### 2. Prompts - 工作流模板
+
+**用途**: 提供预定义的、可重用的交互模板
+
+**可用 Prompts**:
+
+#### `leaderboard-integration`
+完整的排行榜接入引导流程：
+- 自动检查现有排行榜
+- 引导创建或选择排行榜
+- 提供集成代码示例
+
+**使用示例**:
+```javascript
+// MCP 客户端调用
+const prompt = await client.getPrompt({
+  name: 'leaderboard-integration',
+  arguments: {}
+});
+
+// prompt.messages 包含预定义的对话流程
+for (const message of prompt.messages) {
+  console.log(`${message.role}: ${message.content.text}`);
+}
+```
+
+#### `leaderboard-troubleshooting`
+排行榜问题排查指南：
+- 支持通用排查步骤
+- 支持特定错误码排查（可选参数 `error_code`）
+
+**使用示例**:
+```javascript
+// 通用排查
+const prompt1 = await client.getPrompt({
+  name: 'leaderboard-troubleshooting'
+});
+
+// 特定错误码排查
+const prompt2 = await client.getPrompt({
+  name: 'leaderboard-troubleshooting',
+  arguments: { error_code: '500001' }
+});
+```
+
+**优点**:
+- ✅ 标准化工作流 - 一致的用户体验
+- ✅ 用户触发 - 明确的意图表达
+- ✅ 可参数化 - 支持动态内容
+- ✅ 可重用 - 封装最佳实践
+
+## 🔄 向后兼容
+
+为了确保平滑迁移，我们保留了所有现有的 Tools：
+
+### 文档 Tools（保留）
+- `get_leaderboard_manager`
+- `open_leaderboard`
+- `submit_scores`
+- `load_leaderboard_scores`
+- `load_current_player_score`
+- `load_player_centered_scores`
+- `get_leaderboard_overview`
+- `get_leaderboard_patterns`
+- `search_leaderboard_docs`
+
+这些工具仍然可用，但推荐使用对应的 Resources。
+
+### 迁移建议
+
+#### AI Agent 使用者
+**推荐**: 优先使用 Resources 读取文档
+```typescript
+// ✅ 推荐 - 使用 Resources
+readResource('docs://leaderboard/api/submit-scores')
+
+// ⚠️ 仍可用，但不推荐
+callTool('submit_scores')
+```
+
+#### 人类用户
+**推荐**: 使用 Prompts 启动工作流
+```typescript
+// ✅ 推荐 - 使用 Prompts
+getPrompt('leaderboard-integration')
+
+// ⚠️ 仍可用，但不推荐
+callTool('start_leaderboard_integration')
+```
+
+## 📁 新增文件
+
+### 配置文件
+- `src/config/resourceDefinitions.ts` - Resources 定义和 URI 映射
+- `src/config/promptDefinitions.ts` - Prompts 定义
+
+### 处理器文件
+- `src/handlers/promptHandlers.ts` - Prompts 模板生成逻辑
+
+### 修改文件
+- `src/server.ts` - 添加 Resources 和 Prompts 请求处理器
+
+## 🎨 MCP 协议实现
+
+### Resources 协议
+```typescript
+// 列出所有 Resources
+{
+  method: 'resources/list',
+  result: {
+    resources: [
+      {
+        uri: 'docs://leaderboard/api/get-manager',
+        name: 'LeaderboardManager 实例获取',
+        description: '如何获取 LeaderboardManager 实例',
+        mimeType: 'text/markdown'
+      },
+      // ...
+    ]
+  }
+}
+
+// 读取特定 Resource
+{
+  method: 'resources/read',
+  params: {
+    uri: 'docs://leaderboard/api/get-manager'
+  },
+  result: {
+    contents: [
+      {
+        uri: 'docs://leaderboard/api/get-manager',
+        mimeType: 'text/markdown',
+        text: '# tap.getLeaderboardManager\n\n...'
+      }
+    ]
+  }
+}
+```
+
+### Prompts 协议
+```typescript
+// 列出所有 Prompts
+{
+  method: 'prompts/list',
+  result: {
+    prompts: [
+      {
+        name: 'leaderboard-integration',
+        description: 'Complete interactive guide for integrating...',
+        arguments: []
+      },
+      {
+        name: 'leaderboard-troubleshooting',
+        description: 'Common leaderboard issues...',
+        arguments: [
+          {
+            name: 'error_code',
+            description: 'Optional error code...',
+            required: false
+          }
+        ]
+      }
+    ]
+  }
+}
+
+// 获取特定 Prompt
+{
+  method: 'prompts/get',
+  params: {
+    name: 'leaderboard-integration',
+    arguments: {}
+  },
+  result: {
+    description: '排行榜接入完整工作流引导',
+    messages: [
+      {
+        role: 'user',
+        content: {
+          type: 'text',
+          text: '我想在我的 TapTap 小游戏中接入排行榜功能...'
+        }
+      },
+      {
+        role: 'assistant',
+        content: {
+          type: 'text',
+          text: '好的！我会帮你完成排行榜接入...'
+        }
+      }
+    ]
+  }
+}
+```
+
+## 🚀 启动信息
+
+新版本启动时会显示：
+
+```
+🚀 TapTap Minigame MCP Server Started
+📚 Providing 17 tools, 8 resources, 2 prompts
+🏆 Features: Leaderboard Documentation & Management API
+🌍 Environment: production
+🔗 API Base: https://agent.tapapis.cn
+
+📖 MCP Capabilities:
+   ✅ Tools (17) - Execute operations with side effects
+   ✅ Resources (8) - Read-only documentation and data
+   ✅ Prompts (2) - Reusable workflow templates
+
+💡 Tip: Set TAPTAP_MINIGAME_MCP_VERBOSE=true for detailed logs
+```
+
+## 🎯 最佳实践
+
+### 何时使用 Resources
+- ✅ 读取 API 文档
+- ✅ 获取代码示例
+- ✅ 查看配置说明
+- ✅ 访问最佳实践指南
+
+### 何时使用 Prompts
+- ✅ 启动标准化工作流
+- ✅ 获取问题排查指南
+- ✅ 使用预定义的对话模板
+- ✅ 触发常见操作流程
+
+### 何时使用 Tools
+- ✅ 创建排行榜（副作用）
+- ✅ 发布排行榜（副作用）
+- ✅ 查询排行榜列表（需要认证）
+- ✅ 检查环境配置（需要运行时信息）
+
+## 📊 对比总结
+
+| 特性 | Tools | Resources | Prompts |
+|------|-------|-----------|---------|
+| **作用** | 执行操作 | 提供数据 | 提供模板 |
+| **副作用** | ✅ 有 | ❌ 无 | ❌ 无 |
+| **控制方** | 模型控制 | 应用控制 | 用户控制 |
+| **可缓存** | ❌ 否 | ✅ 是 | ✅ 是 |
+| **并发访问** | ⚠️ 需注意 | ✅ 安全 | ✅ 安全 |
+| **参数化** | ✅ 是 | ❌ 否 | ✅ 是 |
+| **用例** | 创建、修改、删除 | 文档、配置、示例 | 工作流、引导、模板 |
+
+## 🔮 未来规划
+
+随着项目的发展，我们将：
+
+1. **逐步迁移**: 鼓励用户使用 Resources 和 Prompts
+2. **标记废弃**: 在未来版本中标记文档类 Tools 为 deprecated
+3. **最终移除**: 在 v2.0.0 中移除废弃的 Tools，保持架构清晰
+
+## 💡 总结
+
+v1.1.0 版本通过添加 Resources 和 Prompts 支持：
+
+- ✅ **更符合 MCP 规范** - 正确分离了不同类型的功能
+- ✅ **更好的语义** - "读取文档" vs "调用工具"
+- ✅ **更高的性能** - Resources 可缓存，可并发
+- ✅ **更好的体验** - Prompts 提供标准化工作流
+- ✅ **向后兼容** - 所有现有功能仍然可用
+
+这是一个重要的架构升级，为未来的功能扩展奠定了坚实的基础！🚀

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mikoto_zero/minigame-open-mcp",
-  "version": "1.0.16",
+  "version": "1.1.0",
   "type": "module",
   "description": "TapTap Minigame Open API MCP Server - Documentation and Management APIs for TapTap minigame (Leaderboard, and more features coming)",
   "main": "dist/server.js",

--- a/src/config/promptDefinitions.ts
+++ b/src/config/promptDefinitions.ts
@@ -1,0 +1,40 @@
+/**
+ * MCP Prompts Definitions
+ * Prompts provide reusable templates and workflows
+ */
+
+export interface PromptArgument {
+  name: string;
+  description: string;
+  required: boolean;
+}
+
+export interface PromptDefinition {
+  name: string;
+  description: string;
+  arguments?: PromptArgument[];
+}
+
+/**
+ * Get all prompt definitions
+ */
+export function getPromptDefinitions(): PromptDefinition[] {
+  return [
+    {
+      name: 'leaderboard-integration',
+      description: 'Complete interactive guide for integrating TapTap leaderboard into your game. Checks existing leaderboards and guides through setup.',
+      arguments: []
+    },
+    {
+      name: 'leaderboard-troubleshooting',
+      description: 'Common leaderboard issues and troubleshooting guide with solutions for frequent error codes.',
+      arguments: [
+        {
+          name: 'error_code',
+          description: 'Optional error code to get specific troubleshooting steps (e.g., 500001, 1025, 104)',
+          required: false
+        }
+      ]
+    }
+  ];
+}

--- a/src/config/resourceDefinitions.ts
+++ b/src/config/resourceDefinitions.ts
@@ -1,0 +1,84 @@
+/**
+ * MCP Resources Definitions
+ * Resources expose read-only documentation and reference data
+ */
+
+export interface ResourceDefinition {
+  uri: string;
+  name: string;
+  description?: string;
+  mimeType?: string;
+}
+
+/**
+ * Get all resource definitions
+ */
+export function getResourceDefinitions(): ResourceDefinition[] {
+  return [
+    // LeaderboardManager API Documentation Resources
+    {
+      uri: 'docs://leaderboard/api/get-manager',
+      name: 'LeaderboardManager 实例获取',
+      description: '如何获取 LeaderboardManager 实例以访问排行榜功能',
+      mimeType: 'text/markdown'
+    },
+    {
+      uri: 'docs://leaderboard/api/open',
+      name: '打开排行榜 UI',
+      description: 'openLeaderboard() API - 打开并显示排行榜页面',
+      mimeType: 'text/markdown'
+    },
+    {
+      uri: 'docs://leaderboard/api/submit-scores',
+      name: '提交玩家分数',
+      description: 'submitScores() API - 向排行榜提交玩家分数',
+      mimeType: 'text/markdown'
+    },
+    {
+      uri: 'docs://leaderboard/api/load-scores',
+      name: '加载排行榜数据',
+      description: 'loadLeaderboardScores() API - 加载排行榜分数列表',
+      mimeType: 'text/markdown'
+    },
+    {
+      uri: 'docs://leaderboard/api/load-player-score',
+      name: '获取当前玩家分数',
+      description: 'loadCurrentPlayerLeaderboardScore() API - 获取当前玩家的分数和排名',
+      mimeType: 'text/markdown'
+    },
+    {
+      uri: 'docs://leaderboard/api/load-centered-scores',
+      name: '加载玩家周围分数',
+      description: 'loadPlayerCenteredScores() API - 加载当前玩家周围的其他玩家分数',
+      mimeType: 'text/markdown'
+    },
+
+    // Overview and Best Practices
+    {
+      uri: 'docs://leaderboard/overview',
+      name: '排行榜系统完整概览',
+      description: '排行榜 API 的完整概览，包括所有功能和使用场景',
+      mimeType: 'text/markdown'
+    },
+    {
+      uri: 'docs://leaderboard/patterns',
+      name: '集成模式和最佳实践',
+      description: '常见使用场景、集成模式和最佳实践指南',
+      mimeType: 'text/markdown'
+    }
+  ];
+}
+
+/**
+ * Resource URI mapping to handler keys
+ */
+export const RESOURCE_URI_MAP: Record<string, string> = {
+  'docs://leaderboard/api/get-manager': 'getLeaderboardManager',
+  'docs://leaderboard/api/open': 'openLeaderboard',
+  'docs://leaderboard/api/submit-scores': 'submitScores',
+  'docs://leaderboard/api/load-scores': 'loadLeaderboardScores',
+  'docs://leaderboard/api/load-player-score': 'loadCurrentPlayerScore',
+  'docs://leaderboard/api/load-centered-scores': 'loadPlayerCenteredScores',
+  'docs://leaderboard/overview': 'getLeaderboardOverview',
+  'docs://leaderboard/patterns': 'getLeaderboardPatterns'
+};

--- a/src/handlers/promptHandlers.ts
+++ b/src/handlers/promptHandlers.ts
@@ -1,0 +1,359 @@
+/**
+ * MCP Prompts Handlers
+ * Handle prompt template generation
+ */
+
+export interface PromptMessage {
+  role: 'user' | 'assistant';
+  content: {
+    type: 'text' | 'image' | 'resource';
+    text?: string;
+    data?: string;
+    mimeType?: string;
+  };
+}
+
+export interface PromptResponse {
+  description?: string;
+  messages: PromptMessage[];
+}
+
+/**
+ * Leaderboard integration guide prompt
+ */
+export async function getLeaderboardIntegrationPrompt(args: any): Promise<PromptResponse> {
+  return {
+    description: '排行榜接入完整工作流引导',
+    messages: [
+      {
+        role: 'user',
+        content: {
+          type: 'text',
+          text: `我想在我的 TapTap 小游戏中接入排行榜功能。请帮我：
+
+1. 检查我是否已经有排行榜配置
+2. 如果没有，引导我创建新的排行榜
+3. 如果有，列出现有排行榜供我选择
+4. 提供完整的客户端集成代码示例
+
+请使用 list_leaderboards 工具开始检查。`
+        }
+      },
+      {
+        role: 'assistant',
+        content: {
+          type: 'text',
+          text: `好的！我会帮你完成排行榜接入。让我先检查你现有的排行榜配置...
+
+**步骤 1: 检查现有排行榜**
+我会调用 list_leaderboards 工具来查看你已有的排行榜。
+
+**接下来的步骤：**
+- 如果你还没有排行榜，我会引导你使用 create_leaderboard 创建
+- 如果已有排行榜，我会列出它们并提供对应的集成代码
+
+让我现在开始检查...`
+        }
+      }
+    ]
+  };
+}
+
+/**
+ * Leaderboard troubleshooting guide prompt
+ */
+export async function getLeaderboardTroubleshootingPrompt(args: any): Promise<PromptResponse> {
+  const errorCode = args.error_code;
+
+  if (errorCode) {
+    // Specific error code troubleshooting
+    return {
+      description: `排行榜错误 ${errorCode} 的排查指南`,
+      messages: [
+        {
+          role: 'user',
+          content: {
+            type: 'text',
+            text: `我遇到了排行榜错误代码 ${errorCode}，请帮我排查和解决。`
+          }
+        },
+        {
+          role: 'assistant',
+          content: {
+            type: 'text',
+            text: getErrorCodeSolution(errorCode)
+          }
+        }
+      ]
+    };
+  }
+
+  // General troubleshooting guide
+  return {
+    description: '排行榜常见问题排查指南',
+    messages: [
+      {
+        role: 'user',
+        content: {
+          type: 'text',
+          text: '我在使用 TapTap 排行榜时遇到了问题，请提供常见问题的排查步骤。'
+        }
+      },
+      {
+        role: 'assistant',
+        content: {
+          type: 'text',
+          text: `# TapTap 排行榜常见问题排查指南
+
+## 🔍 常见错误代码
+
+### 错误码 500001: 排行榜 ID 未找到
+**原因：** leaderboard_id 不存在或输入错误
+
+**解决方案：**
+1. 使用 list_leaderboards 工具检查你的排行榜 ID
+2. 确认排行榜已经创建并发布
+3. 检查 leaderboard_id 拼写是否正确
+
+### 错误码 1025: 未声明好友关系权限
+**原因：** 尝试访问好友排行榜但未申请权限
+
+**解决方案：**
+1. 在 TapTap 开发者中心申请好友关系权限
+2. 等待审核通过
+3. 或者使用 collection: "public" 显示全局排行榜
+
+### 错误码 104/103: 用户隐私/授权问题
+**原因：** 用户未授权或隐私设置限制
+
+**解决方案：**
+1. 确保用户已登录 TapTap
+2. 引导用户授权必要的权限
+3. 处理用户拒绝授权的情况
+
+## 🛠️ 排查步骤
+
+### 1. 检查环境配置
+使用 check_environment 工具验证：
+- MAC Token 是否正确配置
+- Client ID 和 Secret 是否有效
+- 网络连接是否正常
+
+### 2. 验证排行榜配置
+使用 list_leaderboards 工具检查：
+- 排行榜是否已创建
+- 排行榜状态是否正常
+- leaderboard_id 是否正确
+
+### 3. 检查客户端代码
+确认以下几点：
+- LeaderboardManager 实例正确获取
+- leaderboard_id 传递正确
+- 回调函数正确处理错误
+
+### 4. 查看详细文档
+使用 Resources 获取详细 API 文档：
+- docs://leaderboard/api/open - 打开排行榜 API
+- docs://leaderboard/api/submit-scores - 提交分数 API
+- docs://leaderboard/overview - 完整概览
+
+## 💡 最佳实践
+
+1. **始终实现错误处理回调**
+\`\`\`javascript
+callback: {
+  onFailure: function(code, message) {
+    console.error(\`Error \${code}: \${message}\`);
+    // 向用户显示友好的错误提示
+  }
+}
+\`\`\`
+
+2. **先检查后使用**
+在使用排行榜前，先调用 list_leaderboards 确认配置
+
+3. **处理网络异常**
+实现重试机制和离线提示
+
+需要针对特定错误的帮助吗？请告诉我错误代码，我会提供详细的解决方案。`
+        }
+      }
+    ]
+  };
+}
+
+/**
+ * Get specific error code solution
+ */
+function getErrorCodeSolution(errorCode: string): string {
+  const solutions: Record<string, string> = {
+    '500001': `# 错误码 500001: 排行榜 ID 未找到
+
+## 问题原因
+你使用的 leaderboard_id 在系统中不存在。
+
+## 解决步骤
+
+### 1. 检查现有排行榜
+我会帮你调用 list_leaderboards 工具来查看你的所有排行榜。
+
+### 2. 常见原因
+- 排行榜尚未创建
+- leaderboard_id 拼写错误
+- 排行榜已被删除
+- 使用了其他应用的 leaderboard_id
+
+### 3. 解决方案
+如果你还没有排行榜，可以使用 create_leaderboard 工具创建：
+
+\`\`\`javascript
+// 创建排行榜示例
+{
+  "name": "每周高分榜",
+  "score_type": "better_than",
+  "reset_cycle": "weekly",
+  "sort_order": "desc"
+}
+\`\`\`
+
+创建成功后，你会获得一个 leaderboard_id，在客户端代码中使用它。
+
+需要我帮你检查或创建排行榜吗？`,
+
+    '1025': `# 错误码 1025: 未声明好友关系权限
+
+## 问题原因
+你的代码尝试访问好友排行榜（collection: "friends"），但应用未申请好友关系权限。
+
+## 解决步骤
+
+### 1. 申请权限
+前往 TapTap 开发者中心：
+1. 选择你的应用
+2. 进入"权限管理"
+3. 申请"好友关系权限"
+4. 等待审核通过
+
+### 2. 临时解决方案
+在权限审核期间，使用全局排行榜：
+
+\`\`\`javascript
+leaderboardManager.openLeaderboard({
+  leaderboardId: "your_leaderboard_id",
+  collection: "public",  // 使用全局排行榜
+  callback: {
+    onSuccess: function(res) {
+      console.log("打开成功");
+    }
+  }
+});
+\`\`\`
+
+### 3. 权限通过后
+权限审核通过后，就可以使用好友排行榜：
+
+\`\`\`javascript
+collection: "friends"  // 显示好友排行榜
+\`\`\`
+
+需要查看完整的 openLeaderboard API 文档吗？可以访问 Resource: docs://leaderboard/api/open`,
+
+    '104': `# 错误码 104: 用户未授权
+
+## 问题原因
+当前用户未登录或未授权访问排行榜功能。
+
+## 解决步骤
+
+### 1. 检查用户登录状态
+确保用户已登录 TapTap：
+
+\`\`\`javascript
+// 检查登录状态
+tap.checkLoginStatus({
+  onSuccess: function(res) {
+    if (res.isLogin) {
+      // 用户已登录，可以使用排行榜
+      openLeaderboard();
+    } else {
+      // 引导用户登录
+      tap.login({
+        onSuccess: function() {
+          openLeaderboard();
+        }
+      });
+    }
+  }
+});
+\`\`\`
+
+### 2. 处理授权流程
+\`\`\`javascript
+leaderboardManager.openLeaderboard({
+  leaderboardId: "your_leaderboard_id",
+  callback: {
+    onFailure: function(code, message) {
+      if (code === 104) {
+        // 引导用户登录
+        showLoginDialog();
+      }
+    }
+  }
+});
+\`\`\`
+
+### 3. 用户体验优化
+- 在使用排行榜前主动检查登录状态
+- 提供清晰的登录引导
+- 处理用户拒绝登录的情况
+
+需要更多关于用户认证的帮助吗？`,
+
+    '103': `# 错误码 103: 用户隐私设置限制
+
+## 问题原因
+用户的隐私设置限制了排行榜数据的访问。
+
+## 解决步骤
+
+### 1. 尊重用户隐私
+这是用户的主动选择，应用应该优雅处理：
+
+\`\`\`javascript
+leaderboardManager.openLeaderboard({
+  leaderboardId: "your_leaderboard_id",
+  callback: {
+    onFailure: function(code, message) {
+      if (code === 103) {
+        // 向用户说明隐私设置的影响
+        showMessage("由于隐私设置，无法显示你的排行榜数据");
+      }
+    }
+  }
+});
+\`\`\`
+
+### 2. 提供替代方案
+- 仍然显示全局排行榜（不包含该用户）
+- 提供其他游戏功能
+- 说明如何修改隐私设置（但不要强制）
+
+### 3. 最佳实践
+- 不要重复提示用户修改隐私设置
+- 确保应用的其他功能正常可用
+- 在 UI 上给予友好提示
+
+用户隐私是重要的，应用应该优雅地处理这种情况。`
+  };
+
+  return solutions[errorCode] || `# 错误码 ${errorCode}
+
+这是一个不常见的错误代码。建议：
+
+1. 使用 check_environment 工具检查环境配置
+2. 查看完整的 API 文档（使用 Resources）
+3. 检查网络连接和 API 响应
+4. 联系 TapTap 技术支持获取帮助
+
+需要我帮你检查环境配置吗？`;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,10 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
+  ListPromptsRequestSchema,
+  GetPromptRequestSchema,
   McpError,
   ErrorCode
 } from '@modelcontextprotocol/sdk/types.js';
@@ -17,6 +21,8 @@ import process from 'node:process';
 // 导入配置和工具定义
 import { ApiConfig } from './network/httpClient.js';
 import { getToolDefinitions } from './config/toolDefinitions.js';
+import { getResourceDefinitions, RESOURCE_URI_MAP } from './config/resourceDefinitions.js';
+import { getPromptDefinitions } from './config/promptDefinitions.js';
 import { logger } from './utils/logger.js';
 
 // 导入文档工具
@@ -26,6 +32,7 @@ import { leaderboardTools } from './tools/leaderboardTools.js';
 import * as appHandlers from './handlers/appHandlers.js';
 import * as leaderboardHandlers from './handlers/leaderboardHandlers.js';
 import * as environmentHandlers from './handlers/environmentHandlers.js';
+import * as promptHandlers from './handlers/promptHandlers.js';
 
 // 环境变量配置
 const apiConfig = ApiConfig.getInstance();
@@ -51,7 +58,7 @@ class TapTapMinigameMCPServer {
     this.server = new Server(
       {
         name: 'taptap-minigame-mcp',
-        version: '1.0.16',
+        version: '1.1.0',
       }
     );
 
@@ -103,6 +110,102 @@ class TapTapMinigameMCPServer {
         );
       }
     });
+
+    // 设置资源列表处理器
+    this.server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+      resources: getResourceDefinitions()
+    }));
+
+    // 设置资源读取处理器
+    this.server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+      const uri = request.params.uri;
+
+      logger.logToolCall(`ReadResource: ${uri}`, {});
+
+      try {
+        const content = await this.handleResourceRead(uri);
+
+        logger.logToolResponse(`ReadResource: ${uri}`, content.substring(0, 500), true);
+
+        return {
+          contents: [
+            {
+              uri: uri,
+              mimeType: 'text/markdown',
+              text: content
+            }
+          ]
+        };
+      } catch (error) {
+        logger.logToolResponse(`ReadResource: ${uri}`, error instanceof Error ? error.message : String(error), false);
+
+        throw new McpError(
+          ErrorCode.InternalError,
+          `资源读取失败: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    });
+
+    // 设置提示列表处理器
+    this.server.setRequestHandler(ListPromptsRequestSchema, async () => ({
+      prompts: getPromptDefinitions()
+    }));
+
+    // 设置提示获取处理器
+    this.server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+      const { name, arguments: args } = request.params;
+
+      logger.logToolCall(`GetPrompt: ${name}`, args || {});
+
+      try {
+        const prompt = await this.handlePromptGet(name, args || {});
+
+        logger.logToolResponse(`GetPrompt: ${name}`, JSON.stringify(prompt).substring(0, 500), true);
+
+        return prompt;
+      } catch (error) {
+        logger.logToolResponse(`GetPrompt: ${name}`, error instanceof Error ? error.message : String(error), false);
+
+        throw new McpError(
+          ErrorCode.InternalError,
+          `提示获取失败: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    });
+  }
+
+  /**
+   * 处理资源读取 - 路由到对应的文档工具
+   */
+  private async handleResourceRead(uri: string): Promise<string> {
+    const handlerKey = RESOURCE_URI_MAP[uri];
+
+    if (!handlerKey) {
+      throw new Error(`Unknown resource URI: ${uri}`);
+    }
+
+    // Map to leaderboardTools methods
+    const toolMethod = (leaderboardTools as any)[handlerKey];
+    if (typeof toolMethod !== 'function') {
+      throw new Error(`Handler not found for resource: ${uri}`);
+    }
+
+    return await toolMethod();
+  }
+
+  /**
+   * 处理提示获取 - 路由到对应的提示处理器
+   */
+  private async handlePromptGet(name: string, args: any): Promise<any> {
+    if (name === 'leaderboard-integration') {
+      return promptHandlers.getLeaderboardIntegrationPrompt(args);
+    }
+
+    if (name === 'leaderboard-troubleshooting') {
+      return promptHandlers.getLeaderboardTroubleshootingPrompt(args);
+    }
+
+    throw new Error(`Unknown prompt: ${name}`);
   }
 
   /**
@@ -189,18 +292,25 @@ class TapTapMinigameMCPServer {
     await this.server.connect(transport);
 
     const tools = getToolDefinitions();
+    const resources = getResourceDefinitions();
+    const prompts = getPromptDefinitions();
+
     process.stderr.write('🚀 TapTap Minigame MCP Server Started\n');
-    process.stderr.write(`📚 Providing ${tools.length} tools\n`);
+    process.stderr.write(`📚 Providing ${tools.length} tools, ${resources.length} resources, ${prompts.length} prompts\n`);
     process.stderr.write('🏆 Features: Leaderboard Documentation & Management API\n');
     process.stderr.write(`🌍 Environment: ${apiConfig.environment}\n`);
     process.stderr.write(`🔗 API Base: ${apiConfig.apiBaseUrl}\n`);
+    process.stderr.write('\n📖 MCP Capabilities:\n');
+    process.stderr.write(`   ✅ Tools (${tools.length}) - Execute operations with side effects\n`);
+    process.stderr.write(`   ✅ Resources (${resources.length}) - Read-only documentation and data\n`);
+    process.stderr.write(`   ✅ Prompts (${prompts.length}) - Reusable workflow templates\n`);
 
     if (logger.isVerbose()) {
-      process.stderr.write('🔍 Verbose logging enabled (TAPTAP_MINIGAME_MCP_VERBOSE=true)\n');
+      process.stderr.write('\n🔍 Verbose logging enabled (TAPTAP_MINIGAME_MCP_VERBOSE=true)\n');
       process.stderr.write('   - Tool call inputs and outputs will be logged\n');
       process.stderr.write('   - HTTP requests and responses will be logged\n');
     } else {
-      process.stderr.write('💡 Tip: Set TAPTAP_MINIGAME_MCP_VERBOSE=true for detailed logs\n');
+      process.stderr.write('\n💡 Tip: Set TAPTAP_MINIGAME_MCP_VERBOSE=true for detailed logs\n');
     }
   }
 }

--- a/test-mcp-features.js
+++ b/test-mcp-features.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+/**
+ * Simple test script to verify MCP Resources and Prompts
+ */
+
+import { spawn } from 'child_process';
+
+// Start the MCP server
+const server = spawn('node', ['dist/server.js'], {
+  env: {
+    ...process.env,
+    TDS_MCP_MAC_TOKEN: '{"kid":"test","token_type":"mac","mac_key":"test","mac_algorithm":"hmac-sha-1"}',
+    TDS_MCP_CLIENT_ID: 'test',
+    TDS_MCP_CLIENT_TOKEN: 'test'
+  }
+});
+
+let responseData = '';
+
+server.stdout.on('data', (data) => {
+  responseData += data.toString();
+});
+
+server.stderr.on('data', (data) => {
+  console.error('Server log:', data.toString());
+});
+
+// Wait for server to start
+setTimeout(() => {
+  console.log('\n🧪 Testing MCP Server Features\n');
+
+  // Test 1: List Resources
+  console.log('📖 Test 1: List Resources');
+  const listResourcesRequest = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'resources/list',
+    params: {}
+  };
+
+  server.stdin.write(JSON.stringify(listResourcesRequest) + '\n');
+
+  setTimeout(() => {
+    // Test 2: Read a Resource
+    console.log('\n📖 Test 2: Read Resource (docs://leaderboard/overview)');
+    const readResourceRequest = {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'resources/read',
+      params: {
+        uri: 'docs://leaderboard/overview'
+      }
+    };
+
+    server.stdin.write(JSON.stringify(readResourceRequest) + '\n');
+
+    setTimeout(() => {
+      // Test 3: List Prompts
+      console.log('\n🎨 Test 3: List Prompts');
+      const listPromptsRequest = {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'prompts/list',
+        params: {}
+      };
+
+      server.stdin.write(JSON.stringify(listPromptsRequest) + '\n');
+
+      setTimeout(() => {
+        // Test 4: Get a Prompt
+        console.log('\n🎨 Test 4: Get Prompt (leaderboard-integration)');
+        const getPromptRequest = {
+          jsonrpc: '2.0',
+          id: 4,
+          method: 'prompts/get',
+          params: {
+            name: 'leaderboard-integration',
+            arguments: {}
+          }
+        };
+
+        server.stdin.write(JSON.stringify(getPromptRequest) + '\n');
+
+        setTimeout(() => {
+          console.log('\n✅ All tests sent!');
+          console.log('\n📊 Response data:');
+          console.log(responseData);
+
+          // Kill server
+          server.kill();
+          process.exit(0);
+        }, 1000);
+      }, 1000);
+    }, 1000);
+  }, 1000);
+}, 2000);
+
+setTimeout(() => {
+  console.error('\n❌ Timeout - killing server');
+  server.kill();
+  process.exit(1);
+}, 10000);


### PR DESCRIPTION
## 🎯 功能概述

添加完整的 MCP Resources 和 Prompts 支持，使服务器架构更符合 MCP 设计规范。

## ✨ 主要变更

### 🎯 新增 MCP Resources (8个)
- 提供只读文档资源，数据结构化且可缓存
- URI scheme: `docs://leaderboard/api/*` - LeaderboardManager API 文档 (6个)
- URI scheme: `docs://leaderboard/overview` - 完整概览
- URI scheme: `docs://leaderboard/patterns` - 最佳实践指南
- 实现 `resources/list` 和 `resources/read` MCP 协议

### 🎨 新增 MCP Prompts (2个)
- `leaderboard-integration` - 排行榜接入完整引导流程
- `leaderboard-troubleshooting` - 问题排查指南（支持参数化，可指定错误码）
- 实现 `prompts/list` 和 `prompts/get` MCP 协议

### 📊 架构改进
正确分离三种 MCP 原语的职责：
- **Tools (17个)**: 仅用于有副作用的操作
- **Resources (8个)**: 只读文档和数据
- **Prompts (2个)**: 用户触发的工作流模板

### 🔄 向后兼容
- 保留所有现有的文档类 Tools
- 不影响现有用户的使用
- 提供平滑的迁移路径

## 📁 新增文件

- \`src/config/resourceDefinitions.ts\` - Resources 配置和 URI 映射
- \`src/config/promptDefinitions.ts\` - Prompts 定义
- \`src/handlers/promptHandlers.ts\` - Prompts 模板生成逻辑
- \`MCP-RESOURCES-PROMPTS.md\` - 完整功能说明文档
- \`test-mcp-features.js\` - 功能测试脚本

## 🚀 启动效果

\`\`\`
🚀 TapTap Minigame MCP Server Started
📚 Providing 17 tools, 8 resources, 2 prompts

📖 MCP Capabilities:
   ✅ Tools (17) - Execute operations with side effects
   ✅ Resources (8) - Read-only documentation and data
   ✅ Prompts (2) - Reusable workflow templates
\`\`\`

Ready for review and merge! 🚀