### PR TITLE
fix: remove provenance for internal repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
           # 创建并切换到新分支
           git checkout -b "$BRANCH"
 
-      # ========== 5. 发布到 npm (使用 Provenance) ==========
+      # ========== 5. 发布到 npm ==========
       - name: Publish to npm
         if: steps.analyze.outputs.should_release == 'true'
         env:
@@ -105,8 +105,8 @@ jobs:
           # 更新版本号 (不创建 git tag)
           npm version $VERSION --no-git-tag-version
 
-          # 发布到 npm (启用 provenance)
-          npm publish --access public --provenance
+          # 发布到 npm (不使用 provenance - 仓库为 internal)
+          npm publish --access public
 
       # ========== 6. 生成 CHANGELOG ==========
       - name: Generate CHANGELOG

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -779,21 +779,20 @@ PR 合并到 main/beta/alpha 分支后自动运行：
    - 更新 package.json
    - 生成/更新 CHANGELOG.md
    - Git commit 和 tag
-   - **发布到 npm（带 Provenance）**
+   - **发布到 npm**
    - 创建 GitHub Release
 
-**npm Provenance（可信发布）：**
-- ✅ 使用 GitHub OIDC 认证，无需 NPM_TOKEN
-- ✅ 自动生成来源证明（Provenance Statement）
-- ✅ 提供构建透明度和供应链安全
-- ✅ 通过 `npm publish --provenance` 启用
+**npm 发布策略：**
+- ⚠️ **不使用 Provenance**（npm Provenance 仅支持 public 仓库，当前仓库为 internal）
+- ✅ 使用 **Automation Token** 绕过 2FA
+- ✅ 完整的 CI/CD 质量检查
 
 ### 配置文件
 
 - `.releaserc.js` - Semantic Release 配置
 - `.commitlintrc.js` - Commitlint 配置
 - `.github/workflows/pr.yml` - PR 检查工作流
-- `.github/workflows/release.yml` - 发布工作流（含 Provenance）
+- `.github/workflows/release.yml` - 发布工作流
 
 ### 环境变量和 Secrets
 
@@ -801,8 +800,14 @@ PR 合并到 main/beta/alpha 分支后自动运行：
 
 **Secrets (Settings → Secrets and variables → Actions):**
 - `NPM_TOKEN` - npm 发布令牌（必需）
-  - **推荐**：创建 **Automation Token**（可绕过 2FA）
-  - **安全**：发布时使用 `--provenance` 启用 Trusted Publishing
+  - **类型**：**Automation Token**（可绕过 2FA）
+  - **创建步骤**：
+    1. 登录 https://www.npmjs.com/
+    2. 进入 Access Tokens 页面
+    3. 点击 "Generate New Token"
+    4. 选择 "Automation" 类型
+    5. 勾选 "Bypass 2FA"
+    6. 复制 token 并更新到 GitHub Secret
 
 **自动提供（无需配置）:**
 - `GITHUB_TOKEN` - GitHub API 令牌（用于创建 PR、合并、创建 Release）
@@ -813,7 +818,7 @@ permissions:
   contents: write      # 创建 commit 和 tag
   issues: write        # 发布说明
   pull-requests: write # 创建和合并 PR
-  id-token: write      # OIDC 认证（Provenance）
+  id-token: write      # GitHub OIDC（未来可能需要）
 ```
 
 ### 手动操作


### PR DESCRIPTION
## 🔧 修复 npm 发布失败问题

### 问题描述

发布到 npm 时遇到 Provenance 验证失败：

```
npm error 422 Unprocessable Entity
npm error Error verifying sigstore provenance bundle: 
Unsupported GitHub Actions source repository visibility: "internal". 
Only public source repositories are supported when publishing with provenance.
```

**根因：**
- npm Provenance 仅支持 **public** 仓库
- 当前仓库可见性：**internal**（组织内部仓库）

### 解决方案

移除 `--provenance` 标志，改用 **Automation Token** 方案：

#### 1. 更新 GitHub Actions Workflow
```diff
- # 发布到 npm (启用 provenance)
- npm publish --access public --provenance
+ # 发布到 npm (不使用 provenance - 仓库为 internal)
+ npm publish --access public
```

#### 2. 更新文档
- ✅ 在 `CLAUDE.md` 中说明当前发布策略
- ✅ 添加 Automation Token 详细创建步骤
- ✅ 说明 Provenance 的限制和要求

### 技术细节

**当前方案（Automation Token）：**
- ✅ 使用 `NPM_TOKEN` (Automation 类型) 绕过 2FA
- ✅ 完整的 CI/CD 质量检查（lint、build、test）
- ✅ 自动化发布流程
- ⚠️ 无 Provenance Badge（需要 public 仓库）

**如需启用 Provenance（可选）：**
1. 将仓库改为 public
2. 恢复 `--provenance` 标志
3. 即可获得 Provenance Badge 和构建透明度

### 主要变更

#### `.github/workflows/release.yml`
- 移除 `--provenance` 标志
- 添加注释说明原因

#### `CLAUDE.md`
- 更新 npm 发布策略说明
- 添加 Automation Token 创建步骤
- 说明 Provenance 限制（仅支持 public 仓库）

### 后续操作

合并此 PR 后，需要：

1. **创建 npm Automation Token：**
   - 登录 https://www.npmjs.com/
   - 进入 Access Tokens 页面
   - 生成 "Automation" 类型的 token
   - 勾选 "Bypass 2FA"

2. **更新 GitHub Secret：**
   - Settings → Secrets and variables → Actions
   - 更新 `NPM_TOKEN` 为新的 Automation Token

3. **触发发布：**
   - 合并此 PR
   - 自动触发发布流程
   - 验证发布成功

### 参考文档
- [npm Provenance 文档](https://docs.npmjs.com/generating-provenance-statements)
- [npm Automation Token](https://docs.npmjs.com/creating-and-viewing-access-tokens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)