### PR TITLE
fix(ci): use correct NPM_TOKEN env var for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         id: analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           npx semantic-release --dry-run --no-ci 2>&1 | tee release-output.txt
 


### PR DESCRIPTION
## Summary

修复 release workflow 中 semantic-release 无法识别 npm token 的问题。

### 问题
- Analyze Release 步骤使用 `NODE_AUTH_TOKEN` 环境变量
- 但 semantic-release 期望 `NPM_TOKEN` 环境变量
- 导致 dry-run 分析失败，所有发布被跳过

### 修复
- 将 `NODE_AUTH_TOKEN` 改为 `NPM_TOKEN`

### 前置条件
确保 GitHub Secrets 中已配置 `NPM_TOKEN`（从 npmjs.com 获取的 Automation token）

🤖 Generated with [Claude Code](https://claude.com/claude-code)