### PR TITLE
fix: correct repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,10 +81,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/taptap/minigame-open-mcp.git"
+    "url": "git+https://github.com/taptap/taptap_minigame_open_mcp.git"
   },
-  "homepage": "https://github.com/taptap/minigame-open-mcp#readme",
+  "homepage": "https://github.com/taptap/taptap_minigame_open_mcp#readme",
   "bugs": {
-    "url": "https://github.com/taptap/minigame-open-mcp/issues"
+    "url": "https://github.com/taptap/taptap_minigame_open_mcp/issues"
   }
 }


### PR DESCRIPTION
## 问题描述

GitHub Action 中的 semantic-release 执行失败:
```
fatal: repository 'https://github.com/taptap/minigame-open-mcp.git/' not found
```

## 根本原因

package.json 中配置的仓库 URL 与实际仓库不匹配:
- ❌ 旧配置: `https://github.com/taptap/minigame-open-mcp.git`
- ✅ 实际仓库: `https://github.com/taptap/taptap_minigame_open_mcp.git`

## 修改内容

修正 package.json 中的三个 URL:
- `repository.url`
- `homepage`
- `bugs.url`

## 影响

修复此问题后,semantic-release 将能够:
- ✅ 正确访问 Git 仓库
- ✅ 自动创建 GitHub Release
- ✅ 完成版本发布流程

## 测试计划

- [x] 本地验证 Git remote URL
- [ ] PR 合并后观察 GitHub Action 执行结果

🤖 Generated with [Claude Code](https://claude.com/claude-code)