### PR TITLE
fix(core): resolve Windows absolute path resolution error

### DIFF
--- a/src/core/network/nativeSigner.ts
+++ b/src/core/network/nativeSigner.ts
@@ -20,6 +20,8 @@
 
 import cryptoJS from 'crypto-js';
 import crypto from 'node:crypto';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { logger } from '../utils/logger.js';
 import { EnvConfig } from '../utils/env.js';
 
@@ -79,11 +81,15 @@ async function loadNativeModule(): Promise<NativeSignerModule | null> {
 
   // Native module loading path
   // Bundle mode: dist/server.js → dist/native/index.js
-  // All artifacts are in dist/ directory for easy distribution
-  const importPath = './native/index.js';
+  // Dev mode: src/core/network/nativeSigner.ts → native/index.js
+  const isBundle = typeof __VERSION__ !== 'undefined';
+  const relativePath = isBundle ? './native/index.js' : '../../../native/index.js';
+  const nativePath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), relativePath);
+  const importUrl = pathToFileURL(nativePath).href;
 
   try {
-    const native = (await import(importPath)) as NativeSignerModule;
+    // 使用 import(importUrl) 进行加载
+    const native = (await import(importUrl)) as NativeSignerModule;
 
     // Verify the module works
     native.verifyIntegrity();
@@ -95,7 +101,7 @@ async function loadNativeModule(): Promise<NativeSignerModule | null> {
     return nativeModule;
   } catch (error) {
     const errorMsg = error instanceof Error ? error.message : String(error);
-    loadError = new Error(`${importPath}: ${errorMsg}`);
+    loadError = new Error(`${nativePath}: ${errorMsg}`);
     await logger.info(`⚠️  Native signer not available: ${errorMsg}`);
     await logger.info('   Set TAPTAP_MCP_CLIENT_ID and TAPTAP_MCP_CLIENT_SECRET');
   }


### PR DESCRIPTION
问题描述： 在 Windows 系统下，由于 ESM 模块加载器会将带盘符的绝对路径（如 C:\...）错误识别为未知的网络协议，导致程序启动时触发 Received protocol 'c:' 报错而崩溃。

解决方案： 将原生签名器加载逻辑中的绝对路径拼接替换为 pathToFileURL(...).href 动态解析。

测试结果： 已在 Windows 原生环境下完成测试，路径解析正常，成功绕过 ESM 协议限制。