### PR TITLE
ci(codeql): 切换为 workflow 配置，跳过 release PR

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -30,6 +30,7 @@ jobs:
           ANTHROPIC_BASE_URL: https://llm-proxy.tapsvc.com
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          use_sticky_comment: true
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(cat:*),Bash(grep:*),Bash(git diff:*),Bash(git log:*),Read,Glob,Grep"
           prompt: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '40 2 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    # 跳过 release 分支的 PR（CI bot 自动创建的版本发布 PR）
+    if: ${{ !startsWith(github.head_ref || '', 'release/') }}
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: rust
+            build-mode: none
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
## 改动内容

- 新增 `.github/workflows/codeql.yml` 替代 GitHub default CodeQL configuration
- `release/` 分支的 PR 跳过 CodeQL 扫描（CI bot 自动创建的版本发布 PR）
- 保留 push to main、PR to main、每周定时扫描

## 前置操作（已完成）

- Settings → Code security → CodeQL default configuration → Disabled

## 影响面

- `ci` 类型不触发版本更新