### PR TITLE
fix(ci): temporarily disable macOS Intel build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,22 +77,18 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          # macOS Intel (x64)
-          - host: macos-13
-            target: x86_64-apple-darwin
-            build: |
-              # 将 cargo 添加到 PATH（dtolnay/rust-toolchain 设置了 CARGO_HOME）
-              export PATH="$CARGO_HOME/bin:$PATH"
-              cd native
-              npm run build
-              strip -x *.node
+          # macOS Intel (x64) - 暂时禁用，PATH 问题待解决
+          # - host: macos-13
+          #   target: x86_64-apple-darwin
+          #   build: |
+          #     cd native
+          #     npm run build
+          #     strip -x *.node
 
           # macOS Apple Silicon (ARM64)
           - host: macos-latest
             target: aarch64-apple-darwin
             build: |
-              # 将 cargo 添加到 PATH（dtolnay/rust-toolchain 设置了 CARGO_HOME）
-              export PATH="$CARGO_HOME/bin:$PATH"
               cd native
               npm run build -- --target aarch64-apple-darwin
               strip -x *.node


### PR DESCRIPTION
## Summary

暂时禁用 macOS Intel (x86_64-apple-darwin) 构建，以便发布 pathResolver 修复。

### 问题

macOS Intel 构建失败，`cargo: command not found`。尝试了多种方法：
1. `source "$HOME/.cargo/env"` - 文件不存在
2. `export PATH="$CARGO_HOME/bin:$PATH"` - napi-rs 内部通过 `/bin/sh` 调用 cargo，不继承 PATH

### 临时解决

注释掉 macOS Intel 构建配置，后续单独修复。

### 影响

- ✅ macOS ARM64 (Apple Silicon) - 正常
- ❌ macOS Intel (x64) - 暂时禁用
- ✅ Linux x64 (GNU/musl) - 正常
- ✅ Linux ARM64 (musl) - 使用 zig 交叉编译
- ✅ Windows x64 - 正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)