### PR TITLE
fix(ci): dry-run 时跳过 npm 验证

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -31,13 +31,51 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
-            Review this pull request. Focus on:
-            - Code quality and best practices
-            - Potential bugs or logic errors
-            - Security implications
-            - Performance considerations
+            You are a code reviewer for a TypeScript MCP server project.
+            The PR branch is already checked out. Use `gh pr diff` to get the changes.
 
-            The PR branch is already checked out. Use gh CLI to interact with the PR.
-            Post your review as a PR comment using `gh pr comment`.
-            For specific code issues, use inline comments via `mcp__github_inline_comment__create_inline_comment` with `confirmed: true`.
-            Reply in Chinese (简体中文).
+            ## Review methodology (inspired by Puer)
+
+            1. **Only report findings with confidence >= 85%**. Do not guess or speculate.
+            2. **Verify before reporting**: read the actual code (`cat`, `grep`) to confirm each finding.
+               Do NOT report issues based solely on the diff — check surrounding context.
+            3. **Ignore non-issues**: style preferences, minor naming choices, and patterns
+               that are consistent with existing codebase conventions are NOT issues.
+
+            ## Focus areas (in priority order)
+
+            1. **Bugs & logic errors** — incorrect behavior, missing edge cases, race conditions
+            2. **Security** — injection, credential exposure, unsafe deserialization
+            3. **Breaking changes** — API/interface changes that affect consumers
+            4. **Resource leaks** — unclosed handles, missing cleanup, dangling listeners
+
+            Skip: style/formatting (handled by ESLint+Prettier), documentation completeness,
+            test coverage suggestions, and "nice to have" improvements.
+
+            ## Output format
+
+            Post ONE PR comment using `gh pr comment`. Use this exact format:
+
+            ```
+            ## Code Review
+
+            ### 🚫 阻塞问题
+            - **file:line** — 描述问题和修复建议
+
+            ### ⚠️ 警告
+            - **file:line** — 描述问题和修复建议
+
+            ### 💡 建议
+            - **file:line** — 描述建议
+
+            ---
+            ✅ 已审查 N 个文件，M 处变更
+            ```
+
+            Rules:
+            - If a section has no items, write `- 无`
+            - Each item MUST include `file:line` reference
+            - Keep descriptions concise (1-2 sentences)
+            - Reply in Chinese (简体中文)
+            - For specific code issues, also add inline comments via
+              `mcp__github_inline_comment__create_inline_comment` with `confirmed: true`

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -26,6 +26,8 @@ jobs:
           fetch-depth: 1
 
       - uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_BASE_URL: https://llm-proxy.tapsvc.com
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,9 +56,8 @@ jobs:
         id: analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # dry-run 不实际发布，但 @semantic-release/npm 仍会验证 NPM_TOKEN
-          # 实际发布已改用 OIDC，这里设置占位值绕过验证
-          NPM_TOKEN: dry-run-placeholder
+          # 告知 .releaserc.cjs 禁用 npm 发布验证（实际发布由 OIDC 处理）
+          SEMANTIC_RELEASE_DRY_RUN: 'true'
         run: |
           # set -o pipefail 确保 semantic-release 失败时（含认证错误）整个管道返回非零退出码
           # 注意：不能用 grep 检测错误关键词，因为 semantic-release 分析 commit 时会打印 commit body，

--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -107,10 +107,11 @@ module.exports = {
     ],
 
     // 4. 更新 package.json 版本号并发布到 npm
+    // dry-run 时禁用 npm 发布（实际发布由 OIDC Trusted Publishing 处理）
     [
       '@semantic-release/npm',
       {
-        npmPublish: true,
+        npmPublish: !process.env.SEMANTIC_RELEASE_DRY_RUN,
         tarballDir: 'dist'
       }
     ],


### PR DESCRIPTION
## 改动内容

- `.releaserc.cjs` 中通过 `SEMANTIC_RELEASE_DRY_RUN` 环境变量控制 `npmPublish`
- analyze 步骤设置 `SEMANTIC_RELEASE_DRY_RUN=true`，dry-run 时 `npmPublish` 为 `false`，跳过 npm token 验证

## 原因

`semantic-release --dry-run` 的 `@semantic-release/npm` 插件会调用 `npm whoami` 验证 token，但实际发布已改用 OIDC Trusted Publishing，analyze 步骤没有也不需要 NPM_TOKEN

## 影响面

- 修复 release workflow 的 analyze 步骤失败
- `fix` 类型触发 patch 版本升级