### PR TITLE
feat(debug-feedback): 支持按 moment_id 单查反馈并修复大整数精度丢失

### DIFF
--- a/src/core/network/httpClient.ts
+++ b/src/core/network/httpClient.ts
@@ -89,6 +89,12 @@ export interface RequestOptions {
   params?: Record<string, string>;
   timeout?: number;
   baseUrl?: string;
+  /**
+   * Custom JSON parser. Receives the raw response text and returns the parsed value.
+   * Use this when default JSON.parse causes issues (e.g. precision loss for large integers).
+   * If omitted, falls back to native response.json().
+   */
+  parseJson?: (text: string) => unknown;
 }
 
 /**
@@ -293,7 +299,15 @@ export class HttpClient {
       const contentType = response.headers.get('content-type');
 
       if (contentType?.includes('application/json')) {
-        const jsonData = (await response.json()) as ApiResponse<T>;
+        let jsonData: ApiResponse<T>;
+
+        if (options.parseJson) {
+          // Custom parser, e.g. for preserving large-integer precision
+          const text = await response.text();
+          jsonData = options.parseJson(text) as ApiResponse<T>;
+        } else {
+          jsonData = (await response.json()) as ApiResponse<T>;
+        }
 
         // Log successful response with headers
         await logger.logResponse(

--- a/src/features/h5Game/api.ts
+++ b/src/features/h5Game/api.ts
@@ -40,6 +40,7 @@ export interface GetDebugFeedbacksRequest {
   limit?: number;
   status?: number;
   fetch_and_mark_processed?: boolean;
+  moment_id?: string; // When provided, returns only the matching feedback
 }
 
 /**
@@ -48,6 +49,7 @@ export interface GetDebugFeedbacksRequest {
 export interface FeedbackInfo {
   feedback_id: number;
   version_id: number;
+  moment_id?: string; // Large ID, returned as string to avoid precision loss
   log_file_urls: string[];
   description: string;
   runtime_version: string;
@@ -67,7 +69,94 @@ export interface GetDebugFeedbacksResponse {
 }
 
 /**
+ * Quote large-integer literals (>= 16 digits) in raw JSON text so that
+ * subsequent JSON.parse keeps them as strings instead of lossy numbers.
+ *
+ * Why pre-process the raw text:
+ *   JSON.parse converts number tokens to JS Number BEFORE reviver runs,
+ *   so any value > 2^53-1 is already rounded by the time a reviver sees it.
+ *   The only safe interception point is the textual JSON token.
+ *
+ * Threshold of 16 digits:
+ *   Number.MAX_SAFE_INTEGER (9007199254740991) has 16 digits. Any integer with
+ *   16+ digits *may* exceed it. We err on the safe side and quote them all;
+ *   downstream code that expects an ID can use String() either way.
+ *
+ * Implementation: a tiny string-state machine that skips JSON string literals
+ * (including escapes), so digits inside string values are never touched.
+ */
+function quoteLargeIntegersInJson(jsonText: string): string {
+  let result = '';
+  let i = 0;
+  let inString = false;
+  const len = jsonText.length;
+
+  while (i < len) {
+    const ch = jsonText[i];
+
+    if (inString) {
+      result += ch;
+      if (ch === '\\' && i + 1 < len) {
+        // Preserve any escape sequence verbatim (\", \\, \n, \uXXXX, ...)
+        result += jsonText[i + 1];
+        i += 2;
+        continue;
+      }
+      if (ch === '"') {
+        inString = false;
+      }
+      i++;
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+      result += ch;
+      i++;
+      continue;
+    }
+
+    // Number-literal start (digit or leading minus followed by digit)
+    const isDigit = ch >= '0' && ch <= '9';
+    const isNegStart =
+      ch === '-' && i + 1 < len && jsonText[i + 1] >= '0' && jsonText[i + 1] <= '9';
+    if (isDigit || isNegStart) {
+      let j = i;
+      if (jsonText[j] === '-') j++;
+      while (j < len && jsonText[j] >= '0' && jsonText[j] <= '9') j++;
+      const next = jsonText[j];
+      // Only quote pure integers (skip floats / scientific notation)
+      const isInteger = next !== '.' && next !== 'e' && next !== 'E';
+      const numStr = jsonText.substring(i, j);
+      const digitCount = numStr.startsWith('-') ? numStr.length - 1 : numStr.length;
+      if (isInteger && digitCount >= 16) {
+        result += '"' + numStr + '"';
+      } else {
+        result += numStr;
+      }
+      i = j;
+      continue;
+    }
+
+    result += ch;
+    i++;
+  }
+
+  return result;
+}
+
+/**
+ * Custom JSON parser used by getDebugFeedbacks: preserves large integer IDs
+ * (e.g. moment_id) as strings to avoid IEEE-754 precision loss.
+ */
+export function parseJsonPreservingLargeInts(text: string): unknown {
+  return JSON.parse(quoteLargeIntegersInJson(text));
+}
+
+/**
  * Pull debug feedback list from TapTap Open API.
+ * Uses a custom JSON parser so that large numeric IDs (e.g. moment_id) keep
+ * their full precision when serialized back to feedback.json.
  */
 export async function getDebugFeedbacks(
   request: GetDebugFeedbacksRequest,
@@ -88,8 +177,12 @@ export async function getDebugFeedbacks(
   if (request.fetch_and_mark_processed !== undefined) {
     params.fetch_and_mark_processed = request.fetch_and_mark_processed ? 'true' : 'false';
   }
+  if (request.moment_id !== undefined && request.moment_id !== '') {
+    params.moment_id = request.moment_id;
+  }
 
   return await client.get<GetDebugFeedbacksResponse>('/open/debug/v1/get-debug-feedbacks', {
     params,
+    parseJson: parseJsonPreservingLargeInts,
   });
 }

--- a/src/features/h5Game/handlers.ts
+++ b/src/features/h5Game/handlers.ts
@@ -123,6 +123,7 @@ interface GetDebugFeedbacksArgs {
   status?: number;
   fetch_and_mark_processed?: boolean;
   download_assets?: boolean;
+  moment_id?: string;
 }
 
 /**
@@ -671,6 +672,29 @@ async function saveDebugFeedbackFiles(
 }
 
 /**
+ * 把用户传入的 moment 标识规范化为纯数字 ID 字符串。
+ * 接受形式：
+ *   - 纯数字字符串（如 "795659996946762795"）→ 原样返回
+ *   - TapTap moment URL（如 "https://www.taptap.cn/moment/795659996946762795"）→ 提取数字段
+ *   - 含路径或 query 的变体（如 ".../moment/123?from=share"）→ 提取数字段
+ * 无法识别时返回 undefined（避免把脏数据传给后端）。
+ */
+function normalizeMomentId(input?: string): string | undefined {
+  if (!input) return undefined;
+  const trimmed = input.trim();
+  if (!trimmed) return undefined;
+
+  // 优先匹配 .../moment/<digits> 形式
+  const urlMatch = trimmed.match(/\/moment\/(\d+)/);
+  if (urlMatch) return urlMatch[1];
+
+  // 纯数字
+  if (/^\d+$/.test(trimmed)) return trimmed;
+
+  return undefined;
+}
+
+/**
  * 拉取用户调试反馈
  */
 export async function handleGetDebugFeedbacks(
@@ -684,8 +708,17 @@ export async function handleGetDebugFeedbacks(
 
   const limit = normalizeDebugFeedbackLimit(args.limit);
   const status = normalizeDebugFeedbackStatus(args.status);
-  const fetchAndMarkProcessed = args.fetch_and_mark_processed ?? true;
   const downloadAssets = args.download_assets ?? true;
+  const momentId = normalizeMomentId(args.moment_id);
+  const isMomentLookup = !!momentId;
+
+  // 用户传了 moment_id 但格式无法识别（既不是纯数字也不是 moment URL）
+  if (args.moment_id && args.moment_id.trim() && !momentId) {
+    return `无效的 moment_id 参数：${args.moment_id}\n请传入纯数字 ID 或形如 https://www.taptap.cn/moment/{id} 的链接。`;
+  }
+
+  // moment_id 单查强制为 read-only，不改变服务端状态
+  const fetchAndMarkProcessed = isMomentLookup ? false : (args.fetch_and_mark_processed ?? true);
 
   const request: GetDebugFeedbacksRequest = {
     developer_id: appInfo.developerId!,
@@ -694,6 +727,9 @@ export async function handleGetDebugFeedbacks(
     status,
     fetch_and_mark_processed: fetchAndMarkProcessed,
   };
+  if (isMomentLookup) {
+    request.moment_id = momentId;
+  }
 
   const response = await getDebugFeedbacks(request, ctx);
   const feedbackList = response.list || [];
@@ -704,6 +740,9 @@ export async function handleGetDebugFeedbacks(
     msg += `\n\n筛选总数：${response.total ?? 0}`;
     msg += `\n应用：${appInfo.appTitle ?? ''} (ID: ${appInfo.appId})`;
     msg += `\n下载目录：${outputRoot}`;
+    if (isMomentLookup) {
+      msg += `\nmoment_id：${momentId}（未找到对应反馈）`;
+    }
     return msg;
   }
 
@@ -711,11 +750,14 @@ export async function handleGetDebugFeedbacks(
 
   const lines: string[] = [];
   lines.push(
-    `成功拉取了 ${feedbackList.length} 条用户反馈${fetchAndMarkProcessed ? '（并已标记为已处理）' : ''}。`
+    `成功拉取了 ${feedbackList.length} 条用户反馈${fetchAndMarkProcessed ? '（并已标记为已处理）' : '（read-only）'}。`
   );
   lines.push(`筛选总数：${response.total ?? feedbackList.length}`);
   lines.push(`应用：${appInfo.appTitle ?? ''} (ID: ${appInfo.appId})`);
   lines.push(`反馈输出目录：${outputRoot}`);
+  if (isMomentLookup) {
+    lines.push(`查询模式：按 moment_id 单查 (${momentId})`);
+  }
   lines.push('');
 
   for (const feedback of feedbackList) {
@@ -748,6 +790,10 @@ export async function handleGetDebugFeedbacks(
     lines.push(`- 状态：${MESSAGES.DEBUG_FEEDBACK_STATUS_TEXT(feedback.status)}`);
     lines.push(`- 截图：${feedback.screenshots?.length ?? 0} 张`);
     lines.push(`- 日志文件：${feedback.log_file_urls?.length ?? 0} 个`);
+    if (feedback.moment_id) {
+      lines.push(`- moment_id：${feedback.moment_id}`);
+      lines.push(`- TapTap 反馈页：https://www.taptap.cn/moment/${feedback.moment_id}`);
+    }
     if (downloadAssets) {
       lines.push(`- 已下载目录：${files.feedbackDir}`);
       if (files.promptPath) {

--- a/src/features/h5Game/tools.ts
+++ b/src/features/h5Game/tools.ts
@@ -134,6 +134,8 @@ Use the same path confirmed in prepare_h5_upload step.`,
           Let default behavior (true) apply.
         - ONLY pass fetch_and_mark_processed=false when user explicitly requests read-only
           behavior (e.g. "只查看，不标记处理").
+        - When user provides a moment_id (or a TapTap moment URL), pass it via moment_id param to fetch a single feedback.
+          In this case, fetch_and_mark_processed is automatically forced to false (read-only single lookup).
       `,
       inputSchema: {
         type: 'object',
@@ -157,6 +159,15 @@ Use the same path confirmed in prepare_h5_upload step.`,
             description:
               'Whether to download feedback JSON/screenshot/log files to local workspace. Default true.',
           },
+          moment_id: {
+            type: 'string',
+            description:
+              'Optional. Filter to a single feedback by moment_id. ' +
+              'Accepts either a pure numeric ID (e.g. "795659996946762795") or a full TapTap moment URL ' +
+              '(e.g. "https://www.taptap.cn/moment/795659996946762795") — the handler will extract the numeric ID. ' +
+              'When provided, server returns only the matching record, and fetch_and_mark_processed is forced to false (read-only single lookup). ' +
+              'MUST be passed as a string to preserve precision for large IDs.',
+          },
         },
       },
     },
@@ -166,6 +177,7 @@ Use the same path confirmed in prepare_h5_upload step.`,
         status?: number;
         fetch_and_mark_processed?: boolean;
         download_assets?: boolean;
+        moment_id?: string;
       },
       context
     ) => {


### PR DESCRIPTION
## Summary

新增功能（配合后端新增的 moment_id 单查参数）：

- `get_debug_feedbacks` 工具新增可选参数 `moment_id`，透传到 `/open/debug/v1/get-debug-feedbacks` 实现单条反馈精确定位
- 接受纯数字 ID 或完整的 TapTap moment URL（如 `https://www.taptap.cn/moment/{id}`），handler 自动提取数字段
- 传入 `moment_id` 时强制 `fetch_and_mark_processed=false`（read-only 单查，不改服务端反馈状态）
- 无法识别的输入格式返回友好错误，避免污染请求参数
- handler 输出每条反馈的 TapTap 反馈页链接，方便定位玩家原贴

精度修复：

- `response.json()` 会把 `>2^53-1` 的整数解析为有损 number（例：`795659996946762795` → `795659996946762800`），导致 `feedback.json` 落盘后 `moment_id` 不可用，直接影响新单查功能
- `JSON.parse` 的 reviver 在 number 已被解析后执行，**无法挽救精度**
- 改为在 `JSON.parse` 之前对原始文本做预处理：用 state-machine 跳过字符串字面量，把 16+ 位纯整数加引号，避免 IEEE-754 转换
- `HttpClient.RequestOptions` 新增 `parseJson` 选项支持按需注入自定义解析逻辑（向后兼容，未传则保持原 `response.json()` 行为）

## Test plan

- [x] 本地 `npm run build` + `npm run lint` 通过
- [x] state-machine 边界测试：18 位 `moment_id`、字符串内长数字、小数、科学记数法、负数、安全范围内整数 — 全部正确
- [x] `normalizeMomentId` 输入测试：纯数字、带空白、HTTPS/HTTP URL、带 query URL、非法格式 — 全部正确
- [x] 在 Tap 小游戏工程实测拉取反馈，`feedback.json` 中 `moment_id` 与服务端值完全一致
- [x] 后端 `moment_id` 单查参数已上线（merge 前请确认）

🤖 Generated with [Claude Code](https://claude.com/claude-code)