### PR TITLE
fix(app): correct AppStatusResponse parsing and add enums

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "start": "node bin/minigame-open-mcp",
     "dev": "tsx watch src/server.ts",
     "serve": "TAPTAP_MCP_TRANSPORT=sse node dist/server.js",
+    "docker:npm": "cd docker/npm && docker-compose -p taptap-mcp up -d",
     "test": "jest",
     "lint": "eslint \"src/**/*.ts\"",
     "lint:fix": "eslint \"src/**/*.ts\" --fix",

--- a/src/core/types/context.ts
+++ b/src/core/types/context.ts
@@ -11,7 +11,7 @@
 
 import type { MacToken } from './index.js';
 import type { PrivateToolParams } from './privateParams.js';
-import { readAppCache, type AppCacheInfo } from '../utils/cache.js';
+import { readAppCache } from '../utils/cache.js';
 import { loadTokenFromFile, getTokenPath } from '../auth/tokenStorage.js';
 import { EnvConfig } from '../utils/env.js';
 

--- a/src/features/app/api.ts
+++ b/src/features/app/api.ts
@@ -312,9 +312,39 @@ export async function editAppInfo(
 }
 
 /**
+ * 关卡游戏状态
+ * @see https://agent.api.xdrnd.cn/_docs#/level/get_level_v1_status
+ */
+export enum AppStatus {
+  /** 未上线 */
+  Offline = 0,
+  /** 已上线 */
+  Online = 1,
+}
+
+/**
+ * 审核状态
+ * @see https://agent.api.xdrnd.cn/_docs#/level/get_level_v1_status
+ */
+export enum ReviewStatus {
+  /** 未发布 */
+  Unpublished = 0,
+  /** 审核中 */
+  UnderReview = 1,
+  /** 审核失败 */
+  Rejected = 2,
+  /** 已上线 */
+  Published = 4,
+}
+
+/**
  * App Status Response
+ * @see https://agent.api.xdrnd.cn/_docs#/level/get_level_v1_status
  */
 export interface AppStatusResponse {
+  /** 关卡游戏状态 */
+  app_status: number;
+  /** 审核状态 */
   review_status: number;
 }
 

--- a/src/features/app/handlers.ts
+++ b/src/features/app/handlers.ts
@@ -10,6 +10,9 @@ import {
   createDeveloper,
   createAppForDeveloper,
   editAppInfo as editAppInfoApi,
+  getAppStatus as getAppStatusApi,
+  AppStatus,
+  ReviewStatus,
 } from './api.js';
 import { clearAppCache } from '../../core/utils/cache.js';
 import { clearToken, saveToken } from '../../core/auth/tokenStorage.js';
@@ -466,4 +469,39 @@ export async function updateAppInfo(
   );
 
   return MESSAGES.EDIT_GAME_INFO_SUCCESS;
+}
+
+/**
+ * Get app status (app_status and review_status)
+ * @see https://agent.api.xdrnd.cn/_docs#/level/get_level_v1_status
+ */
+export async function getAppStatus(appId: number, ctx: ResolvedContext): Promise<string> {
+  const result = await getAppStatusApi(appId, ctx);
+
+  // 使用枚举映射状态文本
+  const appStatusMap: Record<number, string> = {
+    [AppStatus.Offline]: '未上线',
+    [AppStatus.Online]: '已上线',
+  };
+  const appStatusText = appStatusMap[result.app_status] ?? '未知状态';
+
+  const reviewStatusMap: Record<number, string> = {
+    [ReviewStatus.Unpublished]: '未发布',
+    [ReviewStatus.UnderReview]: '审核中',
+    [ReviewStatus.Rejected]: '审核失败',
+    [ReviewStatus.Published]: '已上线',
+  };
+  const reviewStatusText = reviewStatusMap[result.review_status] ?? '未知状态';
+
+  return (
+    `📋 应用状态查询结果\n\n` +
+    `🎮 关卡游戏状态：${appStatusText} (${result.app_status})\n` +
+    `   - ${AppStatus.Offline}: 未上线\n` +
+    `   - ${AppStatus.Online}: 已上线\n\n` +
+    `📝 审核状态：${reviewStatusText} (${result.review_status})\n` +
+    `   - ${ReviewStatus.Unpublished}: 未发布\n` +
+    `   - ${ReviewStatus.UnderReview}: 审核中\n` +
+    `   - ${ReviewStatus.Rejected}: 审核失败\n` +
+    `   - ${ReviewStatus.Published}: 已上线`
+  );
 }

--- a/src/features/app/tools.ts
+++ b/src/features/app/tools.ts
@@ -247,17 +247,7 @@ export const appTools: ToolRegistration[] = [
       },
     },
     handler: async (args: { app_id: number }, context) => {
-      const result = await appApi.getAppStatus(args.app_id, context);
-      const statusText =
-        ['未发布', '审核中', '审核失败', '已上线'][result.review_status] || '未知状态';
-      return (
-        `📋 应用审核状态：${statusText}\n\n` +
-        `状态码: ${result.review_status}\n` +
-        `- 0: 未发布\n` +
-        `- 1: 审核中\n` +
-        `- 2: 审核失败\n` +
-        `- 3: 已上线`
-      );
+      return appHandlers.getAppStatus(args.app_id, context);
     },
     requiresAuth: true,
   },


### PR DESCRIPTION
## Summary
- 修复 `getAppStatus` API 响应解析，补充缺失的 `app_status` 字段
- 新增 `AppStatus` 和 `ReviewStatus` 枚举，提升代码可读性
- 将 `getAppStatus` 逻辑封装到 `handlers.ts`，保持代码组织一致性
- 修正 API 文档链接
- 添加 `docker:npm` 便捷脚本
- 清理未使用的 import

## Test plan
- [ ] 验证 `get_app_status` 工具正确返回 `app_status` 和 `review_status`
- [ ] 确认枚举值与 API 文档一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)