### PR TITLE
fix: 修复 stdio 模式下的路径解析和 Token 覆盖问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,8 @@
+
 ## <small>1.5.2 (2025-11-17)</small>
 
 * refactor: 优化认证检查逻辑，提高代码可维护性 ([559fd2a](https://github.com/taptap/taptap_minigame_open_mcp/commit/559fd2a))
 * fix: proxy模式下授权检测问题 ([bfbdcc8](https://github.com/taptap/taptap_minigame_open_mcp/commit/bfbdcc8))
-
-
-
-## [Unreleased]
-
-### 🐛 Fixed
-
-- **修复 MCP Proxy 模式下的授权检测问题**
-  - `check_environment` 现在会检查 `context.macToken`（MCP Proxy 注入的 token）
-  - `start_oauth_authorization` 现在会检查请求级别的 token，避免在 Proxy 模式下误提示授权
-  - 优先级：MCP Proxy 注入 > 环境变量 > 本地文件
-  - 在 Proxy 模式下显示友好提示："您正在使用 MCP Proxy 多账号认证模式，无需手动授权"
 
 ## <small>1.5.1 (2025-11-17)</small>
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,82 @@ handler: async (args: { page: number }, context) => {
 
 详见：[docs/PRIVATE_PROTOCOL.md](docs/PRIVATE_PROTOCOL.md)
 
+## 常见问题和重要修复（v1.5.3）
+
+### 路径处理问题
+
+**问题 1: 绝对路径重复拼接**
+- **现象**: 用户输入 `/Users/mikoto/Downloads/game`，实际解析为 `/Users/mikoto/Users/mikoto/Downloads/game`
+- **根本原因**: `pathResolver.ts` 使用 `path.join()` 处理绝对路径时会错误拼接
+- **修复方案**: 在拼接前检查用户输入是否为绝对路径，如果是则直接使用
+
+```typescript
+// ✅ 修复后 (src/core/utils/pathResolver.ts:64-68)
+if (relativePath) {
+  // 如果用户传入的是绝对路径，直接使用（避免重复拼接）
+  if (path.isAbsolute(relativePath)) {
+    return relativePath;
+  }
+  return path.join(basePath, relativePath);
+}
+```
+
+**问题 2: 相对路径基准错误（stdio 模式）**
+- **现象**: Cursor/VSCode 通过 stdio 启动 MCP，相对路径 `frontend/public` 解析为用户 HOME 目录而非项目目录
+- **根本原因**: `process.cwd()` 返回用户 HOME 目录（`/Users/mikoto`），而非 IDE 打开的项目目录
+- **修复方案**:
+  1. 添加详细的路径解析日志（显示 base 路径和解析结果）
+  2. 当路径不存在时，提供友好的警告和建议（使用绝对路径或设置 `WORKSPACE_ROOT` 环境变量）
+  3. 推荐在 MCP 配置中设置 `WORKSPACE_ROOT` 环境变量
+
+```json
+// Cursor/VSCode MCP 配置建议
+{
+  "mcpServers": {
+    "taptap-minigame": {
+      "command": "npx",
+      "args": ["@mikoto_zero/minigame-open-mcp"],
+      "env": {
+        "WORKSPACE_ROOT": "${workspaceFolder}"  // 设置工作空间根路径
+      }
+    }
+  }
+}
+```
+
+### OAuth Token 覆盖问题
+
+**问题 3: 私有参数中的无效 Token 覆盖全局 Token**
+- **现象**: OAuth Token 已成功加载到全局配置，但 HTTP 请求时显示 `Token kid: N/A`
+- **根本原因**: `getEffectiveContext()` 会无条件使用 `args._mac_token`，即使它是 `undefined` 或空对象，导致覆盖已有的全局 Token
+- **修复方案**: 在合并私有参数时，只有当 Token 有效（包含 `kid` 和 `mac_key`）时才覆盖
+
+```typescript
+// ✅ 修复后 (src/core/utils/handlerHelpers.ts:38-41)
+// 只有在私有参数有效时才覆盖（避免 undefined 覆盖已有 token）
+if (args._mac_token && args._mac_token.kid && args._mac_token.mac_key) {
+  result.macToken = args._mac_token;
+}
+```
+
+### 最佳实践建议
+
+1. **路径使用**:
+   - ✅ 推荐：使用绝对路径（如 `/Users/username/project/dist`）
+   - ⚠️ 小心：相对路径在 stdio 模式下可能解析错误
+   - 💡 配置：在 MCP 配置中设置 `WORKSPACE_ROOT` 环境变量
+
+2. **调试技巧**:
+   - 启用详细日志：`TDS_MCP_VERBOSE=true`
+   - 查看路径解析日志：`[PathResolver] Resolved relative path`
+   - 查看 Token 状态：`[DEBUG] HttpClient Token Retrieval`
+
+3. **环境变量配置**:
+   - `WORKSPACE_ROOT`: 工作空间根路径（推荐设置）
+   - `TDS_MCP_VERBOSE`: 详细日志模式（调试时启用）
+   - `TDS_MCP_CACHE_DIR`: 缓存根目录
+   - `TDS_MCP_TEMP_DIR`: 临时文件根目录
+
 ## 常用命令
 
 ### 开发环境设置

--- a/README.md
+++ b/README.md
@@ -38,13 +38,20 @@ npx @mikoto_zero/minigame-open-mcp
   "mcpServers": {
     "taptap-minigame": {
       "command": "npx",
-      "args": ["-y", "@mikoto_zero/minigame-open-mcp"]
+      "args": ["-y", "@mikoto_zero/minigame-open-mcp"],
+      "env": {
+        "WORKSPACE_ROOT": "${workspaceFolder}"
+      }
     }
   }
 }
 ```
 
-**零配置 OAuth**：首次使用会提示扫码授权，token 自动保存！
+**重要说明**：
+- **零配置 OAuth**：首次使用会提示扫码授权，token 自动保存！
+- **路径处理**：设置 `WORKSPACE_ROOT` 环境变量可以正确解析相对路径（推荐）
+  - 如果不设置，相对路径会基于用户 HOME 目录（可能不符合预期）
+  - 建议使用绝对路径，或配置 `WORKSPACE_ROOT`
 
 #### OpenHands（推荐 SSE 模式）
 

--- a/src/core/utils/handlerHelpers.ts
+++ b/src/core/utils/handlerHelpers.ts
@@ -35,7 +35,8 @@ export function getEffectiveContext<T extends PrivateToolParams>(
   const result: HandlerContext = { ...context };
 
   // === 认证层 ===
-  if (args._mac_token) {
+  // 🔧 FIX: 只有在私有参数有效时才覆盖（避免 undefined 覆盖已有 token）
+  if (args._mac_token && args._mac_token.kid && args._mac_token.mac_key) {
     result.macToken = args._mac_token;
   }
   if (args._user_id) {

--- a/src/core/utils/pathResolver.ts
+++ b/src/core/utils/pathResolver.ts
@@ -10,7 +10,9 @@
  */
 
 import * as path from 'node:path';
+import * as fs from 'node:fs';
 import type { HandlerContext } from '../types/index.js';
+import { logger } from './logger.js';
 
 /**
  * 工作空间根路径
@@ -61,7 +63,37 @@ export function resolveWorkPath(relativePath?: string, context?: HandlerContext)
 
   // 3. 拼接用户传入的相对路径
   if (relativePath) {
-    return path.join(basePath, relativePath);
+    // 🔧 FIX: 如果用户传入的是绝对路径，直接使用（避免重复拼接）
+    if (path.isAbsolute(relativePath)) {
+      // 详细日志：绝对路径
+      logger.info(`[PathResolver] Using absolute path: ${relativePath}`).catch(() => {});
+      return relativePath;
+    }
+
+    // 相对路径拼接
+    const resolvedPath = path.join(basePath, relativePath);
+
+    // 详细日志：相对路径解析
+    logger.info(
+      `[PathResolver] Resolved relative path:\n` +
+      `  Input: ${relativePath}\n` +
+      `  Base: ${basePath}\n` +
+      `  Result: ${resolvedPath}`
+    ).catch(() => {});
+
+    // 🔧 FIX: 智能提示 - 如果路径不存在，提供帮助信息
+    if (!fs.existsSync(resolvedPath)) {
+      logger.warning(
+        `[PathResolver] ⚠️  Path does not exist: ${resolvedPath}\n` +
+        `  💡 Tip: Current WORKSPACE_ROOT is ${WORKSPACE_ROOT}\n` +
+        `  💡 Consider using:\n` +
+        `     - Absolute path (e.g., /Users/username/project/path)\n` +
+        `     - Set WORKSPACE_ROOT environment variable in MCP config\n` +
+        `     - Check if the path is correct relative to ${basePath}`
+      ).catch(() => {});
+    }
+
+    return resolvedPath;
   }
 
   return basePath;


### PR DESCRIPTION
## 问题描述

在 Cursor stdio 模式下发现以下问题：

1. **路径重复拼接** - 绝对路径被错误拼接（如 `/Users/mikoto/Users/mikoto/Downloads/...`）
2. **相对路径解析错误** - 相对路径基于用户 HOME 目录而非项目目录
3. **OAuth Token 覆盖** - 空的 `_mac_token` 参数覆盖了已加载的全局 Token

## 修复内容

### 1. 路径重复拼接问题 ✅

**文件**: `src/core/utils/pathResolver.ts`

**修改**:
- 在拼接前检查用户输入是否为绝对路径
- 如果是绝对路径，直接返回，避免重复拼接

```typescript
if (path.isAbsolute(relativePath)) {
  return relativePath;  // 直接返回，避免重复拼接
}
```

### 2. 相对路径解析优化 ✅

**文件**: `src/core/utils/pathResolver.ts`

**修改**:
- 添加详细的路径解析日志（Input、Base、Result）
- 当路径不存在时，输出友好的警告和建议
- 提示用户设置 `WORKSPACE_ROOT` 环境变量或使用绝对路径

### 3. OAuth Token 覆盖问题 ✅

**文件**: `src/core/utils/handlerHelpers.ts`

**修改**:
- 在合并私有参数时，检查 Token 是否有效
- 只有当 Token 包含 `kid` 和 `mac_key` 时才覆盖

```typescript
if (args._mac_token && args._mac_token.kid && args._mac_token.mac_key) {
  result.macToken = args._mac_token;
}
```

## 文档更新

- **CLAUDE.md**: 添加"常见问题和重要修复"章节，详细说明问题和解决方案
- **README.md**: 更新 MCP 配置示例，添加 `WORKSPACE_ROOT` 环境变量建议

## 测试

- ✅ TypeScript 编译通过（`npm run build`）
- ✅ 路径解析逻辑验证通过
- ✅ 无编译错误和警告

## 影响范围

- stdio 模式（Cursor/VSCode/Claude Desktop）
- H5 游戏上传功能
- 所有需要认证的 API 调用

## 用户建议

在 Cursor/VSCode 的 `.mcp.json` 中添加：

\`\`\`json
{
  "mcpServers": {
    "taptap-minigame": {
      "command": "npx",
      "args": ["-y", "@mikoto_zero/minigame-open-mcp"],
      "env": {
        "WORKSPACE_ROOT": "${workspaceFolder}"
      }
    }
  }
}
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)