### PR TITLE
feat(h5game): add debug feedback pull workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -519,7 +519,7 @@ const allModules = [..., yourFeatureModule];
 
 ## 工具和资源概览
 
-### 19 个 MCP Tools
+### 20 个 MCP Tools
 
 **流程指引（1个）**
 
@@ -550,10 +550,11 @@ const allModules = [..., yourFeatureModule];
 - `get_user_leaderboard_scores` - 获取用户分数数据
 - `get_app_status` - 获取应用审核状态
 
-**H5 游戏管理（2个）**
+**H5 游戏管理（3个）**
 
 - `prepare_h5_upload` - 收集 H5 游戏信息（上传前）
 - `upload_h5_game` - 上传 H5 游戏包
+- `get_debug_feedbacks` - 拉取用户调试反馈并下载附件到本地
 
 > 注：创建/编辑应用请使用 `create_app` 和 `update_app_info` 工具（在应用管理分类中）
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ curl http://localhost:5002/health  # RND
 
 ## 📖 功能列表
 
-### 19 个 Tools
+### 20 个 Tools
 
 #### 流程指引 (1)
 
@@ -130,12 +130,11 @@ curl http://localhost:5002/health  # RND
 - `get_user_leaderboard_scores` - 获取用户分数
 - `get_app_status` - 获取应用审核状态
 
-#### H5 游戏管理 (4)
+#### H5 游戏管理 (3)
 
-- `h5_game_info_gatherer` - 收集 H5 游戏信息（上传前）
-- `h5_game_uploader` - 上传 H5 游戏包
-- `h5_create_app` - 创建新 H5 游戏应用
-- `h5_edit_app` - 编辑 H5 游戏信息
+- `prepare_h5_upload` - 收集 H5 游戏信息（上传前）
+- `upload_h5_game` - 上传 H5 游戏包
+- `get_debug_feedbacks` - 拉取用户调试反馈并下载日志/截图
 
 #### 振动 API 文档 (1)
 

--- a/docs/MCP_USAGE.md
+++ b/docs/MCP_USAGE.md
@@ -262,6 +262,7 @@ console.log(result);
 
 - `prepare_h5_upload`: **上传第一步**。收集游戏信息，确认构建目录（如 dist/build）。
 - `upload_h5_game`: **上传第二步**。将确认好的游戏包上传到 TapTap 平台。
+- `get_debug_feedbacks`: 拉取用户调试反馈（可默认标记已处理），并下载截图/日志到本地 `logs/feed_back/`，同时生成 AI 可直接使用的调试上下文。
 
 ---
 
@@ -379,6 +380,17 @@ console.log(result);
 2. 调用 `prepare_h5_upload` 确认信息。
 3. 调用 `upload_h5_game` 执行上传。
 4. 返回上传结果和体验链接。
+
+### 场景 2.1：拉取用户调试反馈
+
+**用户**: "拉取用户反馈"
+
+**AI 助手**:
+
+1. 调用 `get_current_app_info` 确认当前应用已选中。
+2. 调用 `get_debug_feedbacks`（默认会拉取未处理并标记处理）。
+3. 读取 `logs/feed_back/feedback_{id}/` 下的截图、日志和 `debug_prompt.md`。
+4. 基于反馈内容定位问题并继续修复代码。
 
 ### 场景 3：实现多人联机
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -2187,6 +2188,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -3151,6 +3153,7 @@
       "integrity": "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3255,6 +3258,7 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -3449,6 +3453,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4003,6 +4008,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -4663,6 +4669,7 @@
       "integrity": "sha512-20pyHgnO40rvfI0NGF/xiEoFMkXDtkF8FwHvk5BokoFoCuTQRI8vrNCNFWUOfuolKJMm1tPCHc8GgYEtr1XRNA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "meow": "^13.0.0"
       },
@@ -4892,6 +4899,7 @@
       "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
@@ -5642,6 +5650,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5943,6 +5952,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -6850,36 +6860,6 @@
         }
       }
     },
-    "node_modules/git-semver-tags/node_modules/conventional-commits-filter": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
-      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/git-semver-tags/node_modules/conventional-commits-parser": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.2.1.tgz",
-      "integrity": "sha512-20pyHgnO40rvfI0NGF/xiEoFMkXDtkF8FwHvk5BokoFoCuTQRI8vrNCNFWUOfuolKJMm1tPCHc8GgYEtr1XRNA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/git-semver-tags/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
@@ -7675,6 +7655,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -8977,6 +8958,7 @@
       "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -11786,6 +11768,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13387,6 +13370,7 @@
       "integrity": "sha512-0mhiCR/4sZb00RVFJIUlMuiBkW3NMpVIW2Gse7noqEMoFGkvfPPAImEQbkBV8xga4KOPP4FdTRYuLLy32R1fPw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^11.0.0",
         "@semantic-release/error": "^4.0.0",
@@ -14697,6 +14681,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -15295,6 +15280,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15705,6 +15691,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/scripts/test-debug-feedback-rnd.sh
+++ b/scripts/test-debug-feedback-rnd.sh
@@ -19,7 +19,7 @@
 # 1. 先配置环境变量（必须）  oauth_clients.id 、oauth_clients.sdk_secret：
 #   
 #    export TAPTAP_MCP_CLIENT_ID="m2dnabebip3fpardnm" 
-#    export TAPTAP_MCP_CLIENT_SECRET="QUmbMoTQm2qJETi53vWnvaXuBiRL3VRkgcUWnBtb"
+#    export TAPTAP_MCP_CLIENT_SECRET="xxxxx"
 #
 # 2. 运行脚本：
 #    bash scripts/test-debug-feedback-rnd.sh \

--- a/scripts/test-debug-feedback-rnd.sh
+++ b/scripts/test-debug-feedback-rnd.sh
@@ -1,0 +1,456 @@
+#!/bin/bash
+
+# =============================================================================
+# TapTap MCP - Debug Feedback RND 一键测试脚本
+# =============================================================================
+#
+# 本脚本用于本地快速验证 `get_debug_feedbacks` 端到端流程，包含：
+# 1) 启动本地 MCP Server（RND + HTTP）
+# 2) MCP initialize（带租户上下文）
+# 3) check_environment
+# 4) OAuth 授权（start + 等待人工扫码 + complete）
+# 5) select_app
+# 6) get_debug_feedbacks（默认参数）
+# 7) 再次调用 get_debug_feedbacks（验证“无新未处理反馈”）
+#
+# -----------------------------------------------------------------------------
+# 使用方式（推荐）
+# -----------------------------------------------------------------------------
+# 1. 先配置环境变量（必须）  oauth_clients.id 、oauth_clients.sdk_secret：
+#   
+#    export TAPTAP_MCP_CLIENT_ID="m2dnabebip3fpardnm" 
+#    export TAPTAP_MCP_CLIENT_SECRET="QUmbMoTQm2qJETi53vWnvaXuBiRL3VRkgcUWnBtb"
+#
+# 2. 运行脚本：
+#    bash scripts/test-debug-feedback-rnd.sh \
+#      --developer-id 89025 \
+#      --app-id 204213 \
+#      --project-path .
+#
+# 3. 按提示用 TapTap App 扫码授权后，回车继续。
+#
+# -----------------------------------------------------------------------------
+# 可选参数
+# -----------------------------------------------------------------------------
+# --port <n>          MCP 服务端口（默认 3002）
+# --developer-id <n>  目标 developer_id（可交互输入）
+# --app-id <n>        目标 app_id（可交互输入）
+# --user-id <str>     租户 user_id（默认 local-test-user）
+# --project-id <str>  租户 project_id（默认 local-test-project）
+# --project-path <p>  租户 project_path（默认 "."，推荐相对路径）
+# --keep-server       脚本结束后不自动停止 MCP 服务（默认自动停止）
+# --help              显示帮助
+#
+# -----------------------------------------------------------------------------
+# 注意事项
+# -----------------------------------------------------------------------------
+# - 本脚本会在 /tmp 生成临时文件：请求响应、headers、日志等
+# - 默认会自动停止脚本启动的 MCP 服务
+# - 如果你传绝对 project_path，脚本会给出警告（仍可继续）
+# =============================================================================
+
+set -euo pipefail
+
+# ---------------------------
+# 颜色与输出工具函数
+# ---------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+info() {
+  echo -e "${BLUE}[INFO]${NC} $*"
+}
+
+warn() {
+  echo -e "${YELLOW}[WARN]${NC} $*"
+}
+
+error() {
+  echo -e "${RED}[ERROR]${NC} $*"
+}
+
+ok() {
+  echo -e "${GREEN}[OK]${NC} $*"
+}
+
+# ---------------------------
+# 默认参数
+# ---------------------------
+PORT=3002
+DEVELOPER_ID=""
+APP_ID=""
+TENANT_USER_ID="local-test-user"
+TENANT_PROJECT_ID="local-test-project"
+TENANT_PROJECT_PATH="."
+KEEP_SERVER=0
+
+# ---------------------------
+# 路径准备
+# ---------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+SERVER_LOG="/tmp/taptap-mcp-rnd-${PORT}.log"
+SESSION_FILE="/tmp/taptap-mcp-rnd-session-${PORT}.txt"
+REQ_COUNTER=1000
+
+# ---------------------------
+# 参数解析
+# ---------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --port)
+      PORT="$2"
+      shift 2
+      ;;
+    --developer-id)
+      DEVELOPER_ID="$2"
+      shift 2
+      ;;
+    --app-id)
+      APP_ID="$2"
+      shift 2
+      ;;
+    --user-id)
+      TENANT_USER_ID="$2"
+      shift 2
+      ;;
+    --project-id)
+      TENANT_PROJECT_ID="$2"
+      shift 2
+      ;;
+    --project-path)
+      TENANT_PROJECT_PATH="$2"
+      shift 2
+      ;;
+    --keep-server)
+      KEEP_SERVER=1
+      shift
+      ;;
+    --help|-h)
+      awk '/^#/{print}' "$0"
+      exit 0
+      ;;
+    *)
+      error "未知参数: $1"
+      error "使用 --help 查看说明。"
+      exit 1
+      ;;
+  esac
+done
+
+# ---------------------------
+# 依赖检查
+# ---------------------------
+for cmd in curl node awk mktemp; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    error "缺少依赖命令: $cmd"
+    exit 1
+  fi
+done
+
+# ---------------------------
+# 环境变量检查（RND 必需）
+# ---------------------------
+if [[ -z "${TAPTAP_MCP_CLIENT_ID:-}" ]]; then
+  error "未设置 TAPTAP_MCP_CLIENT_ID"
+  exit 1
+fi
+
+if [[ -z "${TAPTAP_MCP_CLIENT_SECRET:-}" ]]; then
+  error "未设置 TAPTAP_MCP_CLIENT_SECRET"
+  exit 1
+fi
+
+# ---------------------------
+# 输入参数交互补全
+# ---------------------------
+if [[ -z "$DEVELOPER_ID" ]]; then
+  read -r -p "请输入 developer_id: " DEVELOPER_ID
+fi
+
+if [[ -z "$APP_ID" ]]; then
+  read -r -p "请输入 app_id: " APP_ID
+fi
+
+if [[ "$TENANT_PROJECT_PATH" = /* ]]; then
+  warn "project_path 当前是绝对路径: $TENANT_PROJECT_PATH"
+  warn "建议使用相对路径（例如 '.'）以避免路径歧义。"
+fi
+
+# ---------------------------
+# 清理函数（退出时执行）
+# ---------------------------
+TEST_SERVER_PID=""
+cleanup() {
+  local pid="${TEST_SERVER_PID:-}"
+  if [[ "$KEEP_SERVER" -eq 1 ]]; then
+    warn "已设置 --keep-server，保留测试服务运行。"
+    if [[ -n "${pid}" ]]; then
+      warn "保留中的服务 PID: ${pid}, 端口: $PORT"
+    fi
+    return
+  fi
+
+  if [[ -n "${pid}" ]] && kill -0 "${pid}" >/dev/null 2>&1; then
+    info "停止测试服务（PID: ${pid}）..."
+    kill "${pid}" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+# ---------------------------
+# 工具函数：解析 MCP 返回 text 内容
+# ---------------------------
+extract_mcp_text() {
+  local json_file="$1"
+  node -e "
+const fs = require('fs');
+const p = process.argv[1];
+const data = JSON.parse(fs.readFileSync(p, 'utf8'));
+if (data.error) {
+  console.error('[MCP_ERROR]', data.error.message || JSON.stringify(data.error));
+  process.exit(2);
+}
+const content = (data.result && data.result.content) || [];
+const text = content.find((c) => c.type === 'text');
+process.stdout.write(text ? text.text : '');
+" "$json_file"
+}
+
+# ---------------------------
+# 工具函数：提取授权 URL
+# ---------------------------
+extract_auth_url() {
+  local json_file="$1"
+  node -e "
+const fs = require('fs');
+const p = process.argv[1];
+const data = JSON.parse(fs.readFileSync(p, 'utf8'));
+const candidates = [];
+const result = data.result || {};
+const content = Array.isArray(result.content) ? result.content : [];
+const structuredContent = result.structuredContent || {};
+
+for (const item of content) {
+  if (item && item.type === 'text' && typeof item.text === 'string') {
+    candidates.push(item.text);
+  }
+}
+
+for (const key of ['verify_uri_complete', 'verification_uri_complete', 'verify_uri', 'verification_uri']) {
+  const value = structuredContent[key];
+  if (typeof value === 'string') {
+    candidates.push(value);
+  }
+}
+
+for (const text of candidates) {
+  const mdLink = text.match(/\\((https?:\\/\\/[^)\\s]+)\\)/);
+  if (mdLink) {
+    process.stdout.write(mdLink[1]);
+    process.exit(0);
+  }
+
+  const raw = text.match(/https?:\\/\\/[^\\s\"'<>]+/);
+  if (raw) {
+    process.stdout.write(raw[0]);
+    process.exit(0);
+  }
+}
+" "$json_file"
+}
+
+# ---------------------------
+# 工具函数：统一发起 tools/call 请求
+# ---------------------------
+call_tool() {
+  local tool_name="$1"
+  local args_json="$2"
+  local output_file="$3"
+  local session_id
+  session_id="$(cat "$SESSION_FILE")"
+  REQ_COUNTER=$((REQ_COUNTER + 1))
+
+  local payload
+  payload="$(cat <<EOF
+{"jsonrpc":"2.0","id":$REQ_COUNTER,"method":"tools/call","params":{"name":"$tool_name","arguments":$args_json}}
+EOF
+)"
+
+  curl -sS -X POST "http://localhost:${PORT}/" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -H "Mcp-Session-Id: ${session_id}" \
+    -d "$payload" >"$output_file"
+}
+
+# ---------------------------
+# Step 0: 构建产物检查
+# ---------------------------
+info "Step 0/8 - 检查 dist/server.js 是否存在..."
+if [[ ! -f "${PROJECT_ROOT}/dist/server.js" ]]; then
+  error "未找到 dist/server.js，请先执行 npm run build。"
+  exit 1
+fi
+ok "构建产物存在。"
+
+# ---------------------------
+# Step 1: 启动本地 RND 服务
+# ---------------------------
+info "Step 1/8 - 启动本地 MCP 服务（RND, HTTP, 端口 ${PORT}）..."
+TAPTAP_MCP_ENV=rnd \
+TAPTAP_MCP_TRANSPORT=http \
+TAPTAP_MCP_PORT="${PORT}" \
+TAPTAP_MCP_WORKSPACE_ROOT="${PROJECT_ROOT}" \
+TAPTAP_MCP_CLIENT_ID="${TAPTAP_MCP_CLIENT_ID}" \
+TAPTAP_MCP_CLIENT_SECRET="${TAPTAP_MCP_CLIENT_SECRET}" \
+node "${PROJECT_ROOT}/dist/server.js" >"${SERVER_LOG}" 2>&1 &
+TEST_SERVER_PID=$!
+
+# 等待服务健康检查就绪（最多 15 秒）
+READY=0
+for _ in $(seq 1 15); do
+  if curl -sS "http://localhost:${PORT}/health" >/tmp/taptap-mcp-health.json 2>/dev/null; then
+    READY=1
+    break
+  fi
+  sleep 1
+done
+
+if [[ "$READY" -ne 1 ]]; then
+  error "服务启动超时，请检查日志：${SERVER_LOG}"
+  exit 1
+fi
+ok "服务启动成功，日志：${SERVER_LOG}"
+
+# ---------------------------
+# Step 2: 初始化 MCP 会话（带租户头）
+# ---------------------------
+info "Step 2/8 - 初始化 MCP 会话（注入 tenant 上下文）..."
+INIT_HEADERS="$(mktemp)"
+INIT_PAYLOAD='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"debug-feedback-test","version":"1.0.0"}}}'
+
+curl -sS -D "${INIT_HEADERS}" -X POST "http://localhost:${PORT}/" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "X-TapTap-User-Id: ${TENANT_USER_ID}" \
+  -H "X-TapTap-Project-Id: ${TENANT_PROJECT_ID}" \
+  -H "X-TapTap-Project-Path: ${TENANT_PROJECT_PATH}" \
+  -d "${INIT_PAYLOAD}" >/tmp/taptap-mcp-init.json
+
+SESSION_ID="$(awk 'tolower($1)=="mcp-session-id:"{print $2}' "${INIT_HEADERS}" | tr -d '\r\n')"
+if [[ -z "${SESSION_ID}" ]]; then
+  error "初始化失败，未获取到 Mcp-Session-Id。"
+  error "请检查响应：/tmp/taptap-mcp-init.json"
+  exit 1
+fi
+echo "${SESSION_ID}" >"${SESSION_FILE}"
+ok "会话初始化成功，Session ID: ${SESSION_ID}"
+
+# ---------------------------
+# Step 3: 检查环境状态
+# ---------------------------
+info "Step 3/8 - 调用 check_environment..."
+CHECK_ENV_JSON="$(mktemp)"
+call_tool "check_environment" "{}" "${CHECK_ENV_JSON}"
+CHECK_ENV_TEXT="$(extract_mcp_text "${CHECK_ENV_JSON}")"
+echo "${CHECK_ENV_TEXT}" >/tmp/taptap-mcp-check-environment.txt
+ok "check_environment 完成。输出已保存：/tmp/taptap-mcp-check-environment.txt"
+
+# ---------------------------
+# Step 4: 发起 OAuth 授权
+# ---------------------------
+info "Step 4/8 - 调用 start_oauth_authorization..."
+START_OAUTH_JSON="$(mktemp)"
+call_tool "start_oauth_authorization" "{}" "${START_OAUTH_JSON}"
+START_OAUTH_TEXT="$(extract_mcp_text "${START_OAUTH_JSON}")"
+AUTH_URL="$(extract_auth_url "${START_OAUTH_JSON}")"
+OAUTH_ALREADY_AUTHED=0
+
+if [[ -z "${AUTH_URL}" ]]; then
+  if [[ "${START_OAUTH_TEXT}" == *"已经完成授权"* ]] \
+    || [[ "${START_OAUTH_TEXT}" == *"已有有效的 MAC Token"* ]] \
+    || [[ "${START_OAUTH_TEXT}" =~ [Aa]lready.*[Aa]uthorized ]]; then
+    OAUTH_ALREADY_AUTHED=1
+    ok "检测到当前会话已授权，跳过扫码与 complete_oauth_authorization。"
+  else
+    error "未从 start_oauth_authorization 响应中提取到授权链接。"
+    error "原始响应：${START_OAUTH_JSON}"
+    exit 1
+  fi
+fi
+
+if [[ "${OAUTH_ALREADY_AUTHED}" -ne 1 ]]; then
+  ok "已获取授权链接："
+  echo "${AUTH_URL}"
+  echo ""
+  echo "请使用 TapTap App 完成授权后，回车继续..."
+  read -r
+fi
+
+# ---------------------------
+# Step 5: 完成 OAuth 授权
+# ---------------------------
+if [[ "${OAUTH_ALREADY_AUTHED}" -eq 1 ]]; then
+  echo "${START_OAUTH_TEXT}" >/tmp/taptap-mcp-complete-oauth.txt
+  ok "OAuth 已处于完成状态。输出已保存：/tmp/taptap-mcp-complete-oauth.txt"
+else
+  info "Step 5/8 - 调用 complete_oauth_authorization..."
+  COMPLETE_OAUTH_JSON="$(mktemp)"
+  call_tool "complete_oauth_authorization" "{}" "${COMPLETE_OAUTH_JSON}"
+  COMPLETE_OAUTH_TEXT="$(extract_mcp_text "${COMPLETE_OAUTH_JSON}")"
+  echo "${COMPLETE_OAUTH_TEXT}" >/tmp/taptap-mcp-complete-oauth.txt
+  ok "OAuth 完成。输出已保存：/tmp/taptap-mcp-complete-oauth.txt"
+fi
+
+# ---------------------------
+# Step 6: 选择目标应用
+# ---------------------------
+info "Step 6/8 - 调用 select_app (developer_id=${DEVELOPER_ID}, app_id=${APP_ID})..."
+SELECT_APP_JSON="$(mktemp)"
+call_tool "select_app" "{\"developer_id\":${DEVELOPER_ID},\"app_id\":${APP_ID}}" "${SELECT_APP_JSON}"
+SELECT_APP_TEXT="$(extract_mcp_text "${SELECT_APP_JSON}")"
+echo "${SELECT_APP_TEXT}" >/tmp/taptap-mcp-select-app.txt
+ok "应用选择完成。输出已保存：/tmp/taptap-mcp-select-app.txt"
+
+# ---------------------------
+# Step 7: 拉取调试反馈（默认参数）
+# ---------------------------
+info "Step 7/8 - 调用 get_debug_feedbacks（默认参数）..."
+FEEDBACK_JSON="$(mktemp)"
+call_tool "get_debug_feedbacks" "{}" "${FEEDBACK_JSON}"
+FEEDBACK_TEXT="$(extract_mcp_text "${FEEDBACK_JSON}")"
+echo "${FEEDBACK_TEXT}" >/tmp/taptap-mcp-debug-feedbacks-first.txt
+ok "首次拉取完成。输出已保存：/tmp/taptap-mcp-debug-feedbacks-first.txt"
+
+# ---------------------------
+# Step 8: 再次拉取（验证默认“仅未处理”）
+# ---------------------------
+info "Step 8/8 - 再次调用 get_debug_feedbacks（验证处理标记后行为）..."
+FEEDBACK_JSON_2="$(mktemp)"
+call_tool "get_debug_feedbacks" "{}" "${FEEDBACK_JSON_2}"
+FEEDBACK_TEXT_2="$(extract_mcp_text "${FEEDBACK_JSON_2}")"
+echo "${FEEDBACK_TEXT_2}" >/tmp/taptap-mcp-debug-feedbacks-second.txt
+ok "二次拉取完成。输出已保存：/tmp/taptap-mcp-debug-feedbacks-second.txt"
+
+echo ""
+ok "=============================================="
+ok "测试流程执行完成"
+ok "=============================================="
+echo "关键输出文件："
+echo "- /tmp/taptap-mcp-check-environment.txt"
+echo "- /tmp/taptap-mcp-complete-oauth.txt"
+echo "- /tmp/taptap-mcp-select-app.txt"
+echo "- /tmp/taptap-mcp-debug-feedbacks-first.txt"
+echo "- /tmp/taptap-mcp-debug-feedbacks-second.txt"
+echo "- 服务日志: ${SERVER_LOG}"
+echo ""
+echo "如果 get_debug_feedbacks 成功，会在项目内生成："
+echo "- logs/feed_back/feedback_<id>/feedback.json"
+echo "- logs/feed_back/feedback_<id>/screenshots/"
+echo "- logs/feed_back/feedback_<id>/logs/"
+echo "- logs/feed_back/feedback_<id>/debug_prompt.md"
+

--- a/src/core/utils/pathResolver.ts
+++ b/src/core/utils/pathResolver.ts
@@ -4,7 +4,9 @@
  * 所有与目录相关的工具都应该使用这个解析器来处理路径
  *
  * 路径解析优先级：
- * 1. 有 Proxy: WORKSPACE_ROOT + _project_path + relativePath
+ * 1. 有 Proxy:
+ *    - _project_path 为绝对路径: _project_path + relativePath
+ *    - _project_path 为相对路径: WORKSPACE_ROOT + _project_path + relativePath
  * 2. 无 Proxy: WORKSPACE_ROOT + relativePath
  * 3. 本地开发: process.cwd() + relativePath
  *
@@ -26,6 +28,25 @@ import { EnvConfig } from './env.js';
  * 注意：使用 EnvConfig.workspaceRoot 来支持新旧环境变量名的兼容
  */
 const WORKSPACE_ROOT = EnvConfig.workspaceRoot;
+
+/**
+ * 计算基础路径（兼容 projectPath 绝对/相对两种模式）
+ *
+ * - 绝对 projectPath: 直接作为 basePath（避免重复拼接 WORKSPACE_ROOT）
+ * - 相对 projectPath: 视为相对于 WORKSPACE_ROOT
+ */
+function resolveBasePath(ctx?: ResolvedContext): string {
+  if (!ctx?.projectPath) {
+    return WORKSPACE_ROOT;
+  }
+
+  const normalizedProjectPath = path.normalize(ctx.projectPath);
+  if (path.isAbsolute(normalizedProjectPath)) {
+    return normalizedProjectPath;
+  }
+
+  return path.join(WORKSPACE_ROOT, normalizedProjectPath);
+}
 
 /**
  * 路径输入类型
@@ -127,19 +148,8 @@ export const PATH_ERRORS = {
  * ```
  */
 export function resolveWorkPath(relativePath?: string, ctx?: ResolvedContext): string {
-  // 1. 基础路径：WORKSPACE_ROOT
-  let basePath = WORKSPACE_ROOT;
-
-  // 2. 如果有 Proxy 注入的 projectPath
-  if (ctx?.projectPath) {
-    // 设计：projectPath 总是相对于 WORKSPACE_ROOT
-    // 即使以 '/' 开头也视为相对路径（去掉开头的 '/'）
-    // 例如："/a51c239e.../workspace" -> "a51c239e.../workspace"
-    const normalizedProjectPath = ctx.projectPath.startsWith('/')
-      ? ctx.projectPath.slice(1)
-      : ctx.projectPath;
-    basePath = path.join(WORKSPACE_ROOT, normalizedProjectPath);
-  }
+  // 1. 计算基础路径
+  const basePath = resolveBasePath(ctx);
 
   // 3. 拼接用户传入的相对路径
   if (relativePath) {
@@ -255,16 +265,8 @@ export function resolvePathSafe(
       ? 'absolute'
       : 'relative';
 
-  // 1. 计算基础路径
-  let basePath = WORKSPACE_ROOT;
-  if (ctx?.projectPath) {
-    // 设计：projectPath 总是相对于 WORKSPACE_ROOT
-    // 即使以 '/' 开头也视为相对路径（去掉开头的 '/'）
-    const normalizedProjectPath = ctx.projectPath.startsWith('/')
-      ? ctx.projectPath.slice(1)
-      : ctx.projectPath;
-    basePath = path.join(WORKSPACE_ROOT, normalizedProjectPath);
-  }
+  // 1. 计算基础路径（兼容绝对/相对 projectPath）
+  const basePath = resolveBasePath(ctx);
 
   // 2. 处理空字符串或未传的情况
   if (inputType === 'empty') {

--- a/src/features/h5Game/api.ts
+++ b/src/features/h5Game/api.ts
@@ -30,3 +30,66 @@ export async function getH5PackageUploadParams(
 
   return await client.get<UploadParams>('/level/v1/upload', { params });
 }
+
+/**
+ * Request payload for debug feedback pulling.
+ */
+export interface GetDebugFeedbacksRequest {
+  developer_id: number;
+  app_id: number;
+  limit?: number;
+  status?: number;
+  fetch_and_mark_processed?: boolean;
+}
+
+/**
+ * Single debug feedback item from server.
+ */
+export interface FeedbackInfo {
+  feedback_id: number;
+  version_id: number;
+  log_file_urls: string[];
+  description: string;
+  runtime_version: string;
+  screenshots: string[];
+  fps: number;
+  memory_usage_mb: number;
+  device_model: string;
+  status: number;
+}
+
+/**
+ * Response payload for debug feedback list API.
+ */
+export interface GetDebugFeedbacksResponse {
+  list: FeedbackInfo[];
+  total: number;
+}
+
+/**
+ * Pull debug feedback list from TapTap Open API.
+ */
+export async function getDebugFeedbacks(
+  request: GetDebugFeedbacksRequest,
+  ctx?: ResolvedContext
+): Promise<GetDebugFeedbacksResponse> {
+  const client = new HttpClient(ctx);
+  const params: Record<string, string> = {
+    developer_id: request.developer_id.toString(),
+    app_id: request.app_id.toString(),
+  };
+
+  if (request.limit !== undefined) {
+    params.limit = request.limit.toString();
+  }
+  if (request.status !== undefined) {
+    params.status = request.status.toString();
+  }
+  if (request.fetch_and_mark_processed !== undefined) {
+    params.fetch_and_mark_processed = request.fetch_and_mark_processed ? 'true' : 'false';
+  }
+
+  return await client.get<GetDebugFeedbacksResponse>('/open/debug/v1/get-debug-feedbacks', {
+    params,
+  });
+}

--- a/src/features/h5Game/handlers.ts
+++ b/src/features/h5Game/handlers.ts
@@ -9,11 +9,21 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import archiver from 'archiver';
 import { MESSAGES } from './messages.js';
-import { getH5PackageUploadParams, type UploadParams } from './api.js';
+import {
+  getDebugFeedbacks,
+  getH5PackageUploadParams,
+  type FeedbackInfo,
+  type GetDebugFeedbacksRequest,
+  type UploadParams,
+} from './api.js';
 import { editAppInfo, refreshAppCache } from '../app/api.js';
 import { readAppCache } from '../../core/utils/cache.js';
 import { logger } from '../../core/utils/logger.js';
-import { resolvePathSafe, type PathResolutionResult } from '../../core/utils/pathResolver.js';
+import {
+  resolvePathSafe,
+  resolveWorkPath,
+  type PathResolutionResult,
+} from '../../core/utils/pathResolver.js';
 import { EnvConfig } from '../../core/utils/env.js';
 import type { ResolvedContext } from '../../core/types/context.js';
 
@@ -99,6 +109,33 @@ function validateH5GamePath(
  * 优先级：环境变量 > 默认值
  */
 const TEMP_ROOT = EnvConfig.tempDir;
+
+/**
+ * 调试反馈下载目录（相对于项目根目录）
+ */
+const DEBUG_FEEDBACK_ROOT = path.join('logs', 'feed_back');
+
+/**
+ * Debug feedback handler args
+ */
+interface GetDebugFeedbacksArgs {
+  limit?: number;
+  status?: number;
+  fetch_and_mark_processed?: boolean;
+  download_assets?: boolean;
+}
+
+/**
+ * 下载后的本地文件信息
+ */
+interface DownloadedFeedbackFiles {
+  feedbackDir: string;
+  feedbackJsonPath?: string;
+  promptPath?: string;
+  screenshotPaths: string[];
+  logPaths: string[];
+  failedDownloads: string[];
+}
 
 /**
  * 获取临时 ZIP 文件路径
@@ -223,6 +260,7 @@ function getSelectedAppInfo(ctx?: ResolvedContext): {
   developerName?: string;
   appId?: number;
   appTitle?: string;
+  miniappId?: string;
 } {
   // 从缓存读取（使用 ctx.projectPath 作为隔离 key）
   const cached = readAppCache(ctx?.projectPath);
@@ -247,6 +285,7 @@ function getSelectedAppInfo(ctx?: ResolvedContext): {
     developerName: cached.developer_name,
     appId: cached.app_id,
     appTitle: cached.app_title,
+    miniappId: cached.miniapp_id,
   };
 }
 
@@ -398,4 +437,328 @@ export async function handleUploadGame(
       }
     }
   }
+}
+
+/**
+ * 规范化拉取数量参数
+ */
+function normalizeDebugFeedbackLimit(limit?: number): number {
+  if (!Number.isFinite(limit)) {
+    return 10;
+  }
+
+  const normalized = Math.floor(limit!);
+  if (normalized < 1) return 1;
+  if (normalized > 20) return 20;
+  return normalized;
+}
+
+/**
+ * 规范化状态筛选参数
+ */
+function normalizeDebugFeedbackStatus(status?: number): 0 | 1 | 2 {
+  if (status === 0 || status === 1 || status === 2) {
+    return status;
+  }
+  return 1;
+}
+
+/**
+ * 确保目录存在
+ */
+function ensureDir(dirPath: string): void {
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true });
+  }
+}
+
+/**
+ * 清理文件名，避免路径字符和非法字符
+ */
+function sanitizeFileName(filename: string): string {
+  return filename.replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+/**
+ * 从 URL 推断文件名
+ */
+function inferFilenameFromUrl(url: string, fallback: string): string {
+  try {
+    const parsed = new URL(url);
+    const rawName = path.basename(decodeURIComponent(parsed.pathname));
+    if (rawName && rawName !== '/' && rawName !== '.') {
+      return sanitizeFileName(rawName);
+    }
+  } catch {
+    // Ignore URL parse errors and use fallback filename.
+  }
+  return fallback;
+}
+
+/**
+ * 获取不冲突的输出路径
+ */
+function getUniqueFilePath(dirPath: string, filename: string): string {
+  const ext = path.extname(filename);
+  const base = path.basename(filename, ext);
+  let candidate = path.join(dirPath, filename);
+  let counter = 1;
+
+  while (fs.existsSync(candidate)) {
+    candidate = path.join(dirPath, `${base}_${counter}${ext}`);
+    counter += 1;
+  }
+
+  return candidate;
+}
+
+/**
+ * 下载远程文件到本地
+ */
+async function downloadRemoteFile(url: string, outputPath: string): Promise<void> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  const fileData = Buffer.from(await response.arrayBuffer());
+  fs.writeFileSync(outputPath, fileData);
+}
+
+/**
+ * 获取调试反馈输出根目录
+ */
+function getDebugFeedbackRootDir(ctx?: ResolvedContext): string {
+  const basePath = resolveWorkPath(undefined, ctx);
+  return path.join(basePath, DEBUG_FEEDBACK_ROOT);
+}
+
+/**
+ * 生成 AI 调试上下文文本
+ */
+function buildDebugPromptContent(
+  feedback: FeedbackInfo,
+  appInfo: {
+    developerId: number;
+    appId: number;
+    appTitle?: string;
+    miniappId?: string;
+  },
+  files: DownloadedFeedbackFiles
+): string {
+  const screenshotLines =
+    files.screenshotPaths.length > 0
+      ? files.screenshotPaths.map((item) => `- ${item}`).join('\n')
+      : '- 无截图文件';
+  const logLines =
+    files.logPaths.length > 0
+      ? files.logPaths.map((item) => `- ${item}`).join('\n')
+      : '- 无日志文件';
+
+  return `# Debug Feedback Context
+
+## App Info
+- app_id: ${appInfo.appId}
+- app_title: ${appInfo.appTitle ?? ''}
+- developer_id: ${appInfo.developerId}
+- miniapp_id: ${appInfo.miniappId ?? ''}
+
+## Feedback Info
+- feedback_id: ${feedback.feedback_id}
+- version_id: ${feedback.version_id}
+- status: ${feedback.status} (${MESSAGES.DEBUG_FEEDBACK_STATUS_TEXT(feedback.status)})
+- description: ${feedback.description || '（无描述）'}
+- runtime_version: ${feedback.runtime_version || '未知'}
+- device_model: ${feedback.device_model || '未知'}
+- fps: ${feedback.fps}
+- memory_usage_mb: ${feedback.memory_usage_mb}
+
+## Artifacts
+### Screenshots
+${screenshotLines}
+
+### Log Files
+${logLines}
+
+## Suggested Debug Steps
+1. First inspect screenshots to reproduce the visual issue.
+2. Correlate user description with runtime metrics (fps/memory/device).
+3. Inspect log files to identify stack traces, warnings, or timing anomalies.
+4. Locate related gameplay logic and create a minimal code fix.
+`;
+}
+
+/**
+ * 下载单条反馈的附件，并写入反馈 JSON 与调试上下文文件
+ */
+async function saveDebugFeedbackFiles(
+  feedback: FeedbackInfo,
+  appInfo: {
+    developerId: number;
+    appId: number;
+    appTitle?: string;
+    miniappId?: string;
+  },
+  ctx?: ResolvedContext
+): Promise<DownloadedFeedbackFiles> {
+  const rootDir = getDebugFeedbackRootDir(ctx);
+  const feedbackDir = path.join(rootDir, `feedback_${feedback.feedback_id}`);
+  ensureDir(feedbackDir);
+
+  const files: DownloadedFeedbackFiles = {
+    feedbackDir,
+    screenshotPaths: [],
+    logPaths: [],
+    failedDownloads: [],
+  };
+
+  // 1) 保存反馈 JSON
+  const feedbackJsonPath = path.join(feedbackDir, 'feedback.json');
+  fs.writeFileSync(feedbackJsonPath, JSON.stringify(feedback, null, 2), 'utf-8');
+  files.feedbackJsonPath = feedbackJsonPath;
+
+  // 2) 下载截图
+  if (feedback.screenshots && feedback.screenshots.length > 0) {
+    const screenshotDir = path.join(feedbackDir, 'screenshots');
+    ensureDir(screenshotDir);
+    for (const [index, screenshotUrl] of feedback.screenshots.entries()) {
+      const fallbackName = `screenshot_${index + 1}.png`;
+      const filename = inferFilenameFromUrl(screenshotUrl, fallbackName);
+      const outputPath = getUniqueFilePath(screenshotDir, filename);
+      try {
+        await downloadRemoteFile(screenshotUrl, outputPath);
+        files.screenshotPaths.push(outputPath);
+      } catch (error) {
+        files.failedDownloads.push(
+          MESSAGES.DEBUG_FEEDBACK_DOWNLOAD_FAILED(
+            screenshotUrl,
+            error instanceof Error ? error.message : String(error)
+          )
+        );
+      }
+    }
+  }
+
+  // 3) 下载日志文件
+  if (feedback.log_file_urls && feedback.log_file_urls.length > 0) {
+    const logDir = path.join(feedbackDir, 'logs');
+    ensureDir(logDir);
+    for (const [index, logUrl] of feedback.log_file_urls.entries()) {
+      const fallbackName = `log_${index + 1}.txt`;
+      const filename = inferFilenameFromUrl(logUrl, fallbackName);
+      const outputPath = getUniqueFilePath(logDir, filename);
+      try {
+        await downloadRemoteFile(logUrl, outputPath);
+        files.logPaths.push(outputPath);
+      } catch (error) {
+        files.failedDownloads.push(
+          MESSAGES.DEBUG_FEEDBACK_DOWNLOAD_FAILED(
+            logUrl,
+            error instanceof Error ? error.message : String(error)
+          )
+        );
+      }
+    }
+  }
+
+  // 4) 写调试上下文 prompt
+  const promptPath = path.join(feedbackDir, 'debug_prompt.md');
+  const promptContent = buildDebugPromptContent(feedback, appInfo, files);
+  fs.writeFileSync(promptPath, promptContent, 'utf-8');
+  files.promptPath = promptPath;
+
+  return files;
+}
+
+/**
+ * 拉取用户调试反馈
+ */
+export async function handleGetDebugFeedbacks(
+  args: GetDebugFeedbacksArgs,
+  ctx?: ResolvedContext
+): Promise<string> {
+  const appInfo = getSelectedAppInfo(ctx);
+  if (!appInfo.success) {
+    return appInfo.message!;
+  }
+
+  const limit = normalizeDebugFeedbackLimit(args.limit);
+  const status = normalizeDebugFeedbackStatus(args.status);
+  const fetchAndMarkProcessed = args.fetch_and_mark_processed ?? true;
+  const downloadAssets = args.download_assets ?? true;
+
+  const request: GetDebugFeedbacksRequest = {
+    developer_id: appInfo.developerId!,
+    app_id: appInfo.appId!,
+    limit,
+    status,
+    fetch_and_mark_processed: fetchAndMarkProcessed,
+  };
+
+  const response = await getDebugFeedbacks(request, ctx);
+  const feedbackList = response.list || [];
+  const outputRoot = getDebugFeedbackRootDir(ctx);
+
+  if (feedbackList.length === 0) {
+    let msg = MESSAGES.DEBUG_FEEDBACK_NO_NEW;
+    msg += `\n\n筛选总数：${response.total ?? 0}`;
+    msg += `\n应用：${appInfo.appTitle ?? ''} (ID: ${appInfo.appId})`;
+    msg += `\n下载目录：${outputRoot}`;
+    return msg;
+  }
+
+  ensureDir(outputRoot);
+
+  const lines: string[] = [];
+  lines.push(
+    `成功拉取了 ${feedbackList.length} 条用户反馈${fetchAndMarkProcessed ? '（并已标记为已处理）' : ''}。`
+  );
+  lines.push(`筛选总数：${response.total ?? feedbackList.length}`);
+  lines.push(`应用：${appInfo.appTitle ?? ''} (ID: ${appInfo.appId})`);
+  lines.push(`反馈输出目录：${outputRoot}`);
+  lines.push('');
+
+  for (const feedback of feedbackList) {
+    let files: DownloadedFeedbackFiles = {
+      feedbackDir: path.join(outputRoot, `feedback_${feedback.feedback_id}`),
+      screenshotPaths: [],
+      logPaths: [],
+      failedDownloads: [],
+    };
+
+    if (downloadAssets) {
+      files = await saveDebugFeedbackFiles(
+        feedback,
+        {
+          developerId: appInfo.developerId!,
+          appId: appInfo.appId!,
+          appTitle: appInfo.appTitle,
+          miniappId: appInfo.miniappId,
+        },
+        ctx
+      );
+    }
+
+    lines.push(`反馈 #${feedback.feedback_id}`);
+    lines.push(`- 描述：${feedback.description || '（无描述）'}`);
+    lines.push(`- 设备：${feedback.device_model || '未知设备'}`);
+    lines.push(`- FPS：${feedback.fps}`);
+    lines.push(`- 内存：${feedback.memory_usage_mb} MB`);
+    lines.push(`- 引擎版本：${feedback.runtime_version || '未知'}`);
+    lines.push(`- 状态：${MESSAGES.DEBUG_FEEDBACK_STATUS_TEXT(feedback.status)}`);
+    lines.push(`- 截图：${feedback.screenshots?.length ?? 0} 张`);
+    lines.push(`- 日志文件：${feedback.log_file_urls?.length ?? 0} 个`);
+    if (downloadAssets) {
+      lines.push(`- 已下载目录：${files.feedbackDir}`);
+      if (files.promptPath) {
+        lines.push(`- 调试上下文：${files.promptPath}`);
+      }
+      if (files.failedDownloads.length > 0) {
+        lines.push(`- 下载失败：${files.failedDownloads.length} 个`);
+      }
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n').trim();
 }

--- a/src/features/h5Game/messages.ts
+++ b/src/features/h5Game/messages.ts
@@ -35,6 +35,12 @@ export const TOOL_DESCRIPTION = {
                  Available genres keys: ${Object.keys(GENRE_LIST).join(', ')}, and the chinese name of the genre is ${Object.values(GENRE_LIST).join(', ')}.
                  When analyzing, consider game rules, player interactions, visual elements, and core gameplay loops.
                  If still uncertain after analysis, default to 'casual' as fallback.`,
+  DEBUG_FEEDBACK_STATUS_DESCRIPTION: `Feedback status filter:
+- 0: all
+- 1: unprocessed
+- 2: processed
+
+When fetch_and_mark_processed=true, status filter will be ignored by server.`,
 };
 
 /**
@@ -92,6 +98,17 @@ export const MESSAGES = {
             ? '审核失败'
             : '已上线'
     }`,
+
+  // 调试反馈相关
+  DEBUG_FEEDBACK_STATUS_TEXT: (status: number) =>
+    status === 0 ? '初始' : status === 1 ? '未处理' : status === 2 ? '已处理' : `未知(${status})`,
+  DEBUG_FEEDBACK_NO_NEW: `当前没有新的未处理反馈。
+
+如需查看历史反馈，可将 status 设置为：
+- 0（全部）
+- 2（已处理）`,
+  DEBUG_FEEDBACK_DOWNLOAD_FAILED: (url: string, reason: string) =>
+    `下载失败：${url}\n原因：${reason}`,
 
   // 开发者身份和游戏选择相关
   SELECT_DEVELOPER_OR_GAME: (results: TapDeveloperInfo[]) => {

--- a/src/features/h5Game/tools.ts
+++ b/src/features/h5Game/tools.ts
@@ -8,7 +8,7 @@
 
 import type { ToolRegistration } from '../../core/types/index.js';
 import { TOOL_DESCRIPTION } from './messages.js';
-import { handleGatherGameInfo, handleUploadGame } from './handlers.js';
+import { handleGatherGameInfo, handleGetDebugFeedbacks, handleUploadGame } from './handlers.js';
 
 /**
  * H5 Game Tools - Unified Format
@@ -105,5 +105,65 @@ Use the same path confirmed in prepare_h5_upload step.`,
     handler: async (args, context) => {
       return await handleUploadGame(args, context);
     },
+  },
+
+  // 3. 拉取用户调试反馈
+  {
+    definition: {
+      name: 'get_debug_feedbacks',
+      description: `
+        [H5 Debug Workflow]
+        Pull user debug feedback records for the selected app, download artifacts (screenshots/logs),
+        and generate AI-ready debug context files.
+
+        **PREREQUISITE: An app MUST be selected first.**
+        Before calling this tool, ALWAYS call get_current_app_info to verify an app is selected.
+        If not selected, guide user through:
+        1) Call list_developers_and_apps to show available apps
+        2) Show list to user and ASK them to choose
+        3) Call select_app with user's choice
+        4) Then call this tool
+
+        **DEFAULT BEHAVIOR:**
+        - fetch_and_mark_processed defaults to true
+        - download_assets defaults to true
+        - downloaded files are saved under logs/feed_back/feedback_{id}/
+      `,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          limit: {
+            type: 'number',
+            description: 'How many feedback records to pull (1-10, default 3).',
+          },
+          status: {
+            type: 'number',
+            description: TOOL_DESCRIPTION.DEBUG_FEEDBACK_STATUS_DESCRIPTION,
+          },
+          fetch_and_mark_processed: {
+            type: 'boolean',
+            description:
+              'Pull unprocessed records and mark them processed on server. Default true. When true, status is ignored.',
+          },
+          download_assets: {
+            type: 'boolean',
+            description:
+              'Whether to download feedback JSON/screenshot/log files to local workspace. Default true.',
+          },
+        },
+      },
+    },
+    handler: async (
+      args: {
+        limit?: number;
+        status?: number;
+        fetch_and_mark_processed?: boolean;
+        download_assets?: boolean;
+      },
+      context
+    ) => {
+      return await handleGetDebugFeedbacks(args, context);
+    },
+    requiresAuth: true,
   },
 ];


### PR DESCRIPTION
## Summary
- add `get_debug_feedbacks` in the h5Game module, including tool registration, API request/response types, and handler implementation.
- implement default pull-unprocessed-and-mark-processed behavior, download artifacts into `logs/feed_back/feedback_{id}/`, and generate `debug_prompt.md` for AI debugging.
- fix absolute `project_path` base path resolution and provide `scripts/test-debug-feedback-rnd.sh` for RND end-to-end validation.

## Test plan
- [x] `npm run build`
- [x] `npm run lint`
- [x] run `bash scripts/test-debug-feedback-rnd.sh --developer-id 89025 --app-id 204213 --project-path .`
- [x] verify downloaded files and prompt under `logs/feed_back/feedback_<id>/`

Made with [Cursor](https://cursor.com)