### PR TITLE
fix(ci): fix macOS Intel and Linux ARM64 native builds

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -34,12 +34,20 @@ jobs:
         settings:
           # macOS Intel (x64)
           # 注意：macos-13 预装了 Rust，但 napi-rs 使用 /bin/sh 调用 cargo
-          # 需要在 build 命令中显式设置 PATH，确保子进程能找到 cargo
+          # 使用 CARGO 环境变量直接指定 cargo 路径，绕过 PATH 查找问题
           - host: macos-13
             target: x86_64-apple-darwin
             artifact: taptap-signer.darwin-x64.node
             build: |
+              # 调试信息
+              echo "CARGO_HOME=$CARGO_HOME"
+              ls -la "$CARGO_HOME/bin/" || echo "cargo bin dir not found"
+              # 设置 CARGO 环境变量让 napi-rs 直接使用
+              export CARGO="$CARGO_HOME/bin/cargo"
               export PATH="$CARGO_HOME/bin:$PATH"
+              echo "CARGO=$CARGO"
+              echo "PATH=$PATH"
+              "$CARGO" --version || echo "cargo not found via CARGO env"
               cd native
               npm run build
               strip -x *.node
@@ -49,6 +57,8 @@ jobs:
             target: aarch64-apple-darwin
             artifact: taptap-signer.darwin-arm64.node
             build: |
+              # 设置 CARGO 环境变量让 napi-rs 直接使用
+              export CARGO="$CARGO_HOME/bin/cargo"
               export PATH="$CARGO_HOME/bin:$PATH"
               cd native
               npm run build -- --target aarch64-apple-darwin

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -33,21 +33,21 @@ jobs:
       matrix:
         settings:
           # macOS Intel (x64)
-          # 注意：macos-13 预装了 Rust，但 napi-rs 使用 /bin/sh 调用 cargo
-          # 使用 CARGO 环境变量直接指定 cargo 路径，绕过 PATH 查找问题
+          # 注意：macos-13 预装的 Rust 符号链接指向 /opt/homebrew（ARM64 路径）
+          # 这是 GitHub Actions runner 的配置问题，需要重新安装 Rust
           - host: macos-13
             target: x86_64-apple-darwin
             artifact: taptap-signer.darwin-x64.node
             build: |
-              # 调试信息
-              echo "CARGO_HOME=$CARGO_HOME"
-              ls -la "$CARGO_HOME/bin/" || echo "cargo bin dir not found"
-              # 设置 CARGO 环境变量让 napi-rs 直接使用
-              export CARGO="$CARGO_HOME/bin/cargo"
-              export PATH="$CARGO_HOME/bin:$PATH"
-              echo "CARGO=$CARGO"
-              echo "PATH=$PATH"
-              "$CARGO" --version || echo "cargo not found via CARGO env"
+              # 检查 cargo 是否可用，如果不可用则重新安装 Rust
+              if ! command -v cargo &> /dev/null; then
+                echo "cargo not found, reinstalling Rust via rustup..."
+                curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+                source "$HOME/.cargo/env"
+              fi
+              # 确保 PATH 正确
+              export PATH="$HOME/.cargo/bin:$PATH"
+              echo "cargo version: $(cargo --version)"
               cd native
               npm run build
               strip -x *.node

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -33,10 +33,13 @@ jobs:
       matrix:
         settings:
           # macOS Intel (x64)
+          # 注意：macos-13 预装了 Rust，但 napi-rs 使用 /bin/sh 调用 cargo
+          # 需要在 build 命令中显式设置 PATH，确保子进程能找到 cargo
           - host: macos-13
             target: x86_64-apple-darwin
             artifact: taptap-signer.darwin-x64.node
             build: |
+              export PATH="$CARGO_HOME/bin:$PATH"
               cd native
               npm run build
               strip -x *.node
@@ -46,6 +49,7 @@ jobs:
             target: aarch64-apple-darwin
             artifact: taptap-signer.darwin-arm64.node
             build: |
+              export PATH="$CARGO_HOME/bin:$PATH"
               cd native
               npm run build -- --target aarch64-apple-darwin
               strip -x *.node
@@ -73,15 +77,22 @@ jobs:
               strip *.node
 
           # Linux Musl ARM64 (Alpine on ARM servers / Apple Silicon Docker)
+          # 使用 zig 作为交叉编译器
           - host: ubuntu-latest
             target: aarch64-unknown-linux-musl
             artifact: taptap-signer.linux-arm64-musl.node
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
             build: |
+              # 安装 zig 用于交叉编译
+              apk add --no-cache zig
+              # 更新 Rust 并添加 ARM64 target
               rustup update stable && rustup default stable
+              rustup target add aarch64-unknown-linux-musl
               cd native
-              npm run build -- --target aarch64-unknown-linux-musl
-              strip *.node
+              # 使用 zig 作为链接器进行交叉编译
+              npm run build -- --target aarch64-unknown-linux-musl --zig
+              # ARM64 需要使用 llvm-strip 或跳过 strip
+              llvm-strip *.node 2>/dev/null || aarch64-linux-gnu-strip *.node 2>/dev/null || echo "Skip strip for cross-compiled binary"
 
           # Windows
           - host: windows-latest

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -108,6 +108,15 @@ jobs:
         with:
           targets: ${{ matrix.settings.target }}
 
+      # 修复：dtolnay/rust-toolchain 在 rustup 已存在时不会添加 PATH
+      # macos-13 预装了 Rust，但 PATH 可能没有正确设置
+      - name: Ensure Cargo in PATH
+        if: ${{ !matrix.settings.docker }}
+        shell: bash
+        run: |
+          echo "$CARGO_HOME/bin" >> $GITHUB_PATH
+          echo "Added $CARGO_HOME/bin to PATH"
+
       - name: Cache Cargo
         uses: actions/cache@v4
         with:

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -33,16 +33,21 @@ jobs:
       matrix:
         settings:
           # macOS Intel (x64)
-          # 注意：macos-13 预装的 Rust 符号链接指向 /opt/homebrew（ARM64 路径）
-          # 这是 GitHub Actions runner 的配置问题，需要重新安装 Rust
+          # 注意：macos-13 预装的 Rust 配置已损坏（符号链接指向 ARM64 路径）
+          # 需要清理损坏的配置并重新安装 Rust
           - host: macos-13
             target: x86_64-apple-darwin
             artifact: taptap-signer.darwin-x64.node
             build: |
-              # 检查 cargo 是否可用，如果不可用则重新安装 Rust
-              if ! command -v cargo &> /dev/null; then
-                echo "cargo not found, reinstalling Rust via rustup..."
-                curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+              # 检查 cargo 是否真正可用（不只是符号链接存在）
+              if ! cargo --version &> /dev/null; then
+                echo "cargo not working, cleaning up and reinstalling Rust..."
+                # 删除损坏的 cargo bin 目录（保留缓存）
+                rm -rf "$HOME/.cargo/bin"
+                # 删除损坏的 rustup 设置
+                rm -f "$HOME/.rustup/settings.toml"
+                # 重新安装 Rust
+                curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --target x86_64-apple-darwin
                 source "$HOME/.cargo/env"
               fi
               # 确保 PATH 正确

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,12 +78,20 @@ jobs:
       matrix:
         settings:
           # macOS Intel (x64)
-          # 注意：macos-13 预装了 Rust，但 napi-rs 使用 /bin/sh 调用 cargo
-          # 需要在 build 命令中显式设置 PATH，确保子进程能找到 cargo
+          # 注意：macos-13 预装的 Rust 符号链接指向 /opt/homebrew（ARM64 路径）
+          # 这是 GitHub Actions runner 的配置问题，需要重新安装 Rust
           - host: macos-13
             target: x86_64-apple-darwin
             build: |
-              export PATH="$CARGO_HOME/bin:$PATH"
+              # 检查 cargo 是否可用，如果不可用则重新安装 Rust
+              if ! command -v cargo &> /dev/null; then
+                echo "cargo not found, reinstalling Rust via rustup..."
+                curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+                source "$HOME/.cargo/env"
+              fi
+              # 确保 PATH 正确
+              export PATH="$HOME/.cargo/bin:$PATH"
+              echo "cargo version: $(cargo --version)"
               cd native
               npm run build
               strip -x *.node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,13 +77,13 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          # macOS Intel (x64) - 暂时禁用，PATH 问题待解决
-          # - host: macos-13
-          #   target: x86_64-apple-darwin
-          #   build: |
-          #     cd native
-          #     npm run build
-          #     strip -x *.node
+          # macOS Intel (x64)
+          - host: macos-13
+            target: x86_64-apple-darwin
+            build: |
+              cd native
+              npm run build
+              strip -x *.node
 
           # macOS Apple Silicon (ARM64)
           - host: macos-latest
@@ -150,6 +150,15 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.settings.target }}
+
+      # 修复：dtolnay/rust-toolchain 在 rustup 已存在时不会添加 PATH
+      # macos-13 预装了 Rust，但 PATH 可能没有正确设置
+      - name: Ensure Cargo in PATH
+        if: ${{ !matrix.settings.docker }}
+        shell: bash
+        run: |
+          echo "$CARGO_HOME/bin" >> $GITHUB_PATH
+          echo "Added $CARGO_HOME/bin to PATH"
 
       - name: Cache Cargo
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,15 +78,20 @@ jobs:
       matrix:
         settings:
           # macOS Intel (x64)
-          # 注意：macos-13 预装的 Rust 符号链接指向 /opt/homebrew（ARM64 路径）
-          # 这是 GitHub Actions runner 的配置问题，需要重新安装 Rust
+          # 注意：macos-13 预装的 Rust 配置已损坏（符号链接指向 ARM64 路径）
+          # 需要清理损坏的配置并重新安装 Rust
           - host: macos-13
             target: x86_64-apple-darwin
             build: |
-              # 检查 cargo 是否可用，如果不可用则重新安装 Rust
-              if ! command -v cargo &> /dev/null; then
-                echo "cargo not found, reinstalling Rust via rustup..."
-                curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+              # 检查 cargo 是否真正可用（不只是符号链接存在）
+              if ! cargo --version &> /dev/null; then
+                echo "cargo not working, cleaning up and reinstalling Rust..."
+                # 删除损坏的 cargo bin 目录（保留缓存）
+                rm -rf "$HOME/.cargo/bin"
+                # 删除损坏的 rustup 设置
+                rm -f "$HOME/.rustup/settings.toml"
+                # 重新安装 Rust
+                curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --target x86_64-apple-darwin
                 source "$HOME/.cargo/env"
               fi
               # 确保 PATH 正确

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,9 +78,12 @@ jobs:
       matrix:
         settings:
           # macOS Intel (x64)
+          # 注意：macos-13 预装了 Rust，但 napi-rs 使用 /bin/sh 调用 cargo
+          # 需要在 build 命令中显式设置 PATH，确保子进程能找到 cargo
           - host: macos-13
             target: x86_64-apple-darwin
             build: |
+              export PATH="$CARGO_HOME/bin:$PATH"
               cd native
               npm run build
               strip -x *.node
@@ -89,6 +92,7 @@ jobs:
           - host: macos-latest
             target: aarch64-apple-darwin
             build: |
+              export PATH="$CARGO_HOME/bin:$PATH"
               cd native
               npm run build -- --target aarch64-apple-darwin
               strip -x *.node


### PR DESCRIPTION
## Summary

- 修复 macOS Intel (x86_64-apple-darwin) 构建失败问题
- 修复 Linux ARM64 (aarch64-unknown-linux-musl) 交叉编译问题

## Root Cause

### macOS Intel
GitHub Actions macos-13 runner 预装的 Rust 配置已损坏：
- `~/.cargo/bin/cargo` → `rustup` → `/opt/homebrew/bin/rustup-init`
- `/opt/homebrew/` 是 ARM64 Homebrew 路径，但 macos-13 是 Intel (x86_64) 芯片
- 导致 cargo 符号链接指向不存在的文件

### Linux ARM64
`build-native.yml` 缺少 zig 交叉编译配置，无法在 x86_64 环境下编译 ARM64 二进制

## Solution

### macOS Intel
在 build 步骤中检测并修复损坏的 Rust 安装：
```bash
if ! cargo --version &> /dev/null; then
  rm -rf "$HOME/.cargo/bin"
  rm -f "$HOME/.rustup/settings.toml"
  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --target x86_64-apple-darwin
  source "$HOME/.cargo/env"
fi
```

### Linux ARM64
添加 zig 交叉编译配置：
```bash
apk add --no-cache zig
rustup target add aarch64-unknown-linux-musl
npm run build -- --target aarch64-unknown-linux-musl --zig
```

## Test Results

Workflow Run #19921749620 - All 7 platforms passed:
- ✅ macOS Intel (x86_64-apple-darwin)
- ✅ macOS Apple Silicon (aarch64-apple-darwin)
- ✅ Linux GNU (x86_64-unknown-linux-gnu)
- ✅ Linux Musl (x86_64-unknown-linux-musl)
- ✅ Linux ARM64 (aarch64-unknown-linux-musl)
- ✅ Windows (x86_64-pc-windows-msvc)
- ✅ Package All Binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)