### PR TITLE
fix(proxy): address PR #116 review + manual release trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (!contains(github.event.head_commit.message, '[skip ci]') &&
+      (github.event.head_commit != null &&
+       !contains(github.event.head_commit.message, '[skip ci]') &&
        github.event.head_commit.author.name != 'github-actions[bot]')
     outputs:
       should_release: ${{ steps.analyze.outputs.should_release }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
       - main
       - beta
       - alpha
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -26,8 +27,9 @@ jobs:
     name: Analyze Release
     runs-on: ubuntu-latest
     if: |
-      !contains(github.event.head_commit.message, '[skip ci]') &&
-      github.event.head_commit.author.name != 'github-actions[bot]'
+      github.event_name == 'workflow_dispatch' ||
+      (!contains(github.event.head_commit.message, '[skip ci]') &&
+       github.event.head_commit.author.name != 'github-actions[bot]')
     outputs:
       should_release: ${{ steps.analyze.outputs.should_release }}
       version: ${{ steps.analyze.outputs.version }}

--- a/docs/PROXY.md
+++ b/docs/PROXY.md
@@ -145,7 +145,7 @@ MCP Proxy 直接在 `arguments` 中注入私有参数：
         "mac_algorithm": "hmac-sha-1"
       },
       "_user_id": "user_12345",
-      "_tenant_id": "project_a",
+      "_project_id": "project_a",
       "_project_path": "/workspace/project_a",
       "_custom_fields": {
         "team": "game-studio-a",
@@ -475,7 +475,7 @@ class TapTapMCPProxy {
         ...args,
         _mac_token: macToken,
         _user_id: userId,
-        _tenant_id: tenantId,
+        _project_id: projectId,
         _project_path: projectPath,
       };
 
@@ -685,14 +685,14 @@ TAPTAP_MCP_VERBOSE=true TAPTAP_MCP_TRANSPORT=sse TAPTAP_MCP_PORT=3001 node mcp-s
 
 #### Q2: 多租户是如何隔离的？
 
-TapTap MCP Server 根据 `_user_id` 和 `_tenant_id` 自动隔离缓存和临时文件：
+TapTap MCP Server 根据 `_user_id` 和 `_project_id` 自动隔离缓存和临时文件：
 
 ```
 /tmp/taptap-mcp/cache/user_123/project_a/app.json
 /tmp/taptap-mcp/cache/user_456/project_b/app.json
 ```
 
-#### Q3: 必须传 `_tenant_id` 吗？
+#### Q3: 必须传 `_project_id` 吗？
 
 不是必需的。如果不传，会使用 `global` 目录：
 
@@ -1402,8 +1402,7 @@ interface ProxyConfig {
   tenant: {
     user_id: string; // 用户 ID（TapCode 用户标识）
     project_id: string; // 项目 ID（TapCode 项目标识）
-    project_path?: string; // Docker 中的挂载点（默认 /workspace）
-    project_path?: string; // 项目相对于 workspace 的路径（推荐）
+    project_path?: string; // 项目路径（Docker 中的挂载点，默认 /workspace）
     custom_fields?: Record<string, string>; // 业务自定义字段（透传到 Server）
   };
   auth: {

--- a/docs/PROXY.md
+++ b/docs/PROXY.md
@@ -461,7 +461,7 @@ class TapTapMCPProxy {
 
       // 1. 识别用户（你需要实现）
       const userId = this.getUserId(request);
-      const tenantId = this.getTenantId(request);
+      const projectId = this.getProjectId(request);
       const projectPath = this.getProjectPath(request);
 
       // 2. 获取 MAC Token（从你的存储系统）
@@ -1402,7 +1402,7 @@ interface ProxyConfig {
   tenant: {
     user_id: string; // 用户 ID（TapCode 用户标识）
     project_id: string; // 项目 ID（TapCode 项目标识）
-    project_path?: string; // 项目路径（Docker 中的挂载点，默认 /workspace）
+    project_path?: string; // 项目路径（相对于 MCP Server WORKSPACE_ROOT，默认 '.'）
     custom_fields?: Record<string, string>; // 业务自定义字段（透传到 Server）
   };
   auth: {

--- a/src/mcp-proxy/config.ts
+++ b/src/mcp-proxy/config.ts
@@ -117,7 +117,12 @@ function validateConfig(config: ProxyConfig): void {
     // custom_fields 必须是 plain object（非 array、非 null），且所有 value 为 string
     if (config.tenant.custom_fields !== undefined) {
       const cf = config.tenant.custom_fields;
-      if (typeof cf !== 'object' || cf === null || Array.isArray(cf)) {
+      if (
+        typeof cf !== 'object' ||
+        cf === null ||
+        Array.isArray(cf) ||
+        Object.getPrototypeOf(cf) !== Object.prototype
+      ) {
         errors.push('- tenant.custom_fields must be a plain object (Record<string, string>)');
       } else if (!Object.values(cf).every((v) => typeof v === 'string')) {
         errors.push('- tenant.custom_fields values must all be strings');

--- a/src/mcp-proxy/config.ts
+++ b/src/mcp-proxy/config.ts
@@ -113,6 +113,16 @@ function validateConfig(config: ProxyConfig): void {
   } else {
     // tenant 字段本身必须存在，但内部所有字段都是可选的
     // user_id 和 project_id 仅用于标识和日志追踪，不影响路径逻辑
+
+    // custom_fields 必须是 plain object（非 array、非 null），且所有 value 为 string
+    if (config.tenant.custom_fields !== undefined) {
+      const cf = config.tenant.custom_fields;
+      if (typeof cf !== 'object' || cf === null || Array.isArray(cf)) {
+        errors.push('- tenant.custom_fields must be a plain object (Record<string, string>)');
+      } else if (!Object.values(cf).every((v) => typeof v === 'string')) {
+        errors.push('- tenant.custom_fields values must all be strings');
+      }
+    }
   }
 
   // 验证 auth

--- a/src/mcp-proxy/proxy.ts
+++ b/src/mcp-proxy/proxy.ts
@@ -175,6 +175,7 @@ export class TapTapMCPProxy {
    * - X-TapTap-Project-Id: 项目标识
    * - X-TapTap-Project-Path: 项目路径
    * - X-TapTap-Mac-Token: MAC 认证令牌（JSON）
+   * - X-TapTap-Custom-Fields: 业务自定义字段（JSON）
    */
   private buildSessionHeaders(): Record<string, string> {
     const headers: Record<string, string> = {};
@@ -215,6 +216,7 @@ export class TapTapMCPProxy {
    * - _user_id: 用户标识（可选）
    * - _project_id: 项目标识（可选）
    * - _project_path: 项目路径（可选）
+   * - _custom_fields: 业务自定义字段（可选）
    */
   private injectPrivateParams(args: Record<string, unknown> | undefined): Record<string, unknown> {
     const injected: Record<string, unknown> = { ...(args || {}) };

--- a/src/server.ts
+++ b/src/server.ts
@@ -606,7 +606,7 @@ class TapTapMinigameMCPServer {
       res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
       res.setHeader(
         'Access-Control-Allow-Headers',
-        'Content-Type, Mcp-Session-Id, X-TapTap-Mac-Token, X-TapTap-User-Id, X-TapTap-Project-Id, X-TapTap-Custom-Fields'
+        'Content-Type, Mcp-Session-Id, X-TapTap-Mac-Token, X-TapTap-User-Id, X-TapTap-Project-Id, X-TapTap-Project-Path, X-TapTap-Custom-Fields'
       );
 
       if (req.method === 'OPTIONS') {


### PR DESCRIPTION
## Summary

- **fix(proxy):** 修复 PR #116 Copilot 审核的 5 条建议
- **ci(release):** 支持手动触发 release workflow

### PR #116 审核修复

- Proxy config `validateConfig()` 添加 `custom_fields` 类型校验（plain object + string values）
- CORS `Access-Control-Allow-Headers` 补上遗漏的 `X-TapTap-Project-Path`
- `buildSessionHeaders()` / `injectPrivateParams()` JSDoc 补上 custom_fields 条目
- `docs/PROXY.md` 4 处 `_tenant_id` → `_project_id`
- `docs/PROXY.md` 删除重复的 `project_path` 行

### Release 手动触发

- `release.yml` 添加 `workflow_dispatch` 触发器
- 修复 `analyze` job 条件兼容手动触发（`head_commit` 为 null）

## Test plan

- [x] `npm run build` 编译通过
- [x] `npm run lint` 检查通过
- [ ] 手动触发 release workflow 验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)