### PR TITLE
fix(ci): correct rust-toolchain action name

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Install Rust
         if: ${{ !matrix.settings.docker }}
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.settings.target }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Install Rust
         if: ${{ !matrix.settings.docker }}
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.settings.target }}
 


### PR DESCRIPTION
## Summary

修复 Native Signer 构建失败的问题。

### 问题
- 错误使用了 `dtolnay/rust-action`（不存在的 repository）
- 导致所有 Build Native jobs 失败

### 修复
- 改为正确的 `dtolnay/rust-toolchain`
- 同时修复 `release.yml` 和 `build-native.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)