### PR TITLE
refactor(package): add publishConfig for @taptap scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
   ],
   "author": "TapTap Team",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=18.14.1"
   },


### PR DESCRIPTION
## 改动内容

- 为 `package.json` 添加 `publishConfig.access: "public"`
- 新 scope `@taptap` 首次发布需要显式声明 public access，避免 npm publish 默认 restricted 导致发布失败

## 影响面

- 触发 `@taptap/minigame-open-mcp` 首次 npm 发布
- `refactor` 类型会触发 patch 版本升级（1.20.0 → 1.20.1）