### PR TITLE
fix(ci): fix native build for macOS Intel and Linux ARM64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,8 @@ jobs:
           - host: macos-13
             target: x86_64-apple-darwin
             build: |
+              # 确保 Rust 在 PATH 中
+              source "$HOME/.cargo/env" 2>/dev/null || true
               cd native
               npm run build
               strip -x *.node
@@ -89,6 +91,8 @@ jobs:
           - host: macos-latest
             target: aarch64-apple-darwin
             build: |
+              # 确保 Rust 在 PATH 中
+              source "$HOME/.cargo/env" 2>/dev/null || true
               cd native
               npm run build -- --target aarch64-apple-darwin
               strip -x *.node
@@ -114,14 +118,21 @@ jobs:
               strip *.node
 
           # Linux Musl ARM64 (Alpine on ARM servers / Apple Silicon Docker)
+          # 使用 zig 作为交叉编译器
           - host: ubuntu-latest
             target: aarch64-unknown-linux-musl
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
             build: |
+              # 安装 zig 用于交叉编译
+              apk add --no-cache zig
+              # 更新 Rust 并添加 ARM64 target
               rustup update stable && rustup default stable
+              rustup target add aarch64-unknown-linux-musl
               cd native
-              npm run build -- --target aarch64-unknown-linux-musl
-              strip *.node
+              # 使用 zig 作为链接器进行交叉编译
+              npm run build -- --target aarch64-unknown-linux-musl --zig
+              # ARM64 需要使用 llvm-strip 或跳过 strip
+              llvm-strip *.node 2>/dev/null || aarch64-linux-gnu-strip *.node 2>/dev/null || echo "Skip strip for cross-compiled binary"
 
           # Windows
           - host: windows-latest

--- a/src/core/utils/pathResolver.ts
+++ b/src/core/utils/pathResolver.ts
@@ -17,12 +17,15 @@ import * as path from 'node:path';
 import * as fs from 'node:fs';
 import type { ResolvedContext } from '../types/context.js';
 import { logger } from './logger.js';
+import { EnvConfig } from './env.js';
 
 /**
  * 工作空间根路径
- * 优先级：环境变量 > process.cwd()
+ * 优先级：TAPTAP_MCP_WORKSPACE_ROOT > WORKSPACE_ROOT（向后兼容）> process.cwd()
+ *
+ * 注意：使用 EnvConfig.workspaceRoot 来支持新旧环境变量名的兼容
  */
-const WORKSPACE_ROOT = process.env.WORKSPACE_ROOT || process.cwd();
+const WORKSPACE_ROOT = EnvConfig.workspaceRoot;
 
 /**
  * 路径输入类型


### PR DESCRIPTION
## Summary

修复 Auto Release #30 中 macOS Intel 和 Linux ARM64 构建失败的问题，同时修复 WORKSPACE_ROOT 环境变量读取问题。

### CI 修复

**macOS Intel (x86_64-apple-darwin)**
- 问题：`cargo: command not found`
- 原因：`dtolnay/rust-toolchain` action 安装 Rust 后，PATH 未在后续步骤中生效
- 修复：在 build 步骤中显式 source `$HOME/.cargo/env`

**Linux ARM64 (aarch64-unknown-linux-musl)**
- 问题：`linking with 'cc' failed` - 交叉编译架构不匹配
- 原因：Alpine x86_64 镜像无法直接编译 ARM64 目标
- 修复：
  - 安装 zig 作为交叉编译器
  - 添加 `rustup target add aarch64-unknown-linux-musl`
  - 使用 `--zig` 选项进行交叉编译

### PathResolver 修复

- 问题：`WORKSPACE_ROOT` 在 Proxy 模式下无法正确读取
- 原因：`pathResolver.ts` 直接使用 `process.env.WORKSPACE_ROOT`，但新的环境变量名是 `TAPTAP_MCP_WORKSPACE_ROOT`
- 修复：使用 `EnvConfig.workspaceRoot` 来支持新旧环境变量名的兼容

## Test plan

- [ ] 验证 macOS Intel 构建成功
- [ ] 验证 Linux ARM64 构建成功
- [ ] 验证 WORKSPACE_ROOT 环境变量正确读取

🤖 Generated with [Claude Code](https://claude.com/claude-code)