### PR TITLE
fix(proxy): add detailed error logging for connection failures

### DIFF
--- a/src/mcp-proxy/proxy.ts
+++ b/src/mcp-proxy/proxy.ts
@@ -228,22 +228,34 @@ export class TapTapMCPProxy {
     // 错误消息
     parts.push(error.message);
 
-    // 错误码（如 ECONNREFUSED）
+    // 系统错误码（如 ECONNREFUSED）
     const errorCode = (error as any).code;
     if (errorCode) {
       parts.push(`[${errorCode}]`);
     }
 
-    // 原因（cause）
+    // HTTP 状态码（如 500, 502, 503）
+    const httpStatus = (error as any).status || (error as any).statusCode;
+    if (httpStatus) {
+      parts.push(`[HTTP ${httpStatus}]`);
+    }
+
+    // HTTP 响应体（如果有）
+    const responseBody = (error as any).body || (error as any).responseText;
+    if (responseBody && typeof responseBody === 'string' && responseBody.length < 200) {
+      parts.push(`(response: ${responseBody})`);
+    }
+
+    // 原因（cause）- 递归提取嵌套错误
     const cause = (error as any).cause;
     if (cause) {
       if (cause instanceof Error) {
         const causeCode = (cause as any).code;
-        if (causeCode) {
-          parts.push(`(cause: ${cause.message} [${causeCode}])`);
-        } else {
-          parts.push(`(cause: ${cause.message})`);
-        }
+        const causeStatus = (cause as any).status || (cause as any).statusCode;
+        let causeInfo = cause.message;
+        if (causeCode) causeInfo += ` [${causeCode}]`;
+        if (causeStatus) causeInfo += ` [HTTP ${causeStatus}]`;
+        parts.push(`(cause: ${causeInfo})`);
       } else {
         parts.push(`(cause: ${String(cause)})`);
       }

--- a/src/mcp-proxy/proxy.ts
+++ b/src/mcp-proxy/proxy.ts
@@ -217,6 +217,20 @@ export class TapTapMCPProxy {
 
   /**
    * 格式化错误信息，提取有用的错误详情
+   *
+   * 错误来源及结构：
+   * 1. 网络层错误 (Node.js fetch):
+   *    - message: "fetch failed"
+   *    - cause.code: "ECONNREFUSED" / "ETIMEDOUT" 等系统错误码
+   *    - cause.message: "connect ECONNREFUSED 127.0.0.1:4000"
+   *
+   * 2. HTTP 错误 (MCP SDK send):
+   *    - message: "Error POSTing to endpoint (HTTP 502): Bad Gateway"
+   *    - HTTP 状态码嵌入在 message 中
+   *
+   * 3. SSE 连接错误 (MCP SDK StreamableHTTPError):
+   *    - message: "Streamable HTTP error: Failed to open SSE stream: Bad Gateway"
+   *    - code: 502 (HTTP 状态码，注意和系统错误码共用 code 字段)
    */
   private formatError(error: unknown): string {
     if (!(error instanceof Error)) {
@@ -225,36 +239,27 @@ export class TapTapMCPProxy {
 
     const parts: string[] = [];
 
-    // 错误消息
+    // 错误消息（HTTP 状态码可能嵌入在消息中）
     parts.push(error.message);
 
-    // 系统错误码（如 ECONNREFUSED）
+    // 错误码：可能是系统错误码 (ECONNREFUSED) 或 HTTP 状态码 (502)
     const errorCode = (error as any).code;
     if (errorCode) {
-      parts.push(`[${errorCode}]`);
+      // 判断是数字（HTTP 状态码）还是字符串（系统错误码）
+      if (typeof errorCode === 'number') {
+        parts.push(`[HTTP ${errorCode}]`);
+      } else {
+        parts.push(`[${errorCode}]`);
+      }
     }
 
-    // HTTP 状态码（如 500, 502, 503）
-    const httpStatus = (error as any).status || (error as any).statusCode;
-    if (httpStatus) {
-      parts.push(`[HTTP ${httpStatus}]`);
-    }
-
-    // HTTP 响应体（如果有）
-    const responseBody = (error as any).body || (error as any).responseText;
-    if (responseBody && typeof responseBody === 'string' && responseBody.length < 200) {
-      parts.push(`(response: ${responseBody})`);
-    }
-
-    // 原因（cause）- 递归提取嵌套错误
+    // 原因（cause）- 网络错误的真正原因在这里
     const cause = (error as any).cause;
     if (cause) {
       if (cause instanceof Error) {
         const causeCode = (cause as any).code;
-        const causeStatus = (cause as any).status || (cause as any).statusCode;
         let causeInfo = cause.message;
         if (causeCode) causeInfo += ` [${causeCode}]`;
-        if (causeStatus) causeInfo += ` [HTTP ${causeStatus}]`;
         parts.push(`(cause: ${causeInfo})`);
       } else {
         parts.push(`(cause: ${String(cause)})`);

--- a/src/mcp-proxy/proxy.ts
+++ b/src/mcp-proxy/proxy.ts
@@ -77,7 +77,8 @@ export class TapTapMCPProxy {
     try {
       await this.connectToServer();
     } catch (error) {
-      console.error('[Proxy] Initial connection failed, will retry in background');
+      console.error('[Proxy] ❌ Initial connection failed:', this.formatError(error));
+      console.error('[Proxy] Will retry in background...');
       this.scheduleReconnect();
       // 不抛出错误，让 Proxy 继续启动
       // Agent 在调用工具时会收到 "not connected" 错误
@@ -215,6 +216,43 @@ export class TapTapMCPProxy {
   }
 
   /**
+   * 格式化错误信息，提取有用的错误详情
+   */
+  private formatError(error: unknown): string {
+    if (!(error instanceof Error)) {
+      return String(error);
+    }
+
+    const parts: string[] = [];
+
+    // 错误消息
+    parts.push(error.message);
+
+    // 错误码（如 ECONNREFUSED）
+    const errorCode = (error as any).code;
+    if (errorCode) {
+      parts.push(`[${errorCode}]`);
+    }
+
+    // 原因（cause）
+    const cause = (error as any).cause;
+    if (cause) {
+      if (cause instanceof Error) {
+        const causeCode = (cause as any).code;
+        if (causeCode) {
+          parts.push(`(cause: ${cause.message} [${causeCode}])`);
+        } else {
+          parts.push(`(cause: ${cause.message})`);
+        }
+      } else {
+        parts.push(`(cause: ${String(cause)})`);
+      }
+    }
+
+    return parts.join(' ');
+  }
+
+  /**
    * 重连到 TapTap Server
    */
   private async reconnectToServer(): Promise<void> {
@@ -233,7 +271,9 @@ export class TapTapMCPProxy {
       await this.connectToServer();
       console.error('[Proxy] ✅ Reconnected successfully');
     } catch (error) {
-      console.error('[Proxy] Reconnect failed, will retry in 5s');
+      const interval = this.config.options?.reconnect_interval ?? 5000;
+      console.error('[Proxy] ❌ Reconnect failed:', this.formatError(error));
+      console.error(`[Proxy] Will retry in ${interval / 1000}s...`);
       this.reconnecting = false; // 重置状态，允许下次重连
       this.scheduleReconnect();
     }


### PR DESCRIPTION
## 问题描述

### 问题 1: 连接失败日志不详细
当 Proxy 连接 MCP Server 失败时，日志只显示 "Initial connection failed" 或 "Reconnect failed"，没有具体的错误信息，不利于排查问题。

### 问题 2: K8s 多副本部署时连接失败
在 K8s 多副本部署环境中，Proxy 连接成功后，后续请求可能被负载均衡到不同的 Pod，导致 "Server not initialized" 错误。

**根本原因：**
- MCP StreamableHTTP 协议是有状态的（Session ID 绑定特定 Server）
- K8s Service 默认负载均衡是无状态的（每次请求独立路由）
- 两者假设冲突

## 解决方案

### 1. 详细的错误日志

**修改前：**
```
[Proxy] Initial connection failed, will retry in background
[Proxy] Reconnect failed, will retry in 5s
```

**修改后：**
```
[Proxy] ❌ Initial connection failed: fetch failed (cause: connect ECONNREFUSED 127.0.0.1:4000 [ECONNREFUSED])
[Proxy] Will retry in background...
[Proxy] ❌ Reconnect failed: Error POSTing to endpoint (HTTP 502): Bad Gateway
[Proxy] Will retry in 5s...
```

### 2. Cookie 会话粘性支持

添加 `CookieJar` 类来管理 HTTP Cookie，实现 K8s Ingress 会话粘性：

```
┌─────────────────────────────────────────────────────────────────┐
│                    Cookie 粘性工作流程                           │
├─────────────────────────────────────────────────────────────────┤
│  第一次请求:                                                     │
│  Proxy ──→ Ingress ──→ Pod A                                    │
│         ←── Set-Cookie: MCP_ROUTE=pod-a-hash (Ingress 植入)     │
│                                                                 │
│  后续请求:                                                       │
│  Proxy ──→ Ingress ──→ Pod A  ← 根据 Cookie 路由到同一个 Pod    │
│    Cookie: MCP_ROUTE=pod-a-hash                                 │
└─────────────────────────────────────────────────────────────────┘
```

## 改动文件

| 文件 | 改动 |
|------|------|
| `src/mcp-proxy/cookieJar.ts` | 新增 - Cookie 管理器 |
| `src/mcp-proxy/proxy.ts` | 集成 Cookie 支持 + 详细错误日志 |
| `src/mcp-proxy/types.ts` | 新增 `enable_cookie_sticky` 配置项 |

## 新增配置项

```typescript
options?: {
  // ...
  /** 启用 Cookie 会话粘性（默认 true） */
  enable_cookie_sticky?: boolean;
}
```

## K8s Ingress 配置示例

### NGINX Ingress
```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: mcp-server-ingress
  annotations:
    nginx.ingress.kubernetes.io/affinity: "cookie"
    nginx.ingress.kubernetes.io/session-cookie-name: "MCP_ROUTE"
    nginx.ingress.kubernetes.io/session-cookie-expires: "3600"
spec:
  rules:
    - host: mcp.example.com
      http:
        paths:
          - path: /
            pathType: Prefix
            backend:
              service:
                name: mcp-server
                port:
                  number: 4000
```

### 阿里云 ALB Ingress
```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: mcp-server-ingress
  annotations:
    alb.ingress.kubernetes.io/sticky-session: "true"
    alb.ingress.kubernetes.io/sticky-session-type: "Insert"
    alb.ingress.kubernetes.io/cookie-timeout: "3600"
spec:
  ingressClassName: alb
  # ...
```

## 测试建议

1. **错误日志测试**：在 MCP Server 未启动时启动 Proxy，验证错误日志详情
2. **Cookie 粘性测试**：
   - 配置 Ingress Cookie 粘性
   - 部署多副本 MCP Server
   - 验证 Proxy 请求始终路由到同一个 Pod