### PR TITLE
revert(bundle): 暂时恢复主服务器为传统部署模式

### DIFF
--- a/bin/minigame-open-mcp
+++ b/bin/minigame-open-mcp
@@ -16,17 +16,17 @@ const __dirname = dirname(__filename);
 // Get package root directory
 const packageRoot = join(__dirname, '..');
 
-// Check if bundled version exists
-const distPath = join(packageRoot, 'dist', 'server-bundle.js');
+// Check if compiled version exists
+const distPath = join(packageRoot, 'dist', 'server.js');
 
 if (existsSync(distPath)) {
-    // Use bundled version (ES Module dynamic import)
+    // Use compiled version (ES Module dynamic import)
     import(distPath).catch(error => {
         console.error('❌ Failed to start server:', error);
         process.exit(1);
     });
 } else {
-    console.error('❌ Server bundle not found. Please build the project first:');
-    console.error('   npm run build:all');
+    console.error('❌ Server not found. Please build the project first:');
+    console.error('   npm run build');
     process.exit(1);
 }

--- a/package.json
+++ b/package.json
@@ -3,26 +3,25 @@
   "version": "1.5.8",
   "type": "module",
   "description": "TapTap Open API MCP Server - Documentation and Management APIs for TapTap Minigame and H5 Games (Leaderboard, and more features coming)",
-  "main": "dist/server-bundle.js",
+  "main": "dist/server.js",
   "bin": {
     "minigame-open-mcp": "bin/minigame-open-mcp",
     "taptap-mcp-proxy": "bin/taptap-mcp-proxy"
   },
   "exports": {
-    ".": "./dist/server-bundle.js",
+    ".": "./dist/server.js",
     "./proxy": "./dist/proxy.js",
     "./package.json": "./package.json"
   },
   "scripts": {
     "build": "tsc",
-    "build:server": "node scripts/bundle-server.js",
     "build:proxy": "node scripts/bundle-proxy.js",
-    "build:all": "npm run build && npm run build:server && npm run build:proxy",
-    "start": "node dist/server-bundle.js",
+    "build:all": "npm run build && npm run build:proxy",
+    "start": "node dist/server.js",
     "dev": "tsx src/server.ts",
-    "serve:sse": "TAPTAP_MCP_TRANSPORT=sse TAPTAP_MCP_PORT=3000 node dist/server-bundle.js",
-    "serve:sse:dev": "TAPTAP_MCP_TRANSPORT=sse TAPTAP_MCP_PORT=3000 TAPTAP_MCP_VERBOSE=true node dist/server-bundle.js",
-    "serve:http": "TAPTAP_MCP_TRANSPORT=http TAPTAP_MCP_PORT=3000 node dist/server-bundle.js",
+    "serve:sse": "TAPTAP_MCP_TRANSPORT=sse TAPTAP_MCP_PORT=3000 node dist/server.js",
+    "serve:sse:dev": "TAPTAP_MCP_TRANSPORT=sse TAPTAP_MCP_PORT=3000 TAPTAP_MCP_VERBOSE=true node dist/server.js",
+    "serve:http": "TAPTAP_MCP_TRANSPORT=http TAPTAP_MCP_PORT=3000 node dist/server.js",
     "prepublishOnly": "npm run build:all",
     "test": "jest",
     "lint": "eslint src/**/*.ts",
@@ -46,12 +45,14 @@
   "engines": {
     "node": ">=16.0.0"
   },
-  "devDependencies": {
+  "dependencies": {
     "@modelcontextprotocol/sdk": "1.20.2",
-    "@types/archiver": "6.0.4",
     "archiver": "7.0.1",
     "crypto-js": "^4.2.0",
-    "dotenv": "17.2.3",
+    "dotenv": "17.2.3"
+  },
+  "devDependencies": {
+    "@types/archiver": "6.0.4",
     "@commitlint/cli": "^18.4.3",
     "@commitlint/config-conventional": "^18.4.3",
     "@semantic-release/changelog": "^6.0.3",
@@ -78,8 +79,7 @@
     "typescript": "^5.0.0"
   },
   "files": [
-    "dist/server-bundle.js",
-    "dist/proxy.js",
+    "dist/",
     "bin/"
   ],
   "repository": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -46,9 +46,8 @@ import { vibrateModule } from './features/vibrate/index.js';
 import type { HandlerContext, FeatureModule } from './core/types/index.js';
 import { EnvConfig, printDeprecationWarnings, getEnv } from './core/utils/env.js';
 
-// Version placeholder - replaced at build time by esbuild
-declare const __SERVER_VERSION__: string;
-const VERSION = typeof __SERVER_VERSION__ !== 'undefined' ? __SERVER_VERSION__ : 'dev';
+// Version import
+import { VERSION } from './version.js';
 
 // 环境变量配置
 const apiConfig = ApiConfig.getInstance();


### PR DESCRIPTION
## 变更说明

由于 esbuild 在打包时对 CommonJS 模块的动态 require 处理存在兼容性问题，暂时将主 MCP Server 恢复为传统的 npm install + tsc 编译模式。

## 主要变更

### 恢复传统部署模式
- **package.json**: 恢复 `main` 为 `dist/server.js`，`dependencies` 移回正常配置
- **bin/minigame-open-mcp**: 恢复引用 `dist/server.js`
- **src/server.ts**: 恢复使用 `VERSION` 从 `version.ts` 导入

### 保留功能
- ✅ MCP Proxy 的单文件 bundle 仍然保留（工作正常）
- ✅ Bundle 优化工作已暂存到 stash，待后续解决兼容性问题后再启用

## 技术背景

在尝试将主 MCP Server 打包成单文件时，遇到了以下问题：
- esbuild 对某些 CommonJS 模块（如 `depd`, `http-errors`）的动态 `require()` 处理存在兼容性问题
- 即使标记为 `external` 和添加 `require` polyfill，在 Docker 环境中仍会报 `Dynamic require of "path" is not supported` 错误

## 相关 Issue

暂无

## 测试情况

- [x] 本地编译测试通过
- [x] Proxy bundle 功能正常
- [x] 保留传统部署方式确保稳定性

## 后续计划

Bundle 优化工作已保存在 stash (`WIP: bundle optimization - fixing dynamic require issue`)，待后续研究更好的解决方案。