### PR TITLE
feat(proxy): add cookie sticky session support for K8s multi-replica

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -2186,7 +2185,6 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -3151,7 +3149,6 @@
       "integrity": "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3246,7 +3243,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -3441,7 +3437,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3996,7 +3991,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -4658,7 +4652,6 @@
       "integrity": "sha512-20pyHgnO40rvfI0NGF/xiEoFMkXDtkF8FwHvk5BokoFoCuTQRI8vrNCNFWUOfuolKJMm1tPCHc8GgYEtr1XRNA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "meow": "^13.0.0"
       },
@@ -4888,7 +4881,6 @@
       "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
@@ -5634,7 +5626,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5936,7 +5927,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -6845,6 +6835,36 @@
         }
       }
     },
+    "node_modules/git-semver-tags/node_modules/conventional-commits-filter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/git-semver-tags/node_modules/conventional-commits-parser": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.2.1.tgz",
+      "integrity": "sha512-20pyHgnO40rvfI0NGF/xiEoFMkXDtkF8FwHvk5BokoFoCuTQRI8vrNCNFWUOfuolKJMm1tPCHc8GgYEtr1XRNA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/git-semver-tags/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
@@ -7640,7 +7660,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -8943,7 +8962,6 @@
       "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -11753,7 +11771,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13208,7 +13225,6 @@
       "integrity": "sha512-0mhiCR/4sZb00RVFJIUlMuiBkW3NMpVIW2Gse7noqEMoFGkvfPPAImEQbkBV8xga4KOPP4FdTRYuLLy32R1fPw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^11.0.0",
         "@semantic-release/error": "^4.0.0",
@@ -14513,7 +14529,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -15112,7 +15127,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15517,7 +15531,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/mcp-proxy/config.example.json
+++ b/src/mcp-proxy/config.example.json
@@ -20,6 +20,7 @@
   "options": {
     "verbose": false,
     "reconnect_interval": 5000,
-    "monitor_interval": 10000
+    "monitor_interval": 10000,
+    "enable_cookie_sticky": true
   }
 }

--- a/src/mcp-proxy/cookieJar.ts
+++ b/src/mcp-proxy/cookieJar.ts
@@ -95,15 +95,15 @@ export class CookieJar {
       const char = header[i];
 
       if (char === ',') {
-        // 检查是否是日期中的逗号（如 "Expires=Mon, 01 Jan 2024"）
+        // Check if this is a comma in a date (e.g., "Expires=Mon, 01 Jan 2024")
         const remaining = header.substring(i + 1).trim();
-        // 更严格的日期格式检测：两位数字 + 空格 + 三位字母（月份）
-        if (/^\d{2}\s[A-Za-z]{3}/.test(remaining)) {
-          // 这是日期中的逗号，继续
+        // Match HTTP date format: two digits + space + month abbreviation
+        if (/^\d{2}\s(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)/i.test(remaining)) {
+          // This is a comma in a date, continue
           current += char;
           continue;
         }
-        // 这是 Cookie 分隔符
+        // This is a Cookie separator
         if (current.trim()) {
           cookies.push(current.trim());
         }

--- a/src/mcp-proxy/cookieJar.ts
+++ b/src/mcp-proxy/cookieJar.ts
@@ -1,0 +1,267 @@
+/**
+ * CookieJar - 管理 HTTP Cookie 用于会话粘性
+ *
+ * 用于解决 K8s 多副本部署时的会话路由问题：
+ * 1. Ingress 在响应中植入 Cookie（如 MCP_ROUTE=pod-hash）
+ * 2. Proxy 在后续请求中携带该 Cookie
+ * 3. Ingress 根据 Cookie 将请求路由到同一个 Pod
+ */
+
+/**
+ * 解析后的 Cookie 结构
+ */
+interface ParsedCookie {
+  name: string;
+  value: string;
+  expires?: Date;
+  maxAge?: number;
+  domain?: string;
+  path?: string;
+  secure?: boolean;
+  httpOnly?: boolean;
+  sameSite?: 'Strict' | 'Lax' | 'None';
+}
+
+/**
+ * Cookie 管理器
+ */
+export class CookieJar {
+  private cookies: Map<string, ParsedCookie> = new Map();
+  private verbose: boolean;
+
+  constructor(verbose: boolean = false) {
+    this.verbose = verbose;
+  }
+
+  /**
+   * 从响应的 Set-Cookie 头中提取并存储 Cookie
+   */
+  setCookiesFromResponse(response: Response): void {
+    // 注意：fetch API 的 response.headers.get('set-cookie') 可能只返回第一个
+    // 使用 getSetCookie() 方法获取所有 Set-Cookie 头（Node.js 18+）
+    const setCookieHeaders = this.getSetCookieHeaders(response);
+
+    for (const setCookieHeader of setCookieHeaders) {
+      const cookie = this.parseSetCookie(setCookieHeader);
+      if (cookie) {
+        // 检查 Cookie 是否过期
+        if (cookie.expires && cookie.expires < new Date()) {
+          this.cookies.delete(cookie.name);
+          if (this.verbose) {
+            console.error(`[CookieJar] Cookie expired and removed: ${cookie.name}`);
+          }
+        } else {
+          this.cookies.set(cookie.name, cookie);
+          if (this.verbose) {
+            console.error(
+              `[CookieJar] Cookie stored: ${cookie.name}=${cookie.value.substring(0, 20)}...`
+            );
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * 获取所有 Set-Cookie 头
+   */
+  private getSetCookieHeaders(response: Response): string[] {
+    const headers = response.headers;
+
+    // Node.js 18+ 支持 getSetCookie() 方法
+    if (typeof (headers as any).getSetCookie === 'function') {
+      return (headers as any).getSetCookie();
+    }
+
+    // 降级方案：使用 get('set-cookie')，但可能只返回第一个
+    const setCookie = headers.get('set-cookie');
+    if (setCookie) {
+      // 尝试按逗号分隔（但这不是完美的解析，因为 Cookie 值可能包含逗号）
+      // 更安全的做法是检查是否有日期格式来避免错误分割
+      return this.splitSetCookieHeader(setCookie);
+    }
+
+    return [];
+  }
+
+  /**
+   * 分割 Set-Cookie 头（处理多个 Cookie 合并的情况）
+   */
+  private splitSetCookieHeader(header: string): string[] {
+    const cookies: string[] = [];
+    let current = '';
+    const depth = 0;
+
+    for (let i = 0; i < header.length; i++) {
+      const char = header[i];
+
+      if (char === ',' && depth === 0) {
+        // 检查是否是日期中的逗号（如 "Expires=Mon, 01 Jan 2024"）
+        const remaining = header.substring(i + 1).trim();
+        if (/^\d{2}\s/.test(remaining)) {
+          // 这是日期中的逗号，继续
+          current += char;
+          continue;
+        }
+        // 这是 Cookie 分隔符
+        if (current.trim()) {
+          cookies.push(current.trim());
+        }
+        current = '';
+      } else {
+        current += char;
+      }
+    }
+
+    if (current.trim()) {
+      cookies.push(current.trim());
+    }
+
+    return cookies;
+  }
+
+  /**
+   * 解析 Set-Cookie 头
+   */
+  private parseSetCookie(setCookieHeader: string): ParsedCookie | null {
+    const parts = setCookieHeader.split(';').map((p) => p.trim());
+    if (parts.length === 0) return null;
+
+    // 第一部分是 name=value
+    const [nameValue, ...attributes] = parts;
+    const eqIndex = nameValue.indexOf('=');
+    if (eqIndex === -1) return null;
+
+    const name = nameValue.substring(0, eqIndex).trim();
+    const value = nameValue.substring(eqIndex + 1).trim();
+
+    if (!name) return null;
+
+    const cookie: ParsedCookie = { name, value };
+
+    // 解析属性
+    for (const attr of attributes) {
+      const attrLower = attr.toLowerCase();
+      const attrEqIndex = attr.indexOf('=');
+
+      if (attrLower.startsWith('expires=')) {
+        const dateStr = attr.substring(8);
+        const date = new Date(dateStr);
+        if (!isNaN(date.getTime())) {
+          cookie.expires = date;
+        }
+      } else if (attrLower.startsWith('max-age=')) {
+        const maxAge = parseInt(attr.substring(8), 10);
+        if (!isNaN(maxAge)) {
+          cookie.maxAge = maxAge;
+          // 计算过期时间
+          cookie.expires = new Date(Date.now() + maxAge * 1000);
+        }
+      } else if (attrLower.startsWith('domain=')) {
+        cookie.domain = attr.substring(7);
+      } else if (attrLower.startsWith('path=')) {
+        cookie.path = attr.substring(5);
+      } else if (attrLower === 'secure') {
+        cookie.secure = true;
+      } else if (attrLower === 'httponly') {
+        cookie.httpOnly = true;
+      } else if (attrLower.startsWith('samesite=')) {
+        const sameSite = attr.substring(9);
+        if (['Strict', 'Lax', 'None'].includes(sameSite)) {
+          cookie.sameSite = sameSite as 'Strict' | 'Lax' | 'None';
+        }
+      }
+    }
+
+    return cookie;
+  }
+
+  /**
+   * 生成 Cookie 请求头值
+   */
+  getCookieHeader(): string | undefined {
+    // 清理过期的 Cookie
+    this.cleanExpiredCookies();
+
+    if (this.cookies.size === 0) return undefined;
+
+    const cookieStr = Array.from(this.cookies.values())
+      .map((cookie) => `${cookie.name}=${cookie.value}`)
+      .join('; ');
+
+    if (this.verbose) {
+      console.error(`[CookieJar] Sending cookies: ${cookieStr.substring(0, 50)}...`);
+    }
+
+    return cookieStr;
+  }
+
+  /**
+   * 清理过期的 Cookie
+   */
+  private cleanExpiredCookies(): void {
+    const now = new Date();
+    for (const [name, cookie] of this.cookies.entries()) {
+      if (cookie.expires && cookie.expires < now) {
+        this.cookies.delete(name);
+        if (this.verbose) {
+          console.error(`[CookieJar] Cookie expired: ${name}`);
+        }
+      }
+    }
+  }
+
+  /**
+   * 清空所有 Cookie（重连时可能需要）
+   */
+  clear(): void {
+    this.cookies.clear();
+    if (this.verbose) {
+      console.error('[CookieJar] All cookies cleared');
+    }
+  }
+
+  /**
+   * 获取当前存储的 Cookie 数量
+   */
+  get size(): number {
+    return this.cookies.size;
+  }
+
+  /**
+   * 检查是否有 Cookie
+   */
+  get hasCookies(): boolean {
+    return this.cookies.size > 0;
+  }
+}
+
+/**
+ * 创建支持 Cookie 的 fetch 包装函数
+ *
+ * @param cookieJar Cookie 管理器实例
+ * @param verbose 是否输出详细日志
+ * @returns 包装后的 fetch 函数
+ */
+export function createCookieFetch(cookieJar: CookieJar): typeof fetch {
+  return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    // 克隆 init 以避免修改原始对象
+    const modifiedInit: RequestInit = { ...init };
+
+    // 添加 Cookie 到请求头
+    const cookieHeader = cookieJar.getCookieHeader();
+    if (cookieHeader) {
+      const headers = new Headers(modifiedInit.headers);
+      headers.set('Cookie', cookieHeader);
+      modifiedInit.headers = headers;
+    }
+
+    // 发送请求
+    const response = await fetch(input, modifiedInit);
+
+    // 保存响应中的 Cookie
+    cookieJar.setCookiesFromResponse(response);
+
+    return response;
+  };
+}

--- a/src/mcp-proxy/cookieJar.ts
+++ b/src/mcp-proxy/cookieJar.ts
@@ -90,15 +90,15 @@ export class CookieJar {
   private splitSetCookieHeader(header: string): string[] {
     const cookies: string[] = [];
     let current = '';
-    const depth = 0;
 
     for (let i = 0; i < header.length; i++) {
       const char = header[i];
 
-      if (char === ',' && depth === 0) {
+      if (char === ',') {
         // 检查是否是日期中的逗号（如 "Expires=Mon, 01 Jan 2024"）
         const remaining = header.substring(i + 1).trim();
-        if (/^\d{2}\s/.test(remaining)) {
+        // 更严格的日期格式检测：两位数字 + 空格 + 三位字母（月份）
+        if (/^\d{2}\s[A-Za-z]{3}/.test(remaining)) {
           // 这是日期中的逗号，继续
           current += char;
           continue;
@@ -142,7 +142,6 @@ export class CookieJar {
     // 解析属性
     for (const attr of attributes) {
       const attrLower = attr.toLowerCase();
-      const attrEqIndex = attr.indexOf('=');
 
       if (attrLower.startsWith('expires=')) {
         const dateStr = attr.substring(8);

--- a/src/mcp-proxy/proxy.ts
+++ b/src/mcp-proxy/proxy.ts
@@ -12,6 +12,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 // import * as path from 'node:path';  // 暂时未使用
 import type { ProxyConfig, PendingRequest } from './types.js';
+import { CookieJar, createCookieFetch } from './cookieJar.js';
 
 // Version placeholder - replaced at build time by esbuild
 declare const __PROXY_VERSION__: string;
@@ -42,8 +43,14 @@ export class TapTapMCPProxy {
   private lastValidationTime: number = 0;
   private readonly SESSION_VALIDATION_INTERVAL = 30000; // 30秒验证一次会话
 
+  // Cookie 粘性支持（用于 K8s 多副本部署）
+  private cookieJar: CookieJar;
+
   constructor(config: ProxyConfig) {
     this.config = config;
+
+    // 初始化 Cookie 管理器（用于会话粘性）
+    this.cookieJar = new CookieJar(config.options?.verbose ?? false);
 
     // 初始化 MCP Client（连接 TapTap Server）
     this.client = new Client(
@@ -64,6 +71,7 @@ export class TapTapMCPProxy {
   async start(): Promise<void> {
     console.error(`[Proxy] TapTap MCP Proxy v${VERSION}`);
     console.error(`[Proxy] Starting...`);
+    console.error(`[Proxy] Server URL: ${this.config.server.url}`);
     console.error(`[Proxy] Project Path: ${this.config.tenant.project_path}`);
     if (this.config.tenant.user_id) {
       console.error(`[Proxy] User ID: ${this.config.tenant.user_id}`);
@@ -72,6 +80,7 @@ export class TapTapMCPProxy {
       console.error(`[Proxy] Project ID: ${this.config.tenant.project_id}`);
     }
     console.error(`[Proxy] Token kid: ${this.config.auth.kid.substring(0, 12)}...`);
+    console.error(`[Proxy] Cookie sticky: ${this.config.options?.enable_cookie_sticky ?? true}`);
 
     // 1. 初始化时直接连接 TapTap Server
     try {
@@ -101,7 +110,17 @@ export class TapTapMCPProxy {
     console.error(`[Proxy] Connecting to ${this.config.server.url}...`);
 
     try {
-      const transport = new StreamableHTTPClientTransport(new URL(this.config.server.url));
+      // 创建支持 Cookie 的 fetch（用于 K8s Ingress 会话粘性）
+      const cookieEnabled = this.config.options?.enable_cookie_sticky ?? true;
+      const customFetch = cookieEnabled ? createCookieFetch(this.cookieJar) : undefined;
+
+      if (cookieEnabled && this.config.options?.verbose) {
+        console.error('[Proxy] Cookie sticky session enabled');
+      }
+
+      const transport = new StreamableHTTPClientTransport(new URL(this.config.server.url), {
+        fetch: customFetch,
+      });
 
       await this.client.connect(transport);
 

--- a/src/mcp-proxy/proxy.ts
+++ b/src/mcp-proxy/proxy.ts
@@ -297,6 +297,16 @@ export class TapTapMCPProxy {
     this.reconnecting = true;
     this.clearReconnectTimer();
 
+    // 清空 Cookie，以便重新获取路由信息
+    // 这确保在连接到不同 Pod 时获得正确的路由 Cookie
+    const cookieEnabled = this.config.options?.enable_cookie_sticky ?? true;
+    if (cookieEnabled && this.cookieJar.hasCookies) {
+      this.cookieJar.clear();
+      if (this.config.options?.verbose) {
+        console.error('[Proxy] Cookies cleared for reconnection');
+      }
+    }
+
     try {
       // 重连时创建新的 Client 实例（避免旧 Client 状态异常）
       this.client = new Client(

--- a/src/mcp-proxy/proxy.ts
+++ b/src/mcp-proxy/proxy.ts
@@ -297,8 +297,8 @@ export class TapTapMCPProxy {
     this.reconnecting = true;
     this.clearReconnectTimer();
 
-    // 清空 Cookie，以便重新获取路由信息
-    // 这确保在连接到不同 Pod 时获得正确的路由 Cookie
+    // Clear cookies to retrieve new routing information
+    // This ensures correct routing cookies when connecting to different Pods
     const cookieEnabled = this.config.options?.enable_cookie_sticky ?? true;
     if (cookieEnabled && this.cookieJar.hasCookies) {
       this.cookieJar.clear();

--- a/src/mcp-proxy/types.ts
+++ b/src/mcp-proxy/types.ts
@@ -51,6 +51,12 @@ export interface ProxyConfig {
     reset_timeout_on_progress?: boolean;
     /** 健康检查间隔（毫秒，默认 30000）- 定期验证 Server 会话是否有效 */
     health_check_interval?: number;
+    /**
+     * 启用 Cookie 会话粘性（默认 true）
+     * 用于 K8s 多副本部署时，通过 Ingress Cookie 实现会话粘性
+     * 确保同一 Proxy 的所有请求被路由到同一个 MCP Server Pod
+     */
+    enable_cookie_sticky?: boolean;
   };
 }
 


### PR DESCRIPTION
## 问题描述

在 K8s 多副本部署环境中，Proxy 连接成功后，后续请求可能被负载均衡到不同的 Pod，导致 "Server not initialized" 错误。

**根本原因：**
- MCP StreamableHTTP 协议是有状态的（Session ID 绑定特定 Server）
- K8s Service 默认负载均衡是无状态的（每次请求独立路由）
- 两者假设冲突

```
┌─────────────────────────────────────────────────────────────────┐
│   MCP StreamableHTTP          vs          K8s 负载均衡          │
│                                                                 │
│   ✅ 有状态 (Stateful)                 ❌ 无状态 (Stateless)    │
│   - Session ID 绑定特定 Server         - 每次请求独立路由       │
│   - 多次 HTTP 请求属于同一会话         - 不感知上下文关系       │
└─────────────────────────────────────────────────────────────────┘
```

## 解决方案

添加 `CookieJar` 类来管理 HTTP Cookie，实现 K8s Ingress 会话粘性：

```
┌─────────────────────────────────────────────────────────────────┐
│                    Cookie 粘性工作流程                           │
├─────────────────────────────────────────────────────────────────┤
│  第一次请求:                                                     │
│  Proxy ──→ Ingress ──→ Pod A                                    │
│         ←── Set-Cookie: MCP_ROUTE=pod-a-hash (Ingress 植入)     │
│                                                                 │
│  后续请求:                                                       │
│  Proxy ──→ Ingress ──→ Pod A  ← 根据 Cookie 路由到同一个 Pod    │
│    Cookie: MCP_ROUTE=pod-a-hash                                 │
└─────────────────────────────────────────────────────────────────┘
```

## 改动文件

| 文件 | 改动 |
|------|------|
| `src/mcp-proxy/cookieJar.ts` | 新增 - Cookie 管理器 |
| `src/mcp-proxy/proxy.ts` | 集成 Cookie 支持 |
| `src/mcp-proxy/types.ts` | 新增 `enable_cookie_sticky` 配置项 |

## CookieJar 功能

- 解析 `Set-Cookie` 响应头（支持 `getSetCookie` API）
- 在后续请求中发送 `Cookie` 头
- 处理 Cookie 过期（`expires`, `max-age`）
- 支持 verbose 日志用于调试

## 新增配置项

```typescript
options?: {
  // ...
  /** 启用 Cookie 会话粘性（默认 true） */
  enable_cookie_sticky?: boolean;
}
```

## K8s Ingress 配置示例

### NGINX Ingress
```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: mcp-server-ingress
  annotations:
    nginx.ingress.kubernetes.io/affinity: "cookie"
    nginx.ingress.kubernetes.io/session-cookie-name: "MCP_ROUTE"
    nginx.ingress.kubernetes.io/session-cookie-expires: "3600"
spec:
  rules:
    - host: mcp.example.com
      http:
        paths:
          - path: /
            pathType: Prefix
            backend:
              service:
                name: mcp-server
                port:
                  number: 4000
```

### 阿里云 ALB Ingress
```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: mcp-server-ingress
  annotations:
    alb.ingress.kubernetes.io/sticky-session: "true"
    alb.ingress.kubernetes.io/sticky-session-type: "Insert"
    alb.ingress.kubernetes.io/cookie-timeout: "3600"
spec:
  ingressClassName: alb
  # ...
```

## 测试建议

1. 配置 Ingress Cookie 粘性
2. 部署多副本 MCP Server
3. 验证 Proxy 请求始终路由到同一个 Pod
4. 检查日志确认 Cookie 被正确存储和发送