### PR TITLE
docs: 完善 commitlint 规范 & refactor(proxy): 优化版本注入

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -11,16 +11,18 @@
 - **工具处理函数必须返回 `Promise<string>` 类型**
 
 ### Git 提交规范
-- **使用 Conventional Commits 规范**（项目已配置自动化 CI/CD）
-  - `feat:` - 新功能（触发 minor 版本升级）
-  - `fix:` - Bug 修复（触发 patch 版本升级）
-  - `feat!:` 或 `fix!:` - 破坏性变更（触发 major 版本升级）
-  - `docs:` - 文档更新（不触发发布）
-  - `refactor:` - 代码重构（触发 patch 版本升级）
-  - `chore:` - 构建/工具/配置更新（不触发发布）
-- **Commit Message 格式**：`<type>(<scope>): <subject>`（5-100 字符，祈使句，无句号）
+- **使用 Conventional Commits 规范**（基于 `.commitlintrc.cjs` 强制执行）
+- **格式**：`<type>(<scope>): <subject>`
+  - **Type**：必须小写（feat/fix/docs/style/refactor/perf/test/build/ci/chore/revert）
+  - **Scope**：必须小写（可选）
+  - **Subject**：5-100 字符，祈使句，不以句号结尾
+  - **Header**（第一行）：最大 100 字符
+- **Body/Footer**（可选）：
+  - 与前面部分之间必须有空行
+  - Body 每行不超过 100 字符（`body-max-line-length` 强制）
 - ❌ **不要直接 commit 到 main 分支**（已配置分支保护）
 - ✅ **创建 feature/fix 分支** → 提交代码 → 创建 PR
+- 📖 **详细说明**：[CLAUDE.md#git-提交规范](CLAUDE.md#git-提交规范)
 
 ### 文档更新规则
 - **主动更新文档**：当有重要代码改动时（新特性、架构变更、API 修改），必须同时更新相关文档

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,11 +27,64 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   - `test:` - 测试相关（不触发发布）
   - `ci:` - CI 配置更新（不触发发布）
 
-- **Commit Message 最佳实践**：
-  - Subject 长度：5-100 字符
-  - 使用祈使句："add feature" 而不是 "added feature"
-  - 不要以句号结尾
-  - 示例：`feat(leaderboard): add score submission API`
+- **Commit Message 格式规范**（基于 `.commitlintrc.cjs`）：
+  ```
+  <type>(<scope>): <subject>
+  
+  <body>
+  
+  <footer>
+  ```
+  
+  - **Header**（第一行，必填）：
+    - 格式：`<type>(<scope>): <subject>`
+    - 最大长度：100 字符
+    - Type 必须小写
+    - Scope 必须小写（可选）
+    - Subject：最少 5 字符，最多 100 字符，不以句号结尾
+  
+  - **Body**（可选）：
+    - 详细描述改动内容
+    - 与 header 之间必须有空行
+    - 每行不超过 100 字符（由 `body-max-line-length` 强制）
+  
+  - **Footer**（可选）：
+    - 关联 issue 或注明破坏性变更
+    - 与 body 之间必须有空行
+
+- **允许的 Type**（共 11 种）：
+  - `feat` - 新功能（触发 minor 版本升级）
+  - `fix` - Bug 修复（触发 patch 版本升级）
+  - `docs` - 文档更新（不触发发布）
+  - `style` - 代码格式（不影响代码运行，不触发发布）
+  - `refactor` - 重构（触发 patch 版本升级）
+  - `perf` - 性能优化（触发 patch 版本升级）
+  - `test` - 测试（不触发发布）
+  - `build` - 构建系统或外部依赖变更（不触发发布）
+  - `ci` - CI 配置文件和脚本变更（不触发发布）
+  - `chore` - 其他不修改 src 或测试文件的变更（不触发发布）
+  - `revert` - 回退之前的 commit（根据回退内容决定版本升级）
+
+- **破坏性变更标记**：
+  - 在 type 后加 `!`：`feat!:` 或 `fix!:`（触发 major 版本升级）
+
+- **完整示例**：
+```
+feat(leaderboard): add score submission API
+
+- 新增 submitScores 工具
+- 支持批量提交分数
+- 添加输入验证
+
+Closes #123
+```
+
+**注意事项**：
+- ✅ Type 和 Scope 必须小写
+- ✅ Subject 最少 5 字符，不以句号结尾
+- ✅ Body 每行不超过 100 字符
+- ✅ Body 和 Footer 前必须有空行
+- ❌ 错误示例：`Feat(API): Added feature.`（Type 大写、Scope 大写、Subject 以句号结尾）
 
 ### 分支工作流
 

--- a/scripts/bundle-proxy.js
+++ b/scripts/bundle-proxy.js
@@ -46,7 +46,7 @@ try {
     },
     // Inject version at build time
     define: {
-      '__VERSION__': `"${VERSION}"`
+      '__PROXY_VERSION__': `"${VERSION}"`
     },
     minify: false,  // Keep readable for debugging
     sourcemap: false,

--- a/src/mcp-proxy/proxy.ts
+++ b/src/mcp-proxy/proxy.ts
@@ -12,7 +12,10 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 // import * as path from 'node:path';  // 暂时未使用
 import type { ProxyConfig, PendingRequest } from './types.js';
-import { VERSION } from '../version.js';
+
+// Version placeholder - replaced at build time by esbuild
+declare const __PROXY_VERSION__: string;
+const VERSION = typeof __PROXY_VERSION__ !== 'undefined' ? __PROXY_VERSION__ : 'dev';
 
 /**
  * TapTap MCP Proxy


### PR DESCRIPTION
## 📝 变更内容

### 1. 完善 commitlint 规范说明（docs）

- 基于 `.commitlintrc.cjs` 更新 `CLAUDE.md` 和 `.cursorrules`
- 添加完整的 11 种 Type 列表和详细格式规范
- 强调 Scope 必须小写、Body 每行不超过 100 字符
- 添加注意事项和完整示例

### 2. 优化 Proxy 单文件版本注入（refactor）

- 移除运行时读取 `version.ts` 的依赖
- 使用 `__PROXY_VERSION__` 占位符，构建时直接注入
- 减少打包体积（13865 → 13849 行）
- 简化运行时逻辑，零依赖、零动态加载

## ✅ 测试验证

- ✅ `npm run build:proxy` 构建成功
- ✅ 单文件 `dist/proxy.js` 不再包含 `createRequire`、`fileURLToPath` 等运行时逻辑
- ✅ 版本号正确注入：`var VERSION = true ? "1.5.5" : "dev";`

## 📊 影响范围

- **文档更新**：`CLAUDE.md`、`.cursorrules`
- **代码重构**：`src/mcp-proxy/proxy.ts`、`scripts/bundle-proxy.js`
- **构建产物**：`dist/proxy.js`（被 gitignore，不提交）

## 🔗 相关 Issue

N/A（文档完善 + 性能优化）