### PR TITLE
fix(ci): analyze 步骤移除对 NPM_TOKEN secret 的依赖

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -28,3 +28,14 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Review this pull request. Focus on:
+            - Code quality and best practices
+            - Potential bugs or logic errors
+            - Security implications
+            - Performance considerations
+
+            The PR branch is already checked out. Use gh CLI to interact with the PR.
+            Post your review as a PR comment using `gh pr comment`.
+            For specific code issues, use inline comments via `mcp__github_inline_comment__create_inline_comment` with `confirmed: true`.
+            Reply in Chinese (简体中文).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,9 @@ jobs:
         id: analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # dry-run 不实际发布，但 @semantic-release/npm 仍会验证 NPM_TOKEN
+          # 实际发布已改用 OIDC，这里设置占位值绕过验证
+          NPM_TOKEN: dry-run-placeholder
         run: |
           # set -o pipefail 确保 semantic-release 失败时（含认证错误）整个管道返回非零退出码
           # 注意：不能用 grep 检测错误关键词，因为 semantic-release 分析 commit 时会打印 commit body，


### PR DESCRIPTION
## 改动内容

- analyze 步骤的 `NPM_TOKEN` 从 `secrets.NPM_TOKEN` 改为占位值
- 实际发布已改用 OIDC Trusted Publishing，dry-run 不需要真实 token

## 原因

合并 OIDC PR 后，`NPM_TOKEN` secret 不再需要但 `semantic-release --dry-run` 的 `@semantic-release/npm` 插件仍会验证它，导致 analyze 步骤失败

## 影响面

- 修复 release workflow 的 analyze 步骤
- `fix` 类型触发 patch 版本升级，可顺便验证完整的 OIDC 发布流程