### PR TITLE
fix(ci): use CARGO_HOME/bin in PATH for macOS builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,8 +81,8 @@ jobs:
           - host: macos-13
             target: x86_64-apple-darwin
             build: |
-              # 确保 Rust 在 PATH 中
-              source "$HOME/.cargo/env" 2>/dev/null || true
+              # 将 cargo 添加到 PATH（dtolnay/rust-toolchain 设置了 CARGO_HOME）
+              export PATH="$CARGO_HOME/bin:$PATH"
               cd native
               npm run build
               strip -x *.node
@@ -91,8 +91,8 @@ jobs:
           - host: macos-latest
             target: aarch64-apple-darwin
             build: |
-              # 确保 Rust 在 PATH 中
-              source "$HOME/.cargo/env" 2>/dev/null || true
+              # 将 cargo 添加到 PATH（dtolnay/rust-toolchain 设置了 CARGO_HOME）
+              export PATH="$CARGO_HOME/bin:$PATH"
               cd native
               npm run build -- --target aarch64-apple-darwin
               strip -x *.node


### PR DESCRIPTION
## Summary

修复 macOS 构建中 `cargo: command not found` 的问题。

### 问题分析

PR #70 合并后，macOS Intel 构建仍然失败：
```
/bin/sh: cargo: command not found
```

原因：`source "$HOME/.cargo/env"` 没有生效，因为：
1. `.cargo/env` 文件可能不存在
2. napi-rs 内部通过 `/bin/sh` 调用 `cargo`，PATH 没有正确传递

### 修复方案

使用 `export PATH="$CARGO_HOME/bin:$PATH"` 替代 `source "$HOME/.cargo/env"`

这利用了 `dtolnay/rust-toolchain` action 已经设置的 `CARGO_HOME` 环境变量。

## Test plan

- [ ] 验证 macOS Intel (x86_64-apple-darwin) 构建成功
- [ ] 验证 macOS ARM64 (aarch64-apple-darwin) 构建成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)