### PR TITLE
chore: add copilot instructions and update commitlint config

### DIFF
--- a/.commitlintrc.cjs
+++ b/.commitlintrc.cjs
@@ -70,10 +70,13 @@ module.exports = {
     'scope-case': [2, 'always', 'lower-case']
   },
 
-  // 忽略某些 commit（如 merge commits）
+  // 忽略某些 commit（如 merge commits、bot 的临时提交）
   ignores: [
     (commit) => commit.includes('Merge'),
-    (commit) => commit.includes('[skip ci]')
+    (commit) => commit.includes('[skip ci]'),
+    // 忽略 Copilot bot 的计划/临时提交（如 "Initial plan"）
+    // 这些通常是空提交，用于记录工作计划
+    (commit) => /^(Initial plan|WIP|TODO|FIXME)$/i.test(commit.trim()),
   ],
 
   // 帮助信息

--- a/.commitlintrc.cjs
+++ b/.commitlintrc.cjs
@@ -74,9 +74,9 @@ module.exports = {
   ignores: [
     (commit) => commit.includes('Merge'),
     (commit) => commit.includes('[skip ci]'),
-    // 忽略 Copilot bot 的计划/临时提交（如 "Initial plan"）
+    // 忽略 Copilot bot 的计划/临时提交（如 "Initial plan for feature X"、"WIP: adding tests"）
     // 这些通常是空提交，用于记录工作计划
-    (commit) => /^(Initial plan|WIP|TODO|FIXME)$/i.test(commit.trim()),
+    (commit) => /^(Initial plan|WIP|TODO|FIXME)\b[:\s]?.*/i.test(commit.trim()),
   ],
 
   // 帮助信息

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -202,8 +202,6 @@ const url = 'https://api.example.com';
 ```
 ````
 
-```
-
 ---
 
 ## Pull Request Guidelines
@@ -211,29 +209,32 @@ const url = 'https://api.example.com';
 ### PR Title Format
 
 PR titles should also follow Conventional Commits format:
-```
 
+```
 feat(proxy): add cookie sticky session support
 fix(auth): handle token refresh edge case
-
-````
+```
 
 ### PR Description Template
 
 ```markdown
 ## Summary
+
 Brief description of changes.
 
 ## Changes
+
 - Change 1
 - Change 2
 
 ## Testing
+
 How was this tested?
 
 ## Related Issues
+
 Closes #123
-````
+```
 
 ### Before Submitting
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,163 +1,322 @@
-# Copilot Instructions for TapTap MCP Server
+# Copilot Instructions
 
-This file provides instructions for GitHub Copilot when reviewing code in this repository.
+> This file provides guidance to GitHub Copilot when working with this repository.
 
-## Language Preference
+## Commit Message Convention
 
-**IMPORTANT**: Always respond in Chinese (简体中文) when providing code review feedback.
-- Use Chinese for all comments, explanations, and suggestions
-- Technical terms can remain in English when appropriate
-- Code examples and snippets should include Chinese comments
+This repository uses [Conventional Commits](https://www.conventionalcommits.org/) specification.
 
-## Project Overview
+**All commits MUST follow this format:**
 
-This is a Model Context Protocol (MCP) server for TapTap Open API, providing:
-- Leaderboard management APIs
-- H5 game management
-- OAuth 2.0 authentication
-- Multi-tenant support
-
-## Code Review Focus Areas
-
-### 1. Architecture and Design
-
-**Modular Architecture**:
-- Each feature is self-contained in `src/features/[feature]/`
-- Business modules can depend on `core/` and `features/app/`
-- Business modules must NOT depend on each other
-- Always check: does new code follow the module dependency rules?
-
-**Unified Format**:
-- All Tools must use `ToolRegistration[]` format with `definition` + `handler`
-- All Resources must use `ResourceRegistration[]` format
-- Check: are tools/resources using the unified format?
-
-### 2. TypeScript and Type Safety
-
-- All async functions must use `async/await` syntax
-- Avoid `any` types unless absolutely necessary (MCP SDK exceptions allowed)
-- All functions and interfaces should have JSDoc comments
-- Check: are types properly defined and documented?
-
-### 3. Security
-
-**Authentication**:
-- All API requests must go through `HttpClient` class
-- MAC Token and request signature are handled automatically
-- Never hardcode tokens or secrets
-- Check: are credentials properly managed?
-
-**Private Parameters**:
-- Private parameters (starting with `_`) are for MCP Proxy only
-- Business logic must NOT access private parameters directly
-- Use `getEffectiveContext()` to merge private params into context
-- Check: is private parameter protocol followed?
-
-### 4. Error Handling
-
-- All API errors must be properly caught and logged
-- User-facing error messages should be clear and actionable
-- Include context in error messages (which tool, what operation)
-- Check: is error handling comprehensive and informative?
-
-### 5. Code Quality
-
-**Naming Conventions**:
-- Use camelCase for variables and functions
-- Use PascalCase for classes and types
-- Use UPPER_CASE for constants
-- Check: does naming follow conventions?
-
-**Code Organization**:
-- Keep functions small and focused (< 50 lines ideally)
-- Avoid code duplication - extract to shared utilities
-- Check: can this code be simplified or deduplicated?
-
-### 6. Testing
-
-- Critical business logic should have unit tests
-- Test files should be in `src/__tests__/` or co-located with source
-- Check: does this change need tests?
-
-### 7. Documentation
-
-**When to update documentation**:
-- New features → Update README.md and CLAUDE.md
-- API changes → Update relevant docs
-- Architecture changes → Update CLAUDE.md
-- Check: does documentation need updating?
-
-### 8. CI/CD Compliance
-
-**Commit Messages**:
-- Must follow Conventional Commits format
-- Types: feat, fix, docs, refactor, chore, test, ci
-- Breaking changes must include `!` or `BREAKING CHANGE:`
-- Check: would this commit message pass commitlint?
-
-**Branch Strategy**:
-- Feature branches only (no direct commits to main)
-- PR must pass all CI checks before merge
-- Check: is this following the PR workflow?
-
-## Common Issues to Flag
-
-1. ❌ Direct API calls without using HttpClient
-2. ❌ Business logic accessing private parameters
-3. ❌ Missing error handling in async operations
-4. ❌ Hardcoded values that should be environment variables
-5. ❌ Missing JSDoc comments on public functions
-6. ❌ Module circular dependencies
-7. ❌ Unused imports or variables
-8. ❌ Console.log statements (should use logger)
-9. ❌ Missing input validation in tool handlers
-10. ❌ Inconsistent code formatting
-
-## Best Practices to Encourage
-
-1. ✅ Use existing core utilities (cache, logger, docHelpers)
-2. ✅ Follow the unified format for tools and resources
-3. ✅ Reuse app module for common operations
-4. ✅ Add TypeScript types for better safety
-5. ✅ Include usage examples in comments
-6. ✅ Keep business logic separate from API calls
-7. ✅ Use context resolver for multi-tenant support
-8. ✅ Log important operations in verbose mode
-9. ✅ Handle edge cases gracefully
-10. ✅ Write self-documenting code
-
-## Review Tone
-
-**Language**: Always respond in Chinese (简体中文)
-
-**Style**:
-- Be constructive and educational (建设性和教育性)
-- Explain WHY a change is needed, not just WHAT to change (解释为什么需要改变，而不仅仅是改什么)
-- Suggest alternatives when pointing out issues (指出问题时提供替代方案)
-- Recognize good patterns when you see them (认可好的代码模式)
-- Focus on meaningful improvements, not nitpicks (关注有意义的改进，而非吹毛求疵)
-
-**Example Response Format**:
 ```
-❌ 问题：这里缺少错误处理
-💡 建议：添加 try-catch 块来处理可能的 API 失败
-📝 原因：如果 API 调用失败，当前代码会导致未捕获的异常
-✅ 示例：[提供代码示例]
+<type>(<scope>): <subject>
+
+[optional body]
+
+[optional footer]
 ```
 
-## Priority Levels
+### Rules
 
-**Critical** (must fix):
-- Security vulnerabilities
-- Breaking changes without proper marking
-- Logic errors that cause incorrect behavior
+1. **NEVER create commits with messages like:**
+   - "Initial plan"
+   - "WIP"
+   - "temp"
+   - "test"
+   - Any message without a type prefix
 
-**Important** (should fix):
-- Performance issues
-- Missing error handling
-- Architectural violations
+2. **Always use one of these types:**
+   - `feat:` - New feature (triggers minor version)
+   - `fix:` - Bug fix (triggers patch version)
+   - `docs:` - Documentation only (no release)
+   - `style:` - Code style (no release)
+   - `refactor:` - Code refactoring (triggers patch version)
+   - `perf:` - Performance improvement (triggers patch version)
+   - `test:` - Adding tests (no release)
+   - `chore:` - Maintenance tasks (no release)
+   - `ci:` - CI configuration (no release)
 
-**Nice to have** (optional):
-- Code style improvements
-- Additional documentation
-- Test coverage improvements
+3. **Subject rules:**
+   - Use imperative mood ("add" not "added")
+   - Don't capitalize first letter
+   - No period at the end
+   - 5-100 characters
+
+### Examples
+
+✅ Good:
+
+```
+feat(proxy): add cookie sticky session support
+fix(auth): handle expired token refresh
+refactor(api): simplify error handling
+chore: update dependencies
+```
+
+❌ Bad:
+
+```
+Initial plan
+WIP
+Added new feature
+fix bug
+```
+
+### For Planning/Investigation
+
+If you need to commit work-in-progress or planning notes, use:
+
+```
+chore(planning): initial investigation for feature X
+docs(notes): document approach for issue #123
+```
+
+---
+
+## Code Style & Standards
+
+### TypeScript
+
+- Use TypeScript for all new code
+- Enable strict mode (`strict: true`)
+- Prefer `interface` over `type` for object shapes
+- Use explicit return types for public functions
+- Avoid `any` - use `unknown` if type is truly unknown
+
+### Naming Conventions
+
+| Type       | Convention                            | Example               |
+| ---------- | ------------------------------------- | --------------------- |
+| Files      | camelCase                             | `cookieJar.ts`        |
+| Classes    | PascalCase                            | `CookieJar`           |
+| Functions  | camelCase                             | `getCookieHeader`     |
+| Constants  | UPPER_SNAKE_CASE                      | `MAX_RETRY_COUNT`     |
+| Interfaces | PascalCase with `I` prefix (optional) | `Cookie` or `ICookie` |
+| Types      | PascalCase                            | `ProxyConfig`         |
+
+### Code Organization
+
+```
+src/
+├── core/           # Core utilities (http, auth, config)
+├── features/       # Feature modules (leaderboard, share, etc.)
+│   └── [feature]/
+│       ├── index.ts    # Module exports
+│       ├── tools.ts    # MCP tool definitions
+│       ├── types.ts    # TypeScript types
+│       └── api.ts      # API calls (if needed)
+├── mcp-proxy/      # Proxy implementation
+└── server.ts       # Main server entry
+```
+
+### Documentation
+
+- Add JSDoc comments for all public APIs
+- Use English for all code comments
+- Include `@param`, `@returns`, `@throws` tags
+- Add `@example` for complex functions
+
+```typescript
+/**
+ * Creates a fetch wrapper that manages cookies automatically.
+ * @param cookieJar - The CookieJar instance to use
+ * @returns A fetch-compatible function
+ * @example
+ * const jar = new CookieJar();
+ * const customFetch = createCookieFetch(jar);
+ * const response = await customFetch('https://api.example.com');
+ */
+export function createCookieFetch(cookieJar: CookieJar): typeof fetch {
+  // ...
+}
+```
+
+### Error Handling
+
+- Use custom error classes for domain-specific errors
+- Always include error context (what operation failed)
+- Log errors with structured information
+- Never swallow errors silently
+
+```typescript
+// ✅ Good
+try {
+  await client.connect();
+} catch (error) {
+  console.error('[Proxy] Connection failed:', formatError(error));
+  throw error;
+}
+
+// ❌ Bad
+try {
+  await client.connect();
+} catch (error) {
+  // silently ignore
+}
+```
+
+---
+
+## Code Review Guidelines
+
+### When Reviewing PRs
+
+1. **Check commit messages** - Must follow Conventional Commits
+2. **Verify tests** - New features should have tests
+3. **Check types** - No `any` without justification
+4. **Review error handling** - Errors should be properly caught and logged
+5. **Check documentation** - Public APIs should have JSDoc
+
+### Review Checklist
+
+- [ ] Commit messages follow Conventional Commits format
+- [ ] No TypeScript errors (`npm run build` passes)
+- [ ] No ESLint errors (`npm run lint` passes)
+- [ ] Code is properly formatted (`npm run format:check` passes)
+- [ ] New public APIs have JSDoc documentation
+- [ ] Error cases are handled appropriately
+- [ ] No hardcoded secrets or credentials
+- [ ] No unnecessary dependencies added
+
+### Suggesting Changes
+
+When suggesting code changes, provide:
+
+1. **What** - Clear description of the change
+2. **Why** - Reason for the change
+3. **How** - Code example if applicable
+
+````markdown
+**Suggestion**: Use `const` instead of `let` for variables that are not reassigned.
+
+**Reason**: Improves code clarity and prevents accidental reassignment.
+
+**Example**:
+
+```typescript
+// Before
+let url = 'https://api.example.com';
+
+// After
+const url = 'https://api.example.com';
+```
+````
+
+```
+
+---
+
+## Pull Request Guidelines
+
+### PR Title Format
+
+PR titles should also follow Conventional Commits format:
+```
+
+feat(proxy): add cookie sticky session support
+fix(auth): handle token refresh edge case
+
+````
+
+### PR Description Template
+
+```markdown
+## Summary
+Brief description of changes.
+
+## Changes
+- Change 1
+- Change 2
+
+## Testing
+How was this tested?
+
+## Related Issues
+Closes #123
+````
+
+### Before Submitting
+
+1. Run `npm run build` - Ensure no TypeScript errors
+2. Run `npm run lint` - Fix any linting issues
+3. Run `npm run format` - Format code properly
+4. Run `npm test` - Ensure tests pass
+5. Update documentation if needed
+
+---
+
+## Architecture Rules
+
+### Module Dependencies
+
+```
+✅ Allowed:
+- features/* → core/*
+- features/* → features/app/*
+- mcp-proxy/* → core/*
+
+❌ Not Allowed:
+- features/A → features/B (cross-feature dependency)
+- core/* → features/* (core should not depend on features)
+```
+
+### Adding New Features
+
+1. Create feature directory under `src/features/`
+2. Define types in `types.ts`
+3. Define MCP tools in `tools.ts`
+4. Register in `src/server.ts`
+
+Use the scaffolding script:
+
+```bash
+./scripts/create-feature.sh
+```
+
+---
+
+## MCP Tool Development
+
+### Tool Definition
+
+```typescript
+export const myToolDefinition: ToolDefinition = {
+  name: 'my_tool_name',
+  description: 'Clear description of what the tool does. Include when to use it.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      param1: {
+        type: 'string',
+        description: 'Description of param1',
+      },
+    },
+    required: ['param1'],
+  },
+};
+```
+
+### Tool Handler
+
+```typescript
+export async function handleMyTool(args: MyToolArgs): Promise<string> {
+  // Validate inputs
+  if (!args.param1) {
+    throw new Error('param1 is required');
+  }
+
+  // Perform operation
+  const result = await doSomething(args.param1);
+
+  // Return JSON string
+  return JSON.stringify(result, null, 2);
+}
+```
+
+### Tool Guidelines
+
+- Tool descriptions should be in English
+- Handler must return `Promise<string>` (JSON formatted)
+- Include usage scenarios in description
+- Validate all required inputs
+- Handle errors gracefully with informative messages

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,16 @@
 
 > This file provides guidance to GitHub Copilot when working with this repository.
 
+## Language Preference
+
+**IMPORTANT: All responses, PR descriptions, commit messages body, and comments MUST be written in Chinese (Simplified).**
+
+所有回复、PR 描述、提交信息正文和评论必须使用中文（简体）。
+
+> Note: Commit message type and scope should remain in English (e.g., `feat(proxy):`, `fix(auth):`), only the subject and body can be in Chinese.
+
+---
+
 ## Commit Message Convention
 
 This repository uses [Conventional Commits](https://www.conventionalcommits.org/) specification.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -525,10 +525,16 @@ jobs:
           git fetch origin
           git checkout -B main origin/main
 
-          git tag "v${VERSION}"
-          git push origin "v${VERSION}"
-
+          # 生成详细的 release notes
           RELEASE_NOTES=$(npx conventional-changelog-cli -p conventionalcommits -o /dev/stdout -r 1)
+
+          # 创建 annotated tag（而非轻量级 tag）
+          # 这样 Tags 页面也会显示详细的 annotation
+          git tag -a "v${VERSION}" -m "Release v${VERSION}
+
+          ${RELEASE_NOTES}"
+
+          git push origin "v${VERSION}"
 
           # 始终上传 native binaries 作为 assets
           # 这样每个 release 都是自包含的，便于下载和追溯

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,16 @@ Closes #123
 - ✅ Body 和 Footer 前必须有空行
 - ❌ 错误示例：`Feat(API): Added feature.`（Type 大写、Scope 大写、Subject 以句号结尾）
 
+### Copilot/AI 提交规范
+
+> 📄 详细规范请参考 `.github/copilot-instructions.md`
+
+**Copilot 和其他 AI 工具必须遵循 Conventional Commits 规范。**
+
+- ❌ **禁止的提交消息**：`Initial plan`、`WIP`、`temp`、`test` 等无类型前缀的消息
+- ✅ **正确格式**：`feat(proxy): add new feature`、`chore(planning): initial investigation`
+- ⚙️ **Commitlint 已配置忽略规则**：自动忽略 `Initial plan`、`WIP` 等模式的提交
+
 ### 分支工作流
 
 - ❌ **不要直接 commit 到 main 分支**（已配置分支保护）


### PR DESCRIPTION
## Summary

长效解决 Copilot 提交不符合 Conventional Commits 规范的问题（如 `Initial plan` 提交），并增强 Release Tag 信息。

## Changes

### 1. 新增 `.github/copilot-instructions.md`

为 GitHub Copilot 提供完整的工作指引：

- **Language Preference** - 要求 Copilot 使用中文回复 ⭐ NEW
- **Commit Message Convention** - Conventional Commits 规范说明
- **Code Style & Standards** - TypeScript 规范、命名约定、代码组织、错误处理
- **Code Review Guidelines** - 代码审核检查清单、建议变更格式
- **Pull Request Guidelines** - PR 标题格式、描述模板、提交前检查
- **Architecture Rules** - 模块依赖规则、添加新功能流程
- **MCP Tool Development** - 工具定义和处理函数规范

### 2. 更新 `.commitlintrc.cjs`

添加忽略规则，自动跳过 bot 的临时提交：
- `Initial plan` / `Initial plan for feature X`
- `WIP` / `WIP: adding tests`
- `TODO` / `FIXME`

**正则表达式改进**（来自 Copilot PR #96）：
```diff
- /^(Initial plan|WIP|TODO|FIXME)$/i
+ /^(Initial plan|WIP|TODO|FIXME)\b[:\s]?.*/i
```

### 3. 更新 `CLAUDE.md`

添加 Copilot/AI 提交规范章节的说明。

### 4. 增强 Release Tag 信息

修改 `.github/workflows/release.yml`：
- 将**轻量级 tag** 改为 **annotated tag**
- Tag annotation 中包含详细的 changelog 信息
- **Tags 页面** 现在也会显示完整的变更记录

### 5. 合并 Copilot PR #96 改动

- 修复 copilot-instructions.md 中的 Markdown 格式问题
- 改进 commitlint 正则表达式，支持更灵活的匹配

## Why This Change

1. **PR #93 问题**：Copilot 创建了 `Initial plan` commit，导致 commitlint CI 检查失败
2. **Tags 页面信息不足**：之前使用轻量级 tag，Tags 页面只显示 commit message
3. **Copilot 使用英文**：之前没有语言偏好设置，Copilot 默认使用英文

## Additional Recommendations

建议在 GitHub 仓库设置中启用以下选项（需手动配置）：

1. **Settings → General → Pull Requests**
   - ✅ Allow squash merging（推荐用于 Copilot PR）
   - ✅ Default to pull request title for squash merge commits

## Testing

- [x] `npm run lint` 通过
- [x] `npm run build` 通过
- [x] commitlint 检查通过