### PR TITLE
fix(proxy): add session validation for multi-replica deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 
 ## 🚀 快速开始
 
+> 🐣 **新手请看这里**：[TapTap MCP 配置指南 (小白版)](docs/USER_GUIDE.md) - 手把手教你配置 Cursor、Claude Code 和 VS Code。
+
 ### 安装
 
 ```bash
@@ -42,7 +44,7 @@ npx @mikoto_zero/minigame-open-mcp
       "command": "npx",
       "args": ["-y", "@mikoto_zero/minigame-open-mcp"],
       "env": {
-        "WORKSPACE_ROOT": "${workspaceFolder}"
+        "TAPTAP_MCP_WORKSPACE_ROOT": "${workspaceFolder}"
       }
     }
   }
@@ -52,9 +54,9 @@ npx @mikoto_zero/minigame-open-mcp
 **重要说明**：
 
 - **零配置 OAuth**：首次使用会提示扫码授权，token 自动保存！
-- **路径处理**：设置 `WORKSPACE_ROOT` 环境变量可以正确解析相对路径（推荐）
+- **路径处理**：设置 `TAPTAP_MCP_WORKSPACE_ROOT` 环境变量可以正确解析相对路径（推荐）
   - 如果不设置，相对路径会基于用户 HOME 目录（可能不符合预期）
-  - 建议使用绝对路径，或配置 `WORKSPACE_ROOT`
+  - 建议使用绝对路径，或配置 `TAPTAP_MCP_WORKSPACE_ROOT`
 
 #### OpenHands（推荐 SSE 模式）
 
@@ -311,6 +313,7 @@ graph LR
 
 ### 用户文档
 
+- **[docs/USER_GUIDE.md](docs/USER_GUIDE.md)** - 🐣 新手配置指南（Cursor/VS Code/Claude Code）
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** - 贡献指南
 - **[CHANGELOG.md](CHANGELOG.md)** - 版本变更历史
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -38,7 +38,7 @@ npx @mikoto_zero/minigame-open-mcp
       "command": "npx",
       "args": ["-y", "@mikoto_zero/minigame-open-mcp"],
       "env": {
-        "WORKSPACE_ROOT": "${workspaceFolder}"
+        "TAPTAP_MCP_WORKSPACE_ROOT": "${workspaceFolder}"
       }
     }
   }
@@ -54,7 +54,7 @@ npx @mikoto_zero/minigame-open-mcp
       "command": "npx",
       "args": ["-y", "@mikoto_zero/minigame-open-mcp"],
       "env": {
-        "WORKSPACE_ROOT": "/path/to/your/project"
+        "TAPTAP_MCP_WORKSPACE_ROOT": "/path/to/your/project"
       }
     }
   }
@@ -65,9 +65,9 @@ npx @mikoto_zero/minigame-open-mcp
 
 - **零配置 OAuth**：首次使用会提示扫码授权，token 自动保存到 `~/.config/taptap-minigame/token.json`
 - **路径处理**：
-  - 推荐设置 `WORKSPACE_ROOT` 环境变量以正确解析相对路径
+  - 推荐设置 `TAPTAP_MCP_WORKSPACE_ROOT` 环境变量以正确解析相对路径
   - 如果不设置，相对路径会基于用户 HOME 目录（可能不符合预期）
-  - 建议使用绝对路径，或配置 `WORKSPACE_ROOT`
+  - 建议使用绝对路径，或配置 `TAPTAP_MCP_WORKSPACE_ROOT`
   - 详见：[PATH_RESOLUTION.md](PATH_RESOLUTION.md)
 
 ---
@@ -188,11 +188,11 @@ export TAPTAP_MCP_MAC_TOKEN='{"kid":"your_kid","token_type":"mac","mac_key":"you
 
 #### 缓存和临时文件（可选）
 
-| 变量                   | 说明           | 默认值                  |
-| ---------------------- | -------------- | ----------------------- |
-| `TAPTAP_MCP_CACHE_DIR` | 缓存根目录     | `/tmp/taptap-mcp/cache` |
-| `TAPTAP_MCP_TEMP_DIR`  | 临时文件根目录 | `/tmp/taptap-mcp/temp`  |
-| `WORKSPACE_ROOT`       | 工作空间根路径 | `process.cwd()`         |
+| 变量                        | 说明           | 默认值                  |
+| --------------------------- | -------------- | ----------------------- |
+| `TAPTAP_MCP_CACHE_DIR`      | 缓存根目录     | `/tmp/taptap-mcp/cache` |
+| `TAPTAP_MCP_TEMP_DIR`       | 临时文件根目录 | `/tmp/taptap-mcp/temp`  |
+| `TAPTAP_MCP_WORKSPACE_ROOT` | 工作空间根路径 | `process.cwd()`         |
 
 **缓存目录结构**：
 
@@ -508,7 +508,7 @@ npx @modelcontextprotocol/inspector node dist/server.js
         "TAPTAP_MCP_CLIENT_ID": "test",
         "TAPTAP_MCP_CLIENT_SECRET": "test",
         "TAPTAP_MCP_VERBOSE": "true",
-        "WORKSPACE_ROOT": "${workspaceFolder}"
+        "TAPTAP_MCP_WORKSPACE_ROOT": "${workspaceFolder}"
       }
     }
   }
@@ -618,8 +618,8 @@ export TAPTAP_MCP_MAC_TOKEN='{"kid":"test","token_type":"mac","mac_key":"test","
 #### 路径解析错误
 
 ```bash
-# 设置 WORKSPACE_ROOT
-export WORKSPACE_ROOT=$(pwd)
+# 设置 TAPTAP_MCP_WORKSPACE_ROOT
+export TAPTAP_MCP_WORKSPACE_ROOT=$(pwd)
 
 # 或使用绝对路径
 ```

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,0 +1,212 @@
+# TapTap Minigame MCP Server 配置指南 (小白版)
+
+这份文档是专门为刚接触 MCP (Model Context Protocol) 的用户准备的。我们会一步步教你如何在常用的 AI 工具中配置 TapTap 小游戏助手。
+
+## 📋 准备工作
+
+在开始之前，请确保你的电脑上已经安装了：
+
+1.  **Node.js** (版本 18 或更高)
+    - 如果不确定，可以在终端/命令行输入 `node -v` 检查。
+    - 如果没有安装，请去 [Node.js 官网](https://nodejs.org/) 下载安装。
+
+    > **💡 偷懒小技巧：让 AI 帮你装**
+    >
+    > 如果你不知道怎么安装，可以直接把下面这段话发给 AI (比如 Cursor 的 Chat)：
+    >
+    > > 我需要安装 Node.js (版本 18+)，我的电脑是 [你的系统，如 Mac/Windows]，请一步步教我怎么安装，最好能给我具体的命令或者下载链接。
+
+---
+
+## 🚀 方式一：项目级配置 (推荐)
+
+这是最简单的方式！只需要在你的游戏项目根目录下创建一个文件，Cursor 和 Claude Code 就能自动识别。
+
+**适用工具**：Cursor, Claude Code (CLI)
+
+### 步骤：
+
+1.  打开你的游戏项目文件夹。
+2.  在根目录创建一个新文件，命名为 `.mcp.json` (注意前面有个点)。
+3.  将下面的内容复制进去并保存 _(如果已有其他配置，请参考 [常见问题 - 2. 多服务器配置示例](#2-我已经有其他-mcp-服务器了怎么合并配置))_：
+
+```json
+{
+  "mcpServers": {
+    "taptap-minigame": {
+      "command": "npx",
+      "args": ["-y", "@mikoto_zero/minigame-open-mcp"]
+    }
+  }
+}
+```
+
+**配置说明**：
+
+- 我们使用了 `npx`，这样你不需要手动下载任何东西，每次都会使用最新版本。
+
+---
+
+## 🛠️ 方式二：工具单独配置
+
+如果你希望在所有项目中都能使用这个工具，或者上面的方法不生效，可以尝试在工具里单独配置。
+
+### 1. Cursor (图形界面配置)
+
+1.  打开 Cursor。
+2.  点击右上角的 **齿轮图标 (Settings)** (或按 `Ctrl/Cmd + ,`)。
+3.  在左侧菜单找到 **Features** -> **MCP**。
+4.  点击 **+ Add New MCP Server** 按钮。
+5.  在弹出的表单中照着填 (见下图表)：
+
+| 选项 (Field) | 填什么 (Value)                      | 说明                 |
+| :----------- | :---------------------------------- | :------------------- |
+| **Name**     | `taptap-minigame`                   | 名字随便起，好记就行 |
+| **Type**     | `command`                           | 必须选 command       |
+| **Command**  | `npx`                               | 这是运行命令         |
+| **Args**     | `-y @mikoto_zero/minigame-open-mcp` | 参数，注意空格和`-y` |
+
+6.  点击 **Save** 保存。
+7.  查看状态指示灯变绿 🟢，说明连接成功！
+
+### 2. Claude Desktop 配置
+
+Claude Desktop (Mac/Windows 客户端) 使用一个全局配置文件。
+
+1.  点击菜单栏的 Claude -> **Settings**。
+2.  点击 **Developer** -> **Edit Config**。
+3.  这会打开一个 `config.json` 文件。在 `mcpServers` 部分添加我们的配置：
+
+```json
+{
+  "mcpServers": {
+    "taptap-minigame": {
+      "command": "npx",
+      "args": ["-y", "@mikoto_zero/minigame-open-mcp"]
+    }
+  }
+}
+```
+
+_(如果文件里已经有其他服务器，请注意 JSON 格式，在上一项后面加逗号，可参考 [常见问题 - 2. 多服务器配置示例](#2-我已经有其他-mcp-服务器了怎么合并配置))_
+
+### 3. VS Code 配置 (原生 / GitHub Copilot)
+
+VS Code 配合 **GitHub Copilot Chat** 扩展现已原生支持 MCP 协议。
+
+#### 方式 A：原生配置文件 (推荐)
+
+1.  确保你安装了 **GitHub Copilot Chat** 插件。
+2.  在你的项目文件夹下，找到或创建一个名为 `.vscode` 的文件夹。
+3.  在 `.vscode` 文件夹里新建一个文件，叫 `mcp.json`。
+4.  复制下面的内容进去 _(如果已有其他配置，请参考 [常见问题 - 2. 多服务器配置示例](#2-我已经有其他-mcp-服务器了怎么合并配置))_：
+
+```json
+{
+  "mcpServers": {
+    "taptap-minigame": {
+      "command": "npx",
+      "args": ["-y", "@mikoto_zero/minigame-open-mcp"]
+    }
+  }
+}
+```
+
+5.  重启 VS Code。现在你可以在 Copilot Chat 中直接使用了！
+
+#### 方式 B：使用插件 (Cline / Roo Code)
+
+如果你没有订阅 GitHub Copilot，可以使用免费的开源插件，比如 **Cline** 或 **Roo Code**，它们也支持 MCP 并且有图形界面。
+
+以 **Cline** 为例：
+
+1.  安装 **Cline** 插件。
+2.  点击插件设置（齿轮图标）。
+3.  找到 **MCP Servers** 并点击编辑。
+4.  添加上面的 JSON 配置即可。
+
+---
+
+## 💡 进阶配置 & 常见问题
+
+### 1. 第一次使用需要认证吗？
+
+是的！当你第一次让 AI 执行创建排行榜等操作时，它会暂停并给出一个**二维码链接**。
+
+1.  点击链接或复制到浏览器打开。
+2.  使用 **TapTap App** 扫码授权。
+3.  授权成功后，告诉 AI "我已经授权了"，它就会继续执行。
+
+- Token 会自动保存在你的电脑上，下次就不需要再扫码了。
+
+### 2. 我已经有其他 MCP 服务器了，怎么合并配置？
+
+如果你需要同时使用多个 MCP 服务器，在编辑 JSON 文件时，请注意 **JSON 语法格式**：
+
+- 每项配置之间必须用**逗号 `,`** 分隔。
+- 最后一项后面**不能**加逗号。
+
+**配置示例：**
+
+```json
+{
+  "mcpServers": {
+    "existing-server": {
+      "command": "...",
+      "args": [...]
+    }, // 👈 注意这里必须有逗号
+    "taptap-minigame": {
+      "command": "npx",
+      "args": ["-y", "@mikoto_zero/minigame-open-mcp"]
+    }
+  }
+}
+```
+
+### 3. 为什么 AI 找不到我的文件？(环境变量 / 路径问题)
+
+如果你在使用 H5 游戏上传等功能时，AI 提示找不到目录，可能是因为相对路径解析问题。
+
+通常情况下，AI 能够自动处理这些问题。但如果它一直报错找不到文件，你可以尝试显式配置 `env`。
+
+**解决方法：**
+在配置中添加 `env` 字段，并指定 `TAPTAP_MCP_WORKSPACE_ROOT`。
+
+**以项目级配置 (.mcp.json) 为例：**
+
+```json
+{
+  "mcpServers": {
+    "taptap-minigame": {
+      "command": "npx",
+      "args": ["-y", "@mikoto_zero/minigame-open-mcp"],
+      "env": {
+        // 👇 这里通常不是必须的，除非遇到路径问题
+        "TAPTAP_MCP_WORKSPACE_ROOT": "${workspaceFolder}"
+        // 注意：${workspaceFolder} 是 VS Code/Cursor 的变量
+        // 如果是在 Claude Desktop 中，这里需要填项目文件夹的绝对路径，例如 "/Users/xxx/MyGame"
+      }
+    }
+  }
+}
+```
+
+### 4. Google Gemini AI Studio 如何配置？
+
+目前 **Google AI Studio** 网页版暂时还**不支持**作为 MCP 客户端直接连接外部 MCP 服务器。它目前主要支持 Google 自家的生态集成。
+
+如果你想用 Gemini 模型配合 MCP 使用，建议使用支持 Gemini 模型的客户端，例如：
+
+- **Cursor**: 在模型设置里选择 Gemini 模型。
+- **Cline (VS Code)**: 模型提供商选择 Gemini。
+
+### 5. 遇到报错怎么办？
+
+如果遇到连接错误，通常是因为网络问题（无法连接 npm）。
+
+- **解决方法**：确保你的网络可以访问 npm 仓库，或者配置了合适的镜像源。
+- **调试**：可以在 Cursor/VS Code 的输出面板查看 MCP 相关的日志。
+
+---
+
+希望这份指南能帮到你！如果有其他问题，欢迎查阅 [DEPLOYMENT.md](DEPLOYMENT.md) 获取更详细的技术细节。

--- a/src/mcp-proxy/proxy.ts
+++ b/src/mcp-proxy/proxy.ts
@@ -34,7 +34,13 @@ export class TapTapMCPProxy {
   private connected: boolean = false;
   private reconnecting: boolean = false;
   private reconnectTimer: NodeJS.Timeout | null = null;
+  private healthCheckTimer: NodeJS.Timeout | null = null;
   private pendingRequests: PendingRequest[] = [];
+
+  // 会话验证相关
+  private sessionValidated: boolean = false;
+  private lastValidationTime: number = 0;
+  private readonly SESSION_VALIDATION_INTERVAL = 30000; // 30秒验证一次会话
 
   constructor(config: ProxyConfig) {
     this.config = config;
@@ -97,9 +103,19 @@ export class TapTapMCPProxy {
       const transport = new StreamableHTTPClientTransport(new URL(this.config.server.url));
 
       await this.client.connect(transport);
-      this.connected = true;
 
-      console.error('[Proxy] ✅ Connected to TapTap MCP Server');
+      // 🔑 关键：连接成功后立即验证会话
+      // 这确保即使连接到新的 Server 副本，也能确认 MCP 会话已正确初始化
+      await this.validateSession();
+
+      this.connected = true;
+      this.sessionValidated = true;
+      this.lastValidationTime = Date.now();
+
+      console.error('[Proxy] ✅ Connected and session validated');
+
+      // 启动定期健康检查
+      this.startHealthCheck();
 
       // 如果是重连，处理待处理的请求
       if (this.reconnecting) {
@@ -109,7 +125,92 @@ export class TapTapMCPProxy {
       }
     } catch (error) {
       this.connected = false; // 确保连接失败时状态正确
+      this.sessionValidated = false;
       throw error;
+    }
+  }
+
+  /**
+   * 验证 MCP 会话是否有效
+   * 通过调用 listTools 来验证 Server 端的 MCP 会话状态
+   */
+  private async validateSession(): Promise<void> {
+    console.error('[Proxy] Validating MCP session...');
+
+    try {
+      // 使用 listTools 作为会话验证手段
+      // 如果 Server 未初始化，这个调用会失败
+      await this.client.listTools();
+      console.error('[Proxy] ✅ Session validation successful');
+    } catch (error) {
+      console.error('[Proxy] ❌ Session validation failed:', error);
+
+      // 检查是否是 "server not initialized" 错误
+      if (this.isSessionInvalidError(error)) {
+        throw new Error('Server session not initialized - need to reconnect');
+      }
+
+      // 其他错误也视为会话无效
+      throw error;
+    }
+  }
+
+  /**
+   * 检测是否是会话无效错误（Server 未初始化）
+   */
+  private isSessionInvalidError(error: unknown): boolean {
+    if (!(error instanceof Error)) return false;
+
+    const errorMsg = error.message.toLowerCase();
+
+    // MCP SDK Server 返回的未初始化错误
+    const sessionInvalidKeywords = [
+      'server not initialized',
+      'not initialized',
+      'session not found',
+      'session expired',
+      'invalid session',
+      'no active session',
+    ];
+
+    return sessionInvalidKeywords.some((keyword) => errorMsg.includes(keyword));
+  }
+
+  /**
+   * 启动定期健康检查
+   */
+  private startHealthCheck(): void {
+    this.stopHealthCheck();
+
+    const interval = this.config.options?.health_check_interval ?? this.SESSION_VALIDATION_INTERVAL;
+
+    this.healthCheckTimer = setInterval(async () => {
+      if (!this.connected || this.reconnecting) return;
+
+      try {
+        await this.validateSession();
+        this.lastValidationTime = Date.now();
+      } catch (error) {
+        console.error('[Proxy] ❌ Health check failed, triggering reconnection');
+        this.connected = false;
+        this.sessionValidated = false;
+
+        if (!this.reconnecting) {
+          this.reconnectToServer();
+        }
+      }
+    }, interval);
+
+    console.error(`[Proxy] Health check started (interval: ${interval}ms)`);
+  }
+
+  /**
+   * 停止健康检查
+   */
+  private stopHealthCheck(): void {
+    if (this.healthCheckTimer) {
+      clearInterval(this.healthCheckTimer);
+      this.healthCheckTimer = null;
     }
   }
 
@@ -163,6 +264,9 @@ export class TapTapMCPProxy {
    * 清理资源（公开方法，供进程退出时调用）
    */
   public cleanup(): void {
+    // 停止健康检查
+    this.stopHealthCheck();
+
     // 清除重连定时器
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
@@ -178,7 +282,7 @@ export class TapTapMCPProxy {
   }
 
   /**
-   * 检测是否是网络错误或连接中断
+   * 检测是否是需要重连的错误（网络错误或会话无效）
    */
   private isNetworkError(error: unknown): boolean {
     if (!(error instanceof Error)) return false;
@@ -211,11 +315,16 @@ export class TapTapMCPProxy {
       'connection reset',
       'timeout',
       'dns',
-      'server not initialized', // MCP SDK Server 未初始化（重启后会话丢失）
       'not connected', // 连接断开
     ];
 
-    return networkErrorKeywords.some((keyword) => errorMsg.includes(keyword));
+    if (networkErrorKeywords.some((keyword) => errorMsg.includes(keyword))) {
+      return true;
+    }
+
+    // 🔑 关键：会话无效错误也需要触发重连
+    // 这解决了多副本部署时连接到未初始化 Server 副本的问题
+    return this.isSessionInvalidError(error);
   }
 
   /**

--- a/src/mcp-proxy/types.ts
+++ b/src/mcp-proxy/types.ts
@@ -49,6 +49,8 @@ export interface ProxyConfig {
     tool_call_timeout?: number;
     /** 收到 progress 通知时重置超时计时器（默认 true） */
     reset_timeout_on_progress?: boolean;
+    /** 健康检查间隔（毫秒，默认 30000）- 定期验证 Server 会话是否有效 */
+    health_check_interval?: number;
   };
 }
 


### PR DESCRIPTION
## 问题描述

在 TapCode 生产环境中，MCP Server 是多副本部署的。当 Proxy 断链后重连时，可能会连接到一个没有初始化的 Server 副本，导致 Proxy 认为自己已经连接成功（`connected = true`），但实际上 Server 端没有该会话的状态，返回 "server not initialized" 错误。

### 问题根因

```
┌─────────────────────────────────────────────────────────────────┐
│               K8s 多副本部署（Pod 重调度时）                      │
├─────────────────────────────────────────────────────────────────┤
│                                                                 │
│                    ┌── MCP Server (Pod A) ←── 已初始化会话       │
│  Proxy ── LB ──────┤                                            │
│                    └── MCP Server (Pod B) ←── 无会话状态         │
│                                                                 │
│  Pod A 被终止后，LB 将请求路由到 Pod B                            │
│  HTTP 连接成功，但 Pod B 没有 Proxy 的 MCP 会话状态               │
│  Proxy: connected = true                                        │
│  Server: "server not initialized" ❌                            │
└─────────────────────────────────────────────────────────────────┘
```

## 解决方案

### 1. 连接后立即验证会话 (`validateSession`)
- 连接成功后调用 `listTools()` 验证 MCP 会话是否真正初始化
- 如果验证失败，连接不会被标记为成功，会触发重连

### 2. 定期健康检查 (`startHealthCheck`)
- 默认每 30 秒验证一次会话有效性
- 如果检测到会话失效，主动触发重连
- 可通过 `health_check_interval` 配置调整间隔

### 3. 增强错误检测 (`isSessionInvalidError`)
- 专门检测 "server not initialized" 等会话无效错误
- 这类错误会自动触发重连流程

## 改动文件

- `src/mcp-proxy/proxy.ts` - 添加会话验证和健康检查逻辑
- `src/mcp-proxy/types.ts` - 添加 `health_check_interval` 配置选项

## 新增配置项

```typescript
options?: {
  // ... 其他配置
  /** 健康检查间隔（毫秒，默认 30000）- 定期验证 Server 会话是否有效 */
  health_check_interval?: number;
}
```

## 测试建议

1. 在多副本 K8s 环境中测试
2. 模拟 Pod 重启/重调度场景
3. 验证 Proxy 能够自动检测会话失效并重连