### PR TITLE
feat(proxy): 新增 force_inject_progress_token 选项以打通长任务超时重置

### DIFF
--- a/docs/PROXY.md
+++ b/docs/PROXY.md
@@ -1157,6 +1157,7 @@ cat config.json | node proxy.js
     "health_check_interval": 30000,
     "enable_cookie_sticky": true,
     "inject_params_per_call": true,
+    "force_inject_progress_token": false,
     "log": {
       "root": "/tmp/taptap-mcp/logs",
       "enabled": false,
@@ -1198,6 +1199,10 @@ node proxy.js
 - `options.health_check_interval` - 健康检查间隔（毫秒，默认 `30000`）- 定期验证 Server 会话是否有效
 - `options.enable_cookie_sticky` - 启用 Cookie 会话粘性（默认 `true`）- 用于 K8s 多副本部署时的会话粘性
 - `options.inject_params_per_call` - 每次工具调用时注入私有参数（默认 `true`）- 为兼容不同 MCP Server 实现，默认每次调用都注入；如果目标 Server 支持从 Session 获取参数，可设为 `false` 以减少数据传输
+- `options.force_inject_progress_token` - 始终注册 onprogress 回调（默认 `false`）
+  - 仅在 client 未提供 `progressToken` 时生效：proxy 会注册一个空的 onprogress 哨兵，借此触发 SDK 自动给 `proxy → 上游` 出站请求注入 `_meta.progressToken = messageId`，让上游工具发的 `notifications/progress` 能命中 `resetTimeoutOnProgress` 路径，把 `tool_call_timeout` 的 deadline 持续重置
+  - 适用于 client SDK 不支持主动声明 `progressToken`（如旧版 Claude Code）但上游会发 progress 的场景
+  - 默认 `false` 保持向后兼容；显式开启需确认上游工具确实会发 progress，否则该选项不会带来任何效果
 - `options.log` - 日志配置对象（可选）
   - `options.log.root` - 日志根目录（默认 `/tmp/taptap-mcp/logs`）
   - `options.log.enabled` - 是否启用文件日志（默认 `false`）
@@ -1423,6 +1428,7 @@ interface ProxyConfig {
     health_check_interval?: number; // 健康检查间隔（默认 30000ms）
     enable_cookie_sticky?: boolean; // 启用 Cookie 会话粘性（默认 true）
     inject_params_per_call?: boolean; // 每次工具调用时注入私有参数（默认 true）
+    force_inject_progress_token?: boolean; // 始终注册 onprogress 哨兵以注入 outbound progressToken（默认 false；仅在 client 未带 token 时生效）
     log?: {
       root?: string; // 日志根目录（默认 /tmp/taptap-mcp/logs）
       enabled?: boolean; // 是否启用文件日志（默认 false）
@@ -1473,6 +1479,7 @@ function generateProxyConfig(user: User, project: Project, macToken: MacToken): 
       health_check_interval: 30000, // 健康检查间隔 30 秒
       enable_cookie_sticky: true, // 启用 Cookie 会话粘性
       inject_params_per_call: true, // 每次调用都注入私有参数（推荐）
+      // force_inject_progress_token: true, // （可选）对接旧版 Claude Code 等不主动带 progressToken 的 client 时开启，让 SDK 给上游注入 token、命中 reset 路径；默认 false
       log: {
         root: '/var/log/taptap-mcp', // TapCode 环境的日志目录
         enabled: true, // 推荐开启文件日志

--- a/src/mcp-proxy/config.ts
+++ b/src/mcp-proxy/config.ts
@@ -182,6 +182,7 @@ function applyDefaults(config: ProxyConfig): ProxyConfig {
       reset_timeout_on_progress: config.options?.reset_timeout_on_progress ?? true,
       health_check_interval: config.options?.health_check_interval ?? 30000,
       enable_cookie_sticky: config.options?.enable_cookie_sticky ?? true,
+      force_inject_progress_token: config.options?.force_inject_progress_token ?? false,
       log: {
         root: config.options?.log?.root ?? DEFAULT_LOG_ROOT,
         enabled: config.options?.log?.enabled ?? false,

--- a/src/mcp-proxy/config.ts
+++ b/src/mcp-proxy/config.ts
@@ -182,6 +182,7 @@ function applyDefaults(config: ProxyConfig): ProxyConfig {
       reset_timeout_on_progress: config.options?.reset_timeout_on_progress ?? true,
       health_check_interval: config.options?.health_check_interval ?? 30000,
       enable_cookie_sticky: config.options?.enable_cookie_sticky ?? true,
+      inject_params_per_call: config.options?.inject_params_per_call ?? true,
       force_inject_progress_token: config.options?.force_inject_progress_token ?? false,
       log: {
         root: config.options?.log?.root ?? DEFAULT_LOG_ROOT,

--- a/src/mcp-proxy/proxy.ts
+++ b/src/mcp-proxy/proxy.ts
@@ -707,17 +707,27 @@ export class TapTapMCPProxy {
         resetTimeoutOnProgress: this.config.options?.reset_timeout_on_progress ?? true,
       };
 
-      // 如果客户端请求了 progress，设置 onprogress 回调转发通知
-      if (progressToken !== undefined) {
-        callToolOptions.onprogress = (progress) => {
-          extra
-            .sendNotification({
-              method: 'notifications/progress',
-              params: { progressToken, ...progress },
-            })
-            .catch(() => {}); // fire-and-forget，不阻塞工具调用
-        };
-      }
+      // 始终注册 onprogress：让 SDK 自动给 proxy→上游 出站请求注入
+      // _meta.progressToken = messageId（见 @modelcontextprotocol/sdk
+      // shared/protocol.js Protocol.request 中 if (options?.onprogress) 分支）。
+      // 这样上游工具发的 notifications/progress 才能匹配 proxy 这边的 messageId，
+      // 命中 resetTimeoutOnProgress 路径，把 callTool 的 timeout deadline 持续重置。
+      //
+      // 之所以"始终注册"而不是仅在 client 提供 progressToken 时注册：当前 Claude
+      // Code SDK 不会主动带 progressToken，按旧逻辑则 SDK 不注入出站 token，
+      // 上游工具即使周期发 progress 也对不上 messageId，reset 路径形同虚设。
+      //
+      // 客户端没要 progress（progressToken === undefined）时，回调内 return，
+      // 不向 client 转发——只复用 SDK 注入 outbound token 的副作用。
+      callToolOptions.onprogress = (progress) => {
+        if (progressToken === undefined) return;
+        extra
+          .sendNotification({
+            method: 'notifications/progress',
+            params: { progressToken, ...progress },
+          })
+          .catch(() => {}); // fire-and-forget，不阻塞工具调用
+      };
 
       // 检查连接状态
       if (!this.connected) {

--- a/src/mcp-proxy/proxy.ts
+++ b/src/mcp-proxy/proxy.ts
@@ -737,6 +737,15 @@ export class TapTapMCPProxy {
         callToolOptions.onprogress = () => {
           /* noop */
         };
+        // verbose 日志：方便排查"开了开关但上游 progress 仍未生效"的情况
+        // （此时 sentinel 已注册，SDK 会自动给出站请求注入 _meta.progressToken；
+        // 若上游工具实际未发 progress，本开关也不会带来任何效果）
+        if (this.config.options?.verbose) {
+          this.log(
+            'debug',
+            `Sentinel onprogress registered for outbound progressToken injection: tool=${name}`
+          );
+        }
       }
 
       // 检查连接状态

--- a/src/mcp-proxy/proxy.ts
+++ b/src/mcp-proxy/proxy.ts
@@ -707,27 +707,37 @@ export class TapTapMCPProxy {
         resetTimeoutOnProgress: this.config.options?.reset_timeout_on_progress ?? true,
       };
 
-      // 始终注册 onprogress：让 SDK 自动给 proxy→上游 出站请求注入
-      // _meta.progressToken = messageId（见 @modelcontextprotocol/sdk
-      // shared/protocol.js Protocol.request 中 if (options?.onprogress) 分支）。
-      // 这样上游工具发的 notifications/progress 才能匹配 proxy 这边的 messageId，
-      // 命中 resetTimeoutOnProgress 路径，把 callTool 的 timeout deadline 持续重置。
+      // onprogress 注册策略：
       //
-      // 之所以"始终注册"而不是仅在 client 提供 progressToken 时注册：当前 Claude
-      // Code SDK 不会主动带 progressToken，按旧逻辑则 SDK 不注入出站 token，
-      // 上游工具即使周期发 progress 也对不上 messageId，reset 路径形同虚设。
-      //
-      // 客户端没要 progress（progressToken === undefined）时，回调内 return，
-      // 不向 client 转发——只复用 SDK 注入 outbound token 的副作用。
-      callToolOptions.onprogress = (progress) => {
-        if (progressToken === undefined) return;
-        extra
-          .sendNotification({
-            method: 'notifications/progress',
-            params: { progressToken, ...progress },
-          })
-          .catch(() => {}); // fire-and-forget，不阻塞工具调用
-      };
+      // - 如果 client 提供了 progressToken：始终注册并转发给 client（原有行为）。
+      // - 否则按 force_inject_progress_token 配置（默认 false）：
+      //     true  → 注册一个哨兵 onprogress（回调内 return，不向 client 转发），
+      //             目的是触发 @modelcontextprotocol/sdk shared/protocol.js
+      //             Protocol.request 中 \`if (options?.onprogress)\` 副作用——
+      //             让 SDK 自动给 proxy → 上游 出站请求注入
+      //             _meta.progressToken = messageId。这样上游工具发的
+      //             notifications/progress 才能匹配 proxy 这边的 messageId，
+      //             命中 resetTimeoutOnProgress 路径，把 callTool 的 timeout
+      //             deadline 持续重置。适用于 client 端 SDK 不支持主动声明
+      //             progressToken（如旧版 Claude Code）但上游会发 progress 的场景。
+      //     false → 不注册，SDK 不会注入 outbound progressToken，长任务依然受
+      //             tool_call_timeout 限制。保持完全向后兼容。
+      const forceInjectProgressToken = this.config.options?.force_inject_progress_token ?? false;
+      if (progressToken !== undefined) {
+        callToolOptions.onprogress = (progress) => {
+          extra
+            .sendNotification({
+              method: 'notifications/progress',
+              params: { progressToken, ...progress },
+            })
+            .catch(() => {}); // fire-and-forget，不阻塞工具调用
+        };
+      } else if (forceInjectProgressToken) {
+        // 哨兵：仅复用 SDK 注入 outbound token 的副作用，不向 client 转发
+        callToolOptions.onprogress = () => {
+          /* noop */
+        };
+      }
 
       // 检查连接状态
       if (!this.connected) {

--- a/src/mcp-proxy/types.ts
+++ b/src/mcp-proxy/types.ts
@@ -115,6 +115,23 @@ export interface ProxyConfig {
      * 如果目标 Server 支持从 Session 获取这些参数，可设置为 false 以减少数据传输量。
      */
     inject_params_per_call?: boolean;
+    /**
+     * 始终注册 onprogress 回调（默认 false）
+     *
+     * 开启后，即使 client 没有在 callTool 时提供 _meta.progressToken，proxy 也会在
+     * 调用上游时设置一个空的 onprogress 回调。这会触发 @modelcontextprotocol/sdk
+     * shared/protocol.js Protocol.request 中的副作用，让 SDK 自动给 proxy → 上游
+     * 出站请求注入 _meta.progressToken = messageId。上游工具发的
+     * notifications/progress 才能匹配 proxy 这边的 messageId，命中
+     * resetTimeoutOnProgress 路径，把 callTool 的 timeout deadline 持续重置。
+     *
+     * 适用于 client 端 SDK 不支持主动声明 progressToken（如旧版 Claude Code）但
+     * 上游工具会发 progress 的场景。
+     *
+     * 默认 false 保持向后兼容；显式开启需要确认上游工具确实会发 progress，
+     * 否则该选项不会带来任何效果。
+     */
+    force_inject_progress_token?: boolean;
     /** 日志配置 */
     log?: LogConfig;
   };


### PR DESCRIPTION
## 背景

不支持 progress 的 client（如当前 Claude Code SDK）调用 `callTool` 时不会带 `progressToken`。原逻辑里 proxy 只在 client 带 token 时才注册 `onprogress`，导致 SDK 不会给 \`proxy → 上游\` 出站请求注入 `_meta.progressToken`，上游工具即使周期发 `notifications/progress` 也匹配不到 proxy 的 `messageId`，`resetTimeoutOnProgress` 路径形同虚设——长任务必然在 `tool_call_timeout`（默认 300s）触顶。

## 改动

新增 `options.force_inject_progress_token` 配置项（**默认 `false`，完全向后兼容**）。

- **关闭（默认）**：行为与改造前完全一致——只在 client 提供 progressToken 时注册 `onprogress`。
- **开启**：当 client 未提供 token 时额外注册一个哨兵 `onprogress`（noop），借助 `@modelcontextprotocol/sdk` `shared/protocol.js` 中 \`if (options?.onprogress) → 注入 progressToken=messageId\` 的副作用，让 \`proxy → 上游\` 出站请求**始终带 token**。上游工具发的 progress 才能命中 reset 路径，把 callTool deadline 持续重置；TCP/SSE 帧流量也顺路保活反向代理的 idle 计时器。

```ts
const forceInjectProgressToken =
  this.config.options?.force_inject_progress_token ?? false;
if (progressToken !== undefined) {
  callToolOptions.onprogress = (progress) => {
    extra.sendNotification({
      method: 'notifications/progress',
      params: { progressToken, ...progress },
    }).catch(() => {});
  };
} else if (forceInjectProgressToken) {
  // 哨兵：仅复用 SDK 注入 outbound token 的副作用，不向 client 转发
  callToolOptions.onprogress = () => { /* noop */ };
}
```

## 行为对比

| 场景 | 改前 / 默认配置 | 开启 `force_inject_progress_token` |
|---|---|---|
| client 带 token + 上游发 progress | 转发 ✅ / reset ✅ | 转发 ✅ / reset ✅（不变） |
| **client 不带 token** + 上游发 progress | 不转发 ✅ / **reset ❌** | 不转发 ✅ / **reset ✅**（新增能力） |
| client 不带 token + 上游不发 progress | 行为正常 | 行为不变（哨兵 noop 无副作用） |

## 已端到端验证（开启状态下）

环境：本地 \`mcp-sce-urhox\`（docker compose） + Claude Code stdio spawn proxy + 测试用 \`keepalive_test\` 工具（10 分钟，每 60 秒发一次 progress）。

- ✅ 上游日志确认 \`context.sendProgress 可用 = true\`（证明 proxy SDK 注入 outbound \`progressToken\` 起作用）
- ✅ **连续两轮**完整跑满 10 分钟（远超 proxy 默认 \`tool_call_timeout=300s\`），proxy 没抛 timeout
- ✅ 第 5 次 tick (elapsed=300s) 之后工具仍在持续 tick，证明 reset 路径在每次 progress 后刷新 deadline
- ✅ Claude Code 这一侧未收到任何 \`notifications/progress\` 帧（哨兵正确丢弃）

## 已知不在本 PR 范围内

Claude Code SDK 自身的 client-side request timeout 是另一层独立超时，本 PR 不解决。需要 client 端配置 \`MCP_TIMEOUT\` 环境变量或升级到支持 \`onprogress\` 的 SDK 版本来根治。

## 启用方式

在 proxy config 的 \`options\` 里显式开启：

\`\`\`json
{
  "options": {
    "force_inject_progress_token": true
  }
}
\`\`\`

⚠️ 仅在确认上游工具会发 \`notifications/progress\` 时启用，否则该选项不会带来任何效果。

## Test plan

- [x] 与 main 相比零新增 typecheck 错误
- [x] 端到端：开启状态下 keepalive_test 工具 10 分钟跑两轮全部成功
- [x] 上游 \`has_progress_token / context.sendProgress\` 字段证明 token 注入到达
- [x] 默认状态下行为与原 main 完全一致（条件分支保留）
- [ ] 待 reviewer 在 \`tool_call_timeout < 工具实际耗时\` 的真实场景下复测一次

🤖 Generated with [Claude Code](https://claude.com/claude-code)