### PR TITLE
refactor(ci): 使用 OIDC Trusted Publishing 替代 NPM_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -342,6 +342,11 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    environment: npm_publish
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     needs: [analyze, build-native, download-native]
     # 只要 analyze 说要发布，且 build-native 或 download-native 其中一个成功
     if: |
@@ -410,10 +415,8 @@ jobs:
 
           git checkout -b "$BRANCH"
 
-      # 发布到 npm (包含 native binaries)
+      # 发布到 npm (包含 native binaries, 使用 OIDC Trusted Publishing)
       - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           VERSION=${{ needs.analyze.outputs.version }}
 
@@ -424,8 +427,8 @@ jobs:
           echo "=== Files to be published ==="
           npm pack --dry-run
 
-          # 发布
-          npm publish --access public
+          # 发布 (OIDC provenance, 无需 NPM_TOKEN)
+          npm publish --access public --provenance
 
       # 生成 CHANGELOG
       - name: Generate CHANGELOG
@@ -515,14 +518,14 @@ jobs:
           PR_URL=${{ steps.pr.outputs.pr_url }}
           PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
 
-          echo "Merging PR #$PR_NUMBER..."
-          sleep 10
+          echo "Enabling auto-merge for PR #$PR_NUMBER..."
 
           gh pr merge "$PR_NUMBER" \
+            --auto \
             --squash \
             --delete-branch
 
-          echo "PR #$PR_NUMBER merged successfully!"
+          echo "Auto-merge enabled for PR #$PR_NUMBER, will merge when all checks pass."
 
       # 创建 GitHub Release (始终包含 native binaries 作为 assets)
       - name: Create GitHub Release


### PR DESCRIPTION
## 改动内容

- Release job 添加 `environment: npm_publish` 和 `id-token: write` 权限
- `npm publish` 使用 `--provenance` 参数，通过 OIDC 自动认证
- 移除发布步骤对 `NPM_TOKEN` 的依赖（analyze 步骤保留用于 dry-run 查询）
- auto-merge 改用 `--auto` flag，等待 checks 通过后自动合并

## 影响面

- npm 发布认证方式从 token 切换到 OIDC Trusted Publishing
- npm 包页面将显示 Trusted Publisher 标记（provenance）
- release PR 不再因 CodeQL 未完成而阻塞合并

## 前置配置（已完成）

- [x] GitHub Environment `npm_publish` 已创建
- [x] npm Trusted Publisher 已关联 `taptap/minigame-open-mcp` + `release.yml` + `npm_publish`