### PR TITLE
fix(bin): support windows esm entry imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ npx @taptap/instant-games-open-mcp
 - **路径处理**：设置 `TAPTAP_MCP_WORKSPACE_ROOT` 环境变量可以正确解析相对路径（推荐）
   - 如果不设置，相对路径会基于用户 HOME 目录（可能不符合预期）
   - 建议使用绝对路径，或配置 `TAPTAP_MCP_WORKSPACE_ROOT`
+- **Windows 启动报 `Received protocol 'c:'`**：这是旧版本 Windows ESM 动态导入路径兼容问题，请升级到包含该修复的最新版本。
 
 #### OpenHands（推荐 SSE 模式）
 

--- a/bin/instant-games-open-mcp
+++ b/bin/instant-games-open-mcp
@@ -9,7 +9,7 @@
 
 import { join, dirname } from 'node:path';
 import { existsSync, readdirSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 // Get current directory in ESM
 const __filename = fileURLToPath(import.meta.url);
@@ -20,6 +20,7 @@ const packageRoot = join(__dirname, '..');
 
 // Check if compiled version exists
 const distPath = join(packageRoot, 'dist', 'server.js');
+const distUrl = pathToFileURL(distPath).href;
 const nativePath = join(packageRoot, 'dist', 'native');
 
 if (!existsSync(distPath)) {
@@ -52,7 +53,7 @@ if (!existsSync(nativePath)) {
 }
 
 // Start server
-import(distPath).catch(error => {
+import(distUrl).catch(error => {
     console.error('');
     console.error('❌ Failed to start server:', error.message);
     console.error('');

--- a/bin/taptap-mcp-proxy
+++ b/bin/taptap-mcp-proxy
@@ -9,7 +9,7 @@
 
 import { join, dirname } from 'node:path';
 import { existsSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 // Get current directory in ESM
 const __filename = fileURLToPath(import.meta.url);
@@ -20,10 +20,11 @@ const packageRoot = join(__dirname, '..');
 
 // Check if bundled version exists
 const distPath = join(packageRoot, 'dist', 'proxy.js');
+const distUrl = pathToFileURL(distPath).href;
 
 if (existsSync(distPath)) {
     // Use dynamic import for ES Module
-    import(distPath).catch(error => {
+    import(distUrl).catch(error => {
         console.error('❌ Failed to start MCP Proxy:', error);
         process.exit(1);
     });

--- a/docs/AI_SETUP_GUIDE.md
+++ b/docs/AI_SETUP_GUIDE.md
@@ -70,6 +70,7 @@ If MCP fails to connect, check in order:
 1. Config file is in the correct location (Cursor uses `~/.cursor/mcp.json`, not project root) and JSON is valid
 2. `npx --version` works in terminal
 3. Network can reach npm registry (`npm ping`). If blocked, set mirror: `npm config set registry https://registry.npmmirror.com`
+4. On Windows, if the error includes `Received protocol 'c:'`, upgrade to a version that includes the Windows ESM path fix
 
 If the user encounters file path errors (e.g., H5 upload), add `env` to the config:
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -700,6 +700,12 @@ echo $TAPTAP_MCP_SERVER_URL
 
 详见：[PATH_RESOLUTION.md](PATH_RESOLUTION.md)
 
+### 问题 5：Windows 启动时报 `Received protocol 'c:'`
+
+旧版本在 Windows 上可能把 `C:\...` 绝对路径直接传给 ESM 动态导入，导致 Node 将 `c:` 误判为不支持的 URL 协议。
+
+**解决方法**：升级到包含 Windows ESM 路径修复的最新版本，然后重启 MCP 客户端。
+
 ---
 
 ## 监控和维护


### PR DESCRIPTION
## Summary

修复 Windows 下通过 `npx` 启动 MCP 包时报 `Received protocol 'c:'` 的问题。

## Changes

- 将 server bin 入口的动态导入路径转换为 `file://` URL
- 将 proxy bin 入口的动态导入路径转换为 `file://` URL
- 补充 Windows ESM 路径错误的用户排查说明

## Testing

- Windows PowerShell 复现并验证通过
- `node --check bin/instant-games-open-mcp`
- `node --check bin/taptap-mcp-proxy`
- `npm run build`
- `npm run lint`

## Related Issues

无
