### PR TITLE
fix(ci): update Rust in Docker before building native

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -55,6 +55,7 @@ jobs:
             artifact: taptap-signer.linux-x64-gnu.node
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
             build: |
+              rustup update stable && rustup default stable
               cd native
               npm run build -- --target x86_64-unknown-linux-gnu
               strip *.node
@@ -65,6 +66,7 @@ jobs:
             artifact: taptap-signer.linux-x64-musl.node
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
             build: |
+              rustup update stable && rustup default stable
               cd native
               npm run build -- --target x86_64-unknown-linux-musl
               strip *.node
@@ -75,6 +77,7 @@ jobs:
             artifact: taptap-signer.linux-arm64-musl.node
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
             build: |
+              rustup update stable && rustup default stable
               cd native
               npm run build -- --target aarch64-unknown-linux-musl
               strip *.node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
             build: |
+              rustup update stable && rustup default stable
               cd native
               npm run build -- --target x86_64-unknown-linux-gnu
               strip *.node
@@ -106,6 +107,7 @@ jobs:
             target: x86_64-unknown-linux-musl
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
             build: |
+              rustup update stable && rustup default stable
               cd native
               npm run build -- --target x86_64-unknown-linux-musl
               strip *.node


### PR DESCRIPTION
## Summary

修复 Linux Docker 构建失败的问题。

### 问题
- Docker 镜像中的 Rust 版本是 1.83.0
- `napi-build@2.3.1` 需要 Rust 1.88+
- 导致 Linux GNU 和 Linux Musl 构建失败

### 修复
- 在 Docker 构建前添加 `rustup update stable && rustup default stable`
- 同时更新 `release.yml` 和 `build-native.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)