### PR TITLE
fix(package): 修正 repository URL 匹配实际仓库名

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
 
 ```bash
 python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py \
-  --repo taptap/taptap_minigame_open_mcp \
+  --repo taptap/minigame-open-mcp \
   --path skills/taptap-dc-ops-brief
 ```
 
@@ -436,4 +436,4 @@ MIT
 - [TapTap 开发者中心](https://developer.taptap.cn/)
 - [官方 API 文档](https://developer.taptap.cn/minigameapidoc/dev/api/open-api/leaderboard/)
 - [MCP 协议规范](https://modelcontextprotocol.io/)
-- [Issues](https://github.com/taptap/taptap_minigame_open_mcp/issues)
+- [Issues](https://github.com/taptap/minigame-open-mcp/issues)

--- a/docs/PROXY.md
+++ b/docs/PROXY.md
@@ -1100,8 +1100,8 @@ node_modules/@taptap/minigame-open-mcp/dist/proxy.js
 
 ```bash
 # 克隆仓库
-git clone https://github.com/taptap/taptap_minigame_open_mcp.git
-cd taptap_minigame_open_mcp
+git clone https://github.com/taptap/minigame-open-mcp.git
+cd minigame-open-mcp
 
 # 构建
 npm install

--- a/package.json
+++ b/package.json
@@ -95,10 +95,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/taptap/taptap_minigame_open_mcp.git"
+    "url": "git+https://github.com/taptap/minigame-open-mcp.git"
   },
-  "homepage": "https://github.com/taptap/taptap_minigame_open_mcp#readme",
+  "homepage": "https://github.com/taptap/minigame-open-mcp#readme",
   "bugs": {
-    "url": "https://github.com/taptap/taptap_minigame_open_mcp/issues"
+    "url": "https://github.com/taptap/minigame-open-mcp/issues"
   }
 }

--- a/packages/openclaw-dc-plugin/package.json
+++ b/packages/openclaw-dc-plugin/package.json
@@ -37,11 +37,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/taptap/taptap_minigame_open_mcp.git",
+    "url": "git+https://github.com/taptap/minigame-open-mcp.git",
     "directory": "packages/openclaw-dc-plugin"
   },
-  "homepage": "https://github.com/taptap/taptap_minigame_open_mcp/tree/main/packages/openclaw-dc-plugin",
+  "homepage": "https://github.com/taptap/minigame-open-mcp/tree/main/packages/openclaw-dc-plugin",
   "bugs": {
-    "url": "https://github.com/taptap/taptap_minigame_open_mcp/issues"
+    "url": "https://github.com/taptap/minigame-open-mcp/issues"
   }
 }


### PR DESCRIPTION
## 改动内容

- 将 `package.json` 和文档中的 `taptap/taptap_minigame_open_mcp` 更正为 `taptap/minigame-open-mcp`
- npm provenance (OIDC) 校验要求 `repository.url` 与 GitHub 实际仓库名一致

## 影响面

- 修复 OIDC Trusted Publishing 发布失败（E422 provenance 校验不通过）
- `fix` 类型触发 patch 版本升级，合并后将以 OIDC 方式发布 `@taptap/minigame-open-mcp@1.20.3`