### PR TITLE
fix(proxy): inject private params on every tool call for MCP Server compatibility

### DIFF
--- a/docs/PROXY.md
+++ b/docs/PROXY.md
@@ -1138,7 +1138,18 @@ cat config.json | node proxy.js
   "options": {
     "verbose": false,
     "reconnect_interval": 5000,
-    "request_timeout": 30000
+    "request_timeout": 30000,
+    "tool_call_timeout": 300000,
+    "reset_timeout_on_progress": true,
+    "health_check_interval": 30000,
+    "enable_cookie_sticky": true,
+    "inject_params_per_call": true,
+    "log": {
+      "root": "/tmp/taptap-mcp/logs",
+      "enabled": false,
+      "level": "info",
+      "max_days": 7
+    }
   }
 }
 ```
@@ -1166,7 +1177,17 @@ node proxy.js
 - `tenant.project_id` - 项目标识符（可选，仅用于日志）
 - `options.verbose` - 详细日志模式（默认 `false`）
 - `options.reconnect_interval` - 重连间隔（毫秒，默认 `5000`）
-- `options.request_timeout` - 请求超时（毫秒，默认 `30000`）
+- `options.request_timeout` - 请求队列超时（毫秒，默认 `30000`）
+- `options.tool_call_timeout` - 工具调用超时（毫秒，默认 `300000`，即 5 分钟）
+- `options.reset_timeout_on_progress` - 收到 progress 通知时重置超时计时器（默认 `true`）
+- `options.health_check_interval` - 健康检查间隔（毫秒，默认 `30000`）- 定期验证 Server 会话是否有效
+- `options.enable_cookie_sticky` - 启用 Cookie 会话粘性（默认 `true`）- 用于 K8s 多副本部署时的会话粘性
+- `options.inject_params_per_call` - 每次工具调用时注入私有参数（默认 `true`）- 为兼容不同 MCP Server 实现，默认每次调用都注入；如果目标 Server 支持从 Session 获取参数，可设为 `false` 以减少数据传输
+- `options.log` - 日志配置对象（可选）
+  - `options.log.root` - 日志根目录（默认 `/tmp/taptap-mcp/logs`）
+  - `options.log.enabled` - 是否启用文件日志（默认 `false`）
+  - `options.log.level` - 日志级别（默认 `info`）- 支持：emergency, alert, critical, error, warning, notice, info, debug
+  - `options.log.max_days` - 日志保留天数（默认 `7`）
 
 ### 6.5 部署场景
 
@@ -1384,6 +1405,15 @@ interface ProxyConfig {
     request_timeout?: number; // 请求队列超时（默认 30000ms）
     tool_call_timeout?: number; // Tool 调用超时（默认 300000ms，即 5 分钟）
     reset_timeout_on_progress?: boolean; // 收到 progress 通知时重置超时（默认 true）
+    health_check_interval?: number; // 健康检查间隔（默认 30000ms）
+    enable_cookie_sticky?: boolean; // 启用 Cookie 会话粘性（默认 true）
+    inject_params_per_call?: boolean; // 每次工具调用时注入私有参数（默认 true）
+    log?: {
+      root?: string; // 日志根目录（默认 /tmp/taptap-mcp/logs）
+      enabled?: boolean; // 是否启用文件日志（默认 false）
+      level?: string; // 日志级别（默认 info）
+      max_days?: number; // 日志保留天数（默认 7）
+    };
   };
 }
 ```
@@ -1419,6 +1449,15 @@ function generateProxyConfig(user: User, project: Project, macToken: MacToken): 
       verbose: true, // 推荐开启详细日志
       tool_call_timeout: 300000, // Tool 调用超时 5 分钟
       reset_timeout_on_progress: true, // 收到 progress 通知时重置超时
+      health_check_interval: 30000, // 健康检查间隔 30 秒
+      enable_cookie_sticky: true, // 启用 Cookie 会话粘性
+      inject_params_per_call: true, // 每次调用都注入私有参数（推荐）
+      log: {
+        root: '/var/log/taptap-mcp', // TapCode 环境的日志目录
+        enabled: true, // 推荐开启文件日志
+        level: 'info',
+        max_days: 7,
+      },
     },
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -2188,7 +2187,6 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -3153,7 +3151,6 @@
       "integrity": "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3258,7 +3255,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -3453,7 +3449,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4008,7 +4003,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -4669,7 +4663,6 @@
       "integrity": "sha512-20pyHgnO40rvfI0NGF/xiEoFMkXDtkF8FwHvk5BokoFoCuTQRI8vrNCNFWUOfuolKJMm1tPCHc8GgYEtr1XRNA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "meow": "^13.0.0"
       },
@@ -4899,7 +4892,6 @@
       "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
@@ -5650,7 +5642,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5952,7 +5943,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -6860,6 +6850,36 @@
         }
       }
     },
+    "node_modules/git-semver-tags/node_modules/conventional-commits-filter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/git-semver-tags/node_modules/conventional-commits-parser": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.2.1.tgz",
+      "integrity": "sha512-20pyHgnO40rvfI0NGF/xiEoFMkXDtkF8FwHvk5BokoFoCuTQRI8vrNCNFWUOfuolKJMm1tPCHc8GgYEtr1XRNA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/git-semver-tags/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
@@ -7655,7 +7675,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -8958,7 +8977,6 @@
       "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -11768,7 +11786,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13370,7 +13387,6 @@
       "integrity": "sha512-0mhiCR/4sZb00RVFJIUlMuiBkW3NMpVIW2Gse7noqEMoFGkvfPPAImEQbkBV8xga4KOPP4FdTRYuLLy32R1fPw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^11.0.0",
         "@semantic-release/error": "^4.0.0",
@@ -14681,7 +14697,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -15280,7 +15295,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15691,7 +15705,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/mcp-proxy/proxy.ts
+++ b/src/mcp-proxy/proxy.ts
@@ -197,6 +197,38 @@ export class TapTapMCPProxy {
   }
 
   /**
+   * 注入私有参数到工具调用参数中
+   *
+   * 私有参数已在初始化连接时通过 Headers 传递，此方法用于在每次工具调用时
+   * 也注入这些参数，以兼容不支持从 Session 获取参数的 MCP Server。
+   *
+   * 注入的参数（以下划线开头，表示私有）：
+   * - _mac_token: MAC 认证令牌
+   * - _user_id: 用户标识（可选）
+   * - _project_id: 项目标识（可选）
+   * - _project_path: 项目路径（可选）
+   */
+  private injectPrivateParams(args: Record<string, unknown> | undefined): Record<string, unknown> {
+    const injected: Record<string, unknown> = { ...(args || {}) };
+
+    // 注入 MAC Token（必需）
+    injected._mac_token = this.config.auth;
+
+    // 注入可选的会话上下文参数
+    if (this.config.tenant.user_id) {
+      injected._user_id = this.config.tenant.user_id;
+    }
+    if (this.config.tenant.project_id) {
+      injected._project_id = this.config.tenant.project_id;
+    }
+    if (this.config.tenant.project_path) {
+      injected._project_path = this.config.tenant.project_path;
+    }
+
+    return injected;
+  }
+
+  /**
    * 连接到 TapTap MCP Server
    */
   private async connectToServer(): Promise<void> {
@@ -631,14 +663,16 @@ export class TapTapMCPProxy {
       return result;
     });
 
-    // 拦截 tools/call - 直接透传（参数已在 Session 创建时通过 Headers 传递）
+    // 拦截 tools/call - 注入私有参数后转发
     this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const { name, arguments: args } = request.params;
 
+      // 根据配置决定是否在每次调用时注入私有参数（默认注入，兼容不同 MCP Server）
+      const shouldInjectParams = this.config.options?.inject_params_per_call ?? true;
+      const finalArgs = shouldInjectParams ? this.injectPrivateParams(args) : args;
+
       if (this.config.options?.verbose) {
-        this.log('debug', `Tool call: ${name}`);
-        // 注意：MAC Token 和其他参数已在 Session 创建时通过 Headers 传递
-        // 无需每次工具调用都注入，减少数据传输量
+        this.log('debug', `Tool call: ${name} (inject_params_per_call: ${shouldInjectParams})`);
       }
 
       // 检查连接状态
@@ -650,7 +684,7 @@ export class TapTapMCPProxy {
           return new Promise((resolve, reject) => {
             this.pendingRequests.push({
               name,
-              arguments: args,
+              arguments: finalArgs,
               resolve,
               reject,
               timestamp: Date.now(),
@@ -665,12 +699,12 @@ export class TapTapMCPProxy {
         );
       }
 
-      // 透传到 TapTap Server（捕获网络错误并触发重连）
+      // 转发到 TapTap Server（捕获网络错误并触发重连）
       try {
         const result = await this.client.callTool(
           {
             name,
-            arguments: args,
+            arguments: finalArgs,
           },
           undefined, // resultSchema
           {
@@ -695,7 +729,7 @@ export class TapTapMCPProxy {
             return new Promise((resolve, reject) => {
               this.pendingRequests.push({
                 name,
-                arguments: args,
+                arguments: finalArgs,
                 resolve,
                 reject,
                 timestamp: Date.now(),

--- a/src/mcp-proxy/types.ts
+++ b/src/mcp-proxy/types.ts
@@ -98,6 +98,17 @@ export interface ProxyConfig {
      * 确保同一 Proxy 的所有请求被路由到同一个 MCP Server Pod
      */
     enable_cookie_sticky?: boolean;
+    /**
+     * 每次工具调用时也注入私有参数（默认 true）
+     *
+     * 私有参数（_mac_token, _user_id, _project_id, _project_path）会在两个时机传递：
+     * 1. 初始化连接时：始终通过 HTTP Headers 传递（不受此配置影响）
+     * 2. 每次工具调用时：通过工具参数注入（由此配置控制）
+     *
+     * 为兼容不同的 MCP Server 实现，默认每次调用都注入。
+     * 如果目标 Server 支持从 Session 获取这些参数，可设置为 false 以减少数据传输量。
+     */
+    inject_params_per_call?: boolean;
     /** 日志配置 */
     log?: LogConfig;
   };


### PR DESCRIPTION
## Summary

- 修复 Proxy 与其他 MCP Server 的兼容性问题
- 每次工具调用时默认注入私有参数（`_mac_token`, `_user_id`, `_project_id`, `_project_path`）
- 新增 `inject_params_per_call` 配置项，可设置为 `false` 以关闭注入

## Background

之前的实现仅在 Session 初始化时通过 HTTP Headers 传递私有参数，但这在不支持从 Session 获取参数的 MCP Server 上存在兼容性问题。

## Changes

- `types.ts`: 新增 `inject_params_per_call` 配置项（默认 `true`）
- `proxy.ts`: 新增 `injectPrivateParams()` 方法，在每次工具调用时注入私有参数

## Test plan

- [ ] 验证默认配置下，工具调用参数中包含私有参数
- [ ] 验证 `inject_params_per_call: false` 时，工具调用参数中不包含私有参数
- [ ] 验证与其他 MCP Server 的兼容性