### PR TITLE
ci(release): fix false positive auth error detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,15 +58,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
+          # set -o pipefail 确保 semantic-release 失败时（含认证错误）整个管道返回非零退出码
+          # 注意：不能用 grep 检测错误关键词，因为 semantic-release 分析 commit 时会打印 commit body，
+          # 如果 commit message 中包含错误关键词（如 EINVALIDNPMTOKEN）会导致误匹配
           set -o pipefail
           npx semantic-release --dry-run --no-ci 2>&1 | tee release-output.txt
-
-          # 检查是否有关键错误（npm token、GitHub token 等认证问题）
-          if grep -qE "EINVALIDNPMTOKEN|EINVALIDGHTOKEN|ENOGHTOKEN|ENONPMTOKEN" release-output.txt; then
-            echo "::error::semantic-release failed due to authentication error, check secrets configuration"
-            cat release-output.txt
-            exit 1
-          fi
 
           NEW_VERSION=$(grep "The next release version is" release-output.txt | sed 's/.*is //' || echo "")
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           set -o pipefail
           npx semantic-release --dry-run --no-ci 2>&1 | tee release-output.txt
 
-          NEW_VERSION=$(grep "The next release version is" release-output.txt | sed 's/.*is //' || echo "")
+          NEW_VERSION=$(grep "\[semantic-release\] .* The next release version is" release-output.txt | sed 's/.*is //' || echo "")
 
           if [ -z "$NEW_VERSION" ]; then
             echo "should_release=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

修复 release workflow 误报认证错误导致发布失败的问题。

### 根因

`semantic-release --dry-run` 分析 commit 时会打印完整的 commit message body。commit `c87781e` 的 body 中包含 `EINVALIDNPMTOKEN` 字符串（用于说明检测逻辑），被 grep 误匹配为真实的认证错误。

### 修复

移除 grep 检测，改为依赖 `set -o pipefail` + semantic-release 退出码：
- semantic-release 的 `verifyConditions` 步骤在认证失败时返回非零退出码
- `set -o pipefail` 确保管道中的非零退出码不会被吞掉

## Test plan

- [ ] PR 合并后观察 release workflow 是否正常通过 analyze 阶段

🤖 Generated with [Claude Code](https://claude.com/claude-code)