### PR TITLE
ci(release): filter out noise commits from release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -425,6 +425,10 @@ jobs:
         run: |
           npx conventional-changelog-cli -p conventionalcommits -i CHANGELOG.md -s
 
+          # 过滤掉噪音提交（与 .commitlintrc.cjs 中的忽略规则一致）
+          # - Initial plan, WIP, TODO, FIXME: Copilot/bot 的临时提交
+          sed -i '/^\* \(Initial plan\|WIP\|TODO\|FIXME\)\b/d' CHANGELOG.md
+
       # 提交并推送
       - name: Commit and push release branch
         run: |
@@ -526,7 +530,10 @@ jobs:
           git checkout -B main origin/main
 
           # 生成详细的 release notes
-          RELEASE_NOTES=$(npx conventional-changelog-cli -p conventionalcommits -o /dev/stdout -r 1)
+          # 过滤掉噪音提交（与 .commitlintrc.cjs 中的忽略规则一致）
+          # - Initial plan, WIP, TODO, FIXME: Copilot/bot 的临时提交
+          # - chore(release): 自动发布的提交
+          RELEASE_NOTES=$(npx conventional-changelog-cli -p conventionalcommits -o /dev/stdout -r 1 | grep -v -E '^\*\s*(Initial plan|WIP|TODO|FIXME)\b|^\*\s*chore\(release\):')
 
           # 创建 annotated tag（而非轻量级 tag）
           # 这样 Tags 页面也会显示详细的 annotation


### PR DESCRIPTION
## Summary

过滤掉 Release Notes、Tag annotation 和 CHANGELOG 中的噪音提交，使发布信息更加清晰。

过滤规则与 `.commitlintrc.cjs` 中的忽略规则保持一致。

## Changes

修改 `.github/workflows/release.yml`：

### 过滤规则（与 commitlint 一致）

```javascript
// .commitlintrc.cjs 中的忽略规则
(commit) => /^(Initial plan|WIP|TODO|FIXME)\b[:\s]?.*/i.test(commit.trim())
```

| 模式 | Release Notes | CHANGELOG | 说明 |
|------|:-------------:|:---------:|------|
| `Initial plan` | ✅ | ✅ | Copilot 的空提交 |
| `WIP` | ✅ | ✅ | Work in progress |
| `TODO` | ✅ | ✅ | 待办事项 |
| `FIXME` | ✅ | ✅ | 待修复标记 |
| `chore(release):` | ✅ | ❌ | 自动发布的提交 |

### 代码改动

```yaml
# Release Notes 过滤
RELEASE_NOTES=$(npx conventional-changelog-cli ... | grep -v -E '^\*\s*(Initial plan|WIP|TODO|FIXME)\b|^\*\s*chore\(release\):')

# CHANGELOG 过滤
sed -i '/^\* \(Initial plan\|WIP\|TODO\|FIXME\)\b/d' CHANGELOG.md
```

## Why This Change

v1.11.5 的 Release Notes 和 CHANGELOG 中包含了噪音提交：

```
* Initial plan ([f365d6d](f365d6d))
* chore(release): 1.11.5 [skip ci] (#97) ([709496a](709496a))
```

这些提交对用户没有意义，应该被过滤掉。

## Testing

- [x] 过滤规则与 commitlint 一致
- [ ] 下次发布时验证 Release Notes 和 CHANGELOG 是否干净