### PR TITLE
ci(review): 接入 Claude Code Review GitHub Action

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,30 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  issue_comment:
+    types: [created]
+
+jobs:
+  review:
+    # PR 评论触发时，仅响应 @claude 提及
+    if: |
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## 改动内容

- 新增 `.github/workflows/claude-review.yml`
- 使用 `anthropics/claude-code-action@v1` 实现 PR 自动代码审查
- PR 创建/更新时自动触发 review
- 支持在 PR 评论中 `@claude` 交互

## 影响面

- 新增 CI job，不影响现有流程
- 使用 org 级别 `ANTHROPIC_API_KEY`（已配置）
- `ci` 类型不触发版本更新