### PR TITLE
ci(claude-review): 改用 vars.ANTHROPIC_BASE_URL 配置

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         env:
-          ANTHROPIC_BASE_URL: https://llm-proxy.tapsvc.com
+          ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           use_sticky_comment: true


### PR DESCRIPTION
## Summary

- 将 `claude-review.yml` 中 `ANTHROPIC_BASE_URL` 从硬编码改为读取 `vars.ANTHROPIC_BASE_URL`
- 便于在不同仓库 / 环境通过 GitHub Actions Variables 灵活配置，无需改代码

## Test plan

- [ ] 在仓库 Settings → Secrets and variables → Actions → Variables 中配置 `ANTHROPIC_BASE_URL`
- [ ] 触发一次 PR review，确认 claude-review workflow 正常运行且使用了配置的 URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)