### PR TITLE
fix(h5game): adjust debug feedback fetch defaults and policy

### DIFF
--- a/src/features/h5Game/handlers.ts
+++ b/src/features/h5Game/handlers.ts
@@ -444,12 +444,12 @@ export async function handleUploadGame(
  */
 function normalizeDebugFeedbackLimit(limit?: number): number {
   if (!Number.isFinite(limit)) {
-    return 10;
+    return 3;
   }
 
   const normalized = Math.floor(limit!);
   if (normalized < 1) return 1;
-  if (normalized > 20) return 20;
+  if (normalized > 10) return 10;
   return normalized;
 }
 

--- a/src/features/h5Game/tools.ts
+++ b/src/features/h5Game/tools.ts
@@ -128,6 +128,12 @@ Use the same path confirmed in prepare_h5_upload step.`,
         - fetch_and_mark_processed defaults to true
         - download_assets defaults to true
         - downloaded files are saved under logs/feed_back/feedback_{id}/
+
+        **CALLING POLICY FOR AGENTS:**
+        - If user says "拉取/查看反馈" without explicit read-only intent, DO NOT pass fetch_and_mark_processed.
+          Let default behavior (true) apply.
+        - ONLY pass fetch_and_mark_processed=false when user explicitly requests read-only
+          behavior (e.g. "只查看，不标记处理").
       `,
       inputSchema: {
         type: 'object',
@@ -143,7 +149,8 @@ Use the same path confirmed in prepare_h5_upload step.`,
           fetch_and_mark_processed: {
             type: 'boolean',
             description:
-              'Pull unprocessed records and mark them processed on server. Default true. When true, status is ignored.',
+              'Pull unprocessed records and mark them processed on server. Default true. ' +
+              'Set false only for explicit read-only requests. When true, status is ignored.',
           },
           download_assets: {
             type: 'boolean',


### PR DESCRIPTION
## Summary
- adjust debug feedback limit normalization in `handleGetDebugFeedbacks` to use default `3` and clamp to `1-10`.
- keep `fetch_and_mark_processed` default behavior as `true` (mark processed unless explicitly set to `false`).
- clarify agent calling policy in tool description: do not pass `false` unless user explicitly requests read-only behavior.

## Test plan
- [x] run `npm run lint`
- [x] run `npm run build`
- [x] verify `get_debug_feedbacks` behavior with and without `fetch_and_mark_processed=false`

Made with [Cursor](https://cursor.com)