### PR TITLE
fix: enable npm provenance for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
           # 创建并切换到新分支
           git checkout -b "$BRANCH"
 
-      # ========== 5. 发布到 npm ==========
+      # ========== 5. 发布到 npm (使用 Provenance) ==========
       - name: Publish to npm
         if: steps.analyze.outputs.should_release == 'true'
         env:
@@ -105,8 +105,8 @@ jobs:
           # 更新版本号 (不创建 git tag)
           npm version $VERSION --no-git-tag-version
 
-          # 发布到 npm
-          npm publish --access public
+          # 发布到 npm (启用 provenance)
+          npm publish --access public --provenance
 
       # ========== 6. 生成 CHANGELOG ==========
       - name: Generate CHANGELOG

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -779,15 +779,21 @@ PR 合并到 main/beta/alpha 分支后自动运行：
    - 更新 package.json
    - 生成/更新 CHANGELOG.md
    - Git commit 和 tag
-   - 发布到 npm
+   - **发布到 npm（带 Provenance）**
    - 创建 GitHub Release
+
+**npm Provenance（可信发布）：**
+- ✅ 使用 GitHub OIDC 认证，无需 NPM_TOKEN
+- ✅ 自动生成来源证明（Provenance Statement）
+- ✅ 提供构建透明度和供应链安全
+- ✅ 通过 `npm publish --provenance` 启用
 
 ### 配置文件
 
 - `.releaserc.js` - Semantic Release 配置
 - `.commitlintrc.js` - Commitlint 配置
 - `.github/workflows/pr.yml` - PR 检查工作流
-- `.github/workflows/release.yml` - 发布工作流
+- `.github/workflows/release.yml` - 发布工作流（含 Provenance）
 
 ### 环境变量和 Secrets
 
@@ -795,9 +801,20 @@ PR 合并到 main/beta/alpha 分支后自动运行：
 
 **Secrets (Settings → Secrets and variables → Actions):**
 - `NPM_TOKEN` - npm 发布令牌（必需）
+  - **推荐**：创建 **Automation Token**（可绕过 2FA）
+  - **安全**：发布时使用 `--provenance` 启用 Trusted Publishing
 
 **自动提供（无需配置）:**
 - `GITHUB_TOKEN` - GitHub API 令牌（用于创建 PR、合并、创建 Release）
+
+**Permissions 要求：**
+```yaml
+permissions:
+  contents: write      # 创建 commit 和 tag
+  issues: write        # 发布说明
+  pull-requests: write # 创建和合并 PR
+  id-token: write      # OIDC 认证（Provenance）
+```
 
 ### 手动操作
 


### PR DESCRIPTION
## 📦 启用 npm Provenance（可信发布）

### 问题
之前的发布流程因为 npm 2FA 要求而失败：
```
npm error code EOTP
npm error This operation requires a one-time password from your authenticator.
```

### 解决方案
启用 npm Provenance（Trusted Publishing），通过 GitHub OIDC 认证提供更强的供应链安全保证。

### 主要变更

#### 1. 更新 GitHub Actions Workflow
- ✅ 在 `npm publish` 命令中添加 `--provenance` 标志
- ✅ 已有 `id-token: write` permission（OIDC 认证必需）
- ✅ 使用 GitHub-hosted runner

#### 2. 更新文档
- ✅ 在 `CLAUDE.md` 中添加 Provenance 说明
- ✅ 说明 Automation Token + Provenance 的组合使用
- ✅ 列出所需的 Permissions 配置

### 技术细节

**npm Provenance 的优势：**
- 🔐 使用 GitHub OIDC 认证
- 📋 自动生成来源证明（Provenance Statement）
- 🔍 提供构建透明度和供应链安全
- ✅ 用户可验证包的真实来源和构建过程

**工作原理：**
1. `NPM_TOKEN` (Automation Token) 提供身份验证并绕过 2FA
2. `--provenance` 标志触发 OIDC 认证
3. npm 自动生成 Provenance Statement
4. 包页面显示 Verified 标记和构建详情

**发布后效果：**
- npm 包页面显示 Provenance Badge
- 包含 GitHub Actions workflow 链接
- 显示确切的 Commit SHA
- 用户可验证包的完整构建过程

### 配置要求

**GitHub 端（✅ 已满足）：**
- ✅ `id-token: write` permission
- ✅ GitHub-hosted runner
- ✅ 公开仓库
- ✅ package.json 配置正确的 repository

**npm 端（⚠️ 需要更新）：**
- ⚠️ 创建新的 Automation Token（绕过 2FA）
- ⚠️ 更新 GitHub Secret: `NPM_TOKEN`

### 测试计划
- [ ] 更新 `NPM_TOKEN` 为 Automation Token
- [ ] 合并 PR 触发自动发布
- [ ] 验证发布成功
- [ ] 检查 npm 包页面是否显示 Provenance Badge

### 相关文档
- [npm Provenance 官方文档](https://docs.npmjs.com/generating-provenance-statements)
- [GitHub Blog: Introducing npm package provenance](https://github.blog/security/supply-chain-security/introducing-npm-package-provenance/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)