### PR TITLE
feat(release): add beta preview workflow

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -1,0 +1,471 @@
+name: Beta Release
+
+# Internal preview release flow.
+# Beta packages should feel the same as official packages, so this workflow
+# prepares native signer binaries before publishing to npm @beta.
+# It does not create release PRs or write package.json / CHANGELOG.md changes
+# back to the repository.
+
+on:
+  push:
+    branches:
+      - beta
+  workflow_dispatch:
+
+concurrency:
+  group: beta-release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  id-token: write
+
+env:
+  DEBUG: napi:*
+  MACOSX_DEPLOYMENT_TARGET: '10.13'
+
+jobs:
+  analyze:
+    name: Analyze Beta Release
+    runs-on: ubuntu-latest
+    if: |
+      github.ref_name == 'beta' &&
+      (github.event_name == 'workflow_dispatch' ||
+      (github.event.head_commit != null &&
+       !contains(github.event.head_commit.message, '[skip ci]') &&
+       github.event.head_commit.author.name != 'github-actions[bot]'))
+    outputs:
+      should_release: ${{ steps.analyze.outputs.should_release }}
+      version: ${{ steps.analyze.outputs.version }}
+      native_changed: ${{ steps.native_check.outputs.changed }}
+      has_native_assets: ${{ steps.release_check.outputs.has_assets }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Analyze commits for beta release
+        id: analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SEMANTIC_RELEASE_DRY_RUN: 'true'
+        run: |
+          set -o pipefail
+          npx semantic-release --dry-run --no-ci 2>&1 | tee release-output.txt
+
+          NEW_VERSION=$(grep "\[semantic-release\] .* The next release version is" release-output.txt | sed 's/.*is //' || echo "")
+
+          if [ -z "$NEW_VERSION" ]; then
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            echo "No beta release needed"
+          else
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+            echo "Will publish beta version: $NEW_VERSION"
+          fi
+
+      - name: Check native changes
+        id: native_check
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+          echo "Last reachable tag: $LAST_TAG"
+
+          if [ -z "$LAST_TAG" ]; then
+            echo "No previous tag found, need to build native"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          CHANGED_FILES=$(git diff --name-only "$LAST_TAG" HEAD -- \
+            native/Cargo.toml \
+            native/Cargo.lock \
+            native/src/ \
+            native/build.rs \
+            native/package.json \
+          )
+
+          if [ -n "$CHANGED_FILES" ]; then
+            echo "Native files changed:"
+            echo "$CHANGED_FILES"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No native files changed since $LAST_TAG"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check existing release assets
+        id: release_check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ steps.native_check.outputs.changed }}" == "true" ]; then
+            echo "Native code changed, will rebuild"
+            echo "has_assets=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          LATEST_RELEASE=$(gh release list --repo ${{ github.repository }} --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null || echo "")
+
+          if [ -z "$LATEST_RELEASE" ]; then
+            echo "No existing release found, need to build native"
+            echo "has_assets=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          ASSETS=$(gh release view "$LATEST_RELEASE" --repo ${{ github.repository }} --json assets --jq '.assets[].name' 2>/dev/null | grep "\.node$" || echo "")
+
+          if [ -z "$ASSETS" ]; then
+            echo "No native binaries in release $LATEST_RELEASE, need to build"
+            echo "has_assets=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Found native binaries in $LATEST_RELEASE:"
+            echo "$ASSETS"
+            echo "has_assets=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  build-native:
+    name: Build Native - ${{ matrix.settings.target }}
+    runs-on: ${{ matrix.settings.host }}
+    needs: analyze
+    if: |
+      needs.analyze.outputs.should_release == 'true' &&
+      (needs.analyze.outputs.native_changed == 'true' || needs.analyze.outputs.has_native_assets == 'false')
+
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          - host: macos-14
+            target: x86_64-apple-darwin
+            build: |
+              if ! cargo --version &> /dev/null; then
+                echo "cargo not working, cleaning up and reinstalling Rust..."
+                rm -rf "$HOME/.cargo/bin"
+                rm -f "$HOME/.rustup/settings.toml"
+                curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --target x86_64-apple-darwin
+                source "$HOME/.cargo/env"
+              fi
+              export PATH="$HOME/.cargo/bin:$PATH"
+              echo "cargo version: $(cargo --version)"
+              cd native
+              npm run build
+              strip -x *.node
+
+          - host: macos-latest
+            target: aarch64-apple-darwin
+            build: |
+              export PATH="$CARGO_HOME/bin:$PATH"
+              cd native
+              npm run build -- --target aarch64-apple-darwin
+              strip -x *.node
+
+          - host: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
+            build: |
+              rustup update stable && rustup default stable
+              cd native
+              npm run build -- --target x86_64-unknown-linux-gnu
+              strip *.node
+
+          - host: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+            build: |
+              rustup update stable && rustup default stable
+              cd native
+              npm run build -- --target x86_64-unknown-linux-musl
+              strip *.node
+
+          - host: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+            build: |
+              apk add --no-cache zig
+              rustup update stable && rustup default stable
+              rustup target add aarch64-unknown-linux-musl
+              cd native
+              npm run build -- --target aarch64-unknown-linux-musl --zig
+              llvm-strip *.node 2>/dev/null || aarch64-linux-gnu-strip *.node 2>/dev/null || echo "Skip strip for cross-compiled binary"
+
+          - host: windows-latest
+            target: x86_64-pc-windows-msvc
+            build: |
+              cd native
+              npm run build
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Rust
+        if: ${{ !matrix.settings.docker }}
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.settings.target }}
+
+      - name: Ensure Cargo in PATH
+        if: ${{ !matrix.settings.docker }}
+        shell: bash
+        run: |
+          echo "$CARGO_HOME/bin" >> "$GITHUB_PATH"
+          echo "Added $CARGO_HOME/bin to PATH"
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            native/target/
+          key: ${{ runner.os }}-cargo-${{ matrix.settings.target }}-${{ hashFiles('native/Cargo.lock') }}
+
+      - name: Install native dependencies
+        run: |
+          cd native
+          npm install
+
+      - name: Build in Docker
+        if: ${{ matrix.settings.docker }}
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ${{ matrix.settings.docker }}
+          options: |
+            --user 0:0
+            -v ${{ github.workspace }}:/build
+            -w /build
+            -e BUILD_CLIENT_ID=${{ secrets.BUILD_CLIENT_ID }}
+            -e BUILD_CLIENT_SECRET=${{ secrets.BUILD_CLIENT_SECRET }}
+          run: ${{ matrix.settings.build }}
+
+      - name: Build
+        if: ${{ !matrix.settings.docker }}
+        shell: bash
+        env:
+          BUILD_CLIENT_ID: ${{ secrets.BUILD_CLIENT_ID }}
+          BUILD_CLIENT_SECRET: ${{ secrets.BUILD_CLIENT_SECRET }}
+        run: ${{ matrix.settings.build }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: beta-bindings-${{ matrix.settings.target }}
+          path: native/*.node
+          if-no-files-found: error
+
+  download-native:
+    name: Download Native from Release
+    runs-on: ubuntu-latest
+    needs: analyze
+    if: |
+      needs.analyze.outputs.should_release == 'true' &&
+      needs.analyze.outputs.native_changed == 'false' &&
+      needs.analyze.outputs.has_native_assets == 'true'
+
+    steps:
+      - name: Download native binaries from latest release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p native
+
+          LATEST_RELEASE=$(gh release list --repo ${{ github.repository }} --limit 1 --json tagName --jq '.[0].tagName')
+          echo "Downloading native binaries from release: $LATEST_RELEASE"
+
+          gh release download "$LATEST_RELEASE" \
+            --repo ${{ github.repository }} \
+            --pattern "*.node" \
+            --dir native/
+
+          echo "=== Downloaded native binaries ==="
+          ls -la native/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: beta-native-from-release
+          path: native/*.node
+          if-no-files-found: error
+
+  publish:
+    name: Publish Beta to npm
+    runs-on: ubuntu-latest
+    environment: npm_publish
+    needs: [analyze, build-native, download-native]
+    if: |
+      always() &&
+      needs.analyze.outputs.should_release == 'true' &&
+      (needs.build-native.result == 'success' || needs.download-native.result == 'success')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download native binaries
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Move native binaries to native/
+        run: |
+          mkdir -p native
+          find artifacts -name "*.node" -exec cp {} native/ \;
+
+          echo "=== Native binaries ==="
+          ls -la native/*.node
+
+      - name: Lint code
+        run: npm run lint
+
+      - name: Check code formatting
+        run: npm run format:check
+
+      - name: Set beta package version
+        run: npm version "${{ needs.analyze.outputs.version }}" --no-git-tag-version
+
+      - name: Build package
+        run: npm run build
+
+      - name: Verify native binaries in package output
+        run: |
+          test -d dist/native
+          test "$(find dist/native -name "*.node" | wc -l | tr -d ' ')" -gt 0
+          find dist/native -maxdepth 1 -name "*.node" -print
+
+      - name: Run tests
+        run: npm test
+
+      - name: Pack beta tarball
+        id: pack
+        run: |
+          TARBALL_DIR="$(mktemp -d)"
+          npm pack --pack-destination "$TARBALL_DIR"
+          TARBALL="$(find "$TARBALL_DIR" -name "*.tgz" -print -quit)"
+
+          if [ -z "$TARBALL" ]; then
+            echo "Failed to create npm tarball"
+            exit 1
+          fi
+
+          echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
+          echo "Packed beta tarball: $TARBALL"
+
+      - name: Publish beta to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          TARBALL="${{ steps.pack.outputs.tarball }}"
+
+          npm publish "$TARBALL" --access public --tag beta --provenance 2>/dev/null \
+            || npm publish "$TARBALL" --access public --tag beta
+
+      - name: Create prerelease tag
+        run: |
+          VERSION="${{ needs.analyze.outputs.version }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${VERSION}" -m "Beta release v${VERSION}"
+          git push origin "v${VERSION}"
+
+      - name: Create GitHub prerelease
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ needs.analyze.outputs.version }}"
+          TARBALL="${{ steps.pack.outputs.tarball }}"
+
+          gh release create "v${VERSION}" \
+            --prerelease \
+            --title "v${VERSION}" \
+            --notes "Internal beta release from \`${GITHUB_REF_NAME}\`." \
+            native/*.node \
+            "$TARBALL"
+
+      - name: Beta release summary
+        run: |
+          VERSION="${{ needs.analyze.outputs.version }}"
+          NATIVE_CHANGED="${{ needs.analyze.outputs.native_changed }}"
+          HAS_ASSETS="${{ needs.analyze.outputs.has_native_assets }}"
+
+          echo "## Beta Release Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Version: ${VERSION}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- npm dist-tag: beta" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Native changed: ${NATIVE_CHANGED}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Reused native assets: ${HAS_ASSETS}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Install: \`npm install @taptap/instant-games-open-mcp@beta\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Run: \`npx -y @taptap/instant-games-open-mcp@beta\`" >> "$GITHUB_STEP_SUMMARY"
+
+  no-release:
+    name: No Beta Release Needed
+    runs-on: ubuntu-latest
+    needs: analyze
+    if: needs.analyze.outputs.should_release == 'false'
+
+    steps:
+      - name: Summary
+        run: |
+          echo "## No Beta Release Needed" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "No beta version was published because commit analysis found no release-worthy changes." >> "$GITHUB_STEP_SUMMARY"
+
+  native-unavailable:
+    name: Native Signer Unavailable
+    runs-on: ubuntu-latest
+    needs: [analyze, build-native, download-native]
+    if: |
+      always() &&
+      needs.analyze.outputs.should_release == 'true' &&
+      needs.build-native.result != 'success' &&
+      needs.download-native.result != 'success'
+
+    steps:
+      - name: Summary
+        run: |
+          echo "## Native Signer Unavailable" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Beta package was not published because native signer binaries could not be prepared." >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+
+  unsupported-ref:
+    name: Unsupported Ref
+    runs-on: ubuntu-latest
+    if: github.ref_name != 'beta'
+
+    steps:
+      - name: Summary
+        run: |
+          echo "## Unsupported Ref" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Beta Release only publishes from the \`beta\` branch." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - beta
       - alpha
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -152,10 +152,11 @@ curl http://localhost:5002/health  # RND
 
 - `get_leaderboard_integration_guide` - 排行榜完整接入工作流指引
 
-#### 信息查询 (2)
+#### 信息查询 (3)
 
 - `get_current_app_info` - 获取当前应用信息
 - `check_environment` - 检查环境配置
+- `get_environment_switch_guide` - 获取 production/RND 环境切换配置指引
 
 #### 认证 (3)
 
@@ -302,6 +303,13 @@ npm test
 - `TAPTAP_MCP_LOG_MAX_DAYS` - 日志保留天数（默认 7）
 
 详细说明请参考 [docs/LOG_SYSTEM.md](docs/LOG_SYSTEM.md)
+
+### 环境切换帮助
+
+如果需要在 AI 对话中切换测试环境，可以让 AI 调用
+`get_environment_switch_guide` 查看配置示例，再更新 MCP 客户端配置中的 `env` 字段。
+RND 环境需要显式配置 `TAPTAP_MCP_CLIENT_ID` 和 `TAPTAP_MCP_CLIENT_SECRET`，
+production 通常使用内置 native signer，无需额外配置。
 
 ### 添加新功能
 

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -128,31 +128,56 @@ git push origin fix/critical-bug
 
 ### 3.3 发布 Beta 版本
 
-```bash
-# 1. 创建或切换到 beta 分支
-git checkout -b beta
+Beta 用于内部预览测试，走独立的 npm `@beta` dist-tag，不会创建 release PR，
+也不会把 `package.json` / `CHANGELOG.md` 的版本变更写回仓库。
+注意：npm 包仍发布到 public registry，`@beta` 不是访问控制；beta 包必须按对外发布标准处理，
+不能包含 RND 凭证、内部账号 Token 或未公开的敏感配置。
 
-# 2. 合并要测试的功能
+```bash
+# 1. 切换到长期 beta 分支（不存在时从 origin/main 创建）
+git fetch origin
+git switch beta || git switch -c beta origin/main
+
+# 2. 先同步 main，再合并要测试的功能分支
+git merge origin/main
 git merge feature/feature-a
 git merge feature/feature-b
 
-# 3. 推送到远程
+# 3. 推送到远程，触发 Beta Release
 git push origin beta
 
-# 4. 自动发布 beta 版本
+# 4. 自动发布 beta 版本到 npm @beta
 # 版本：1.3.0-beta.1
 
 # 5. 用户安装 beta 版本
 npm install @taptap/instant-games-open-mcp@beta
+npx -y @taptap/instant-games-open-mcp@beta
 
-# 6. 测试稳定后，合并到 main
-git checkout main
-git merge beta
-git push origin main
-
-# 7. 发布正式版本
+# 6. 测试稳定后，通过 PR 将对应功能分支合并到 main
+# 7. main 合并后走正式发布流程
 # 版本：1.3.0
 ```
+
+产品侧 MCP 配置可以直接使用 beta 包：
+
+```json
+{
+  "mcpServers": {
+    "taptap-minigame-beta": {
+      "command": "npx",
+      "args": ["-y", "@taptap/instant-games-open-mcp@beta"],
+      "env": {
+        "TAPTAP_MCP_ENV": "rnd",
+        "TAPTAP_MCP_CLIENT_ID": "your_rnd_client_id",
+        "TAPTAP_MCP_CLIENT_SECRET": "your_rnd_client_secret",
+        "TAPTAP_MCP_WORKSPACE_ROOT": "${workspaceFolder}"
+      }
+    }
+  }
+}
+```
+
+> RND 凭证只在 MCP 客户端配置或受控环境变量中注入，不要提交到仓库。
 
 ### 3.4 重要注意事项
 
@@ -280,7 +305,10 @@ npx commitlint --from HEAD~1 --to HEAD
 
 **文件**：`.github/workflows/release.yml`
 
-**触发条件**：PR 合并到 `main` / `beta` / `alpha` 分支后自动运行
+**触发条件**：PR 合并到 `main` / `alpha` 分支后自动运行
+
+> `beta` 使用独立的 `.github/workflows/beta-release.yml`，避免内部预览发布创建
+> release PR 或影响 `main` 正式发版流程。
 
 **执行步骤**：
 
@@ -299,6 +327,30 @@ npx commitlint --from HEAD~1 --to HEAD
 - ⚠️ **不使用 Provenance**（npm Provenance 仅支持 public 仓库，当前仓库为 internal）
 - ✅ 使用 **Automation Token** 绕过 2FA
 - ✅ 完整的 CI/CD 质量检查
+
+### 5.3 Beta 发布工作流
+
+**文件**：`.github/workflows/beta-release.yml`
+
+**触发条件**：推送到 `beta` 分支，或手动运行 workflow
+
+**执行步骤**：
+
+1. 使用 semantic-release dry-run 计算下一个 beta 版本号
+2. 构建或复用 native signer，使 beta 包的 production 体感与正式包一致
+3. 运行 lint、format check、build、test
+4. 将工作区版本临时设置为 beta 版本
+5. 打包并发布到 npm `@beta` dist-tag
+6. 创建 `vX.Y.Z-beta.N` Git tag 和 GitHub prerelease
+
+**设计约束**：
+
+- 不修改 `main` 的正式 release workflow
+- 不创建 release PR
+- 不提交 `package.json` / `CHANGELOG.md`
+- beta 包发布到 public npm，必须视为对外发布产物
+- 内置 production native signer，确保 production 环境开箱即用
+- 不内置 RND 凭证，RND 测试通过 MCP 配置的 `env` 注入
 
 ---
 
@@ -463,11 +515,17 @@ npx semantic-release --dry-run
 **Beta 版本**（测试新特性）：
 
 ```bash
-git checkout -b beta
+git fetch origin
+git switch beta || git switch -c beta origin/main
+git merge origin/main
+git merge feature/feature-a
 git push origin beta
 # 自动发布：1.3.0-beta.1
 npm install @taptap/instant-games-open-mcp@beta
 ```
+
+Beta 发布只用于内部预览测试。测试通过后，应将对应 feature/fix 分支通过 PR 合并到
+`main`，由正式 release workflow 发布 `latest`。
 
 **Alpha 版本**（早期测试）：
 

--- a/docs/MCP_USAGE.md
+++ b/docs/MCP_USAGE.md
@@ -105,6 +105,42 @@ TapTap Minigame MCP Server 是一个基于 [Model Context Protocol (MCP)](https:
 }
 ```
 
+#### 环境切换辅助
+
+MCP 内置 `get_environment_switch_guide` 工具，用于在 AI 对话中获取
+production / RND 的配置示例。你可以直接对 AI 说：
+
+```text
+帮我把 TapTap MCP 切到 RND 环境
+```
+
+AI 应先调用 `get_environment_switch_guide`，再根据返回的步骤修改 MCP 客户端配置中的
+`env` 字段。RND 配置示例：
+
+```json
+{
+  "mcpServers": {
+    "taptap-minigame": {
+      "command": "npx",
+      "args": ["-y", "@taptap/instant-games-open-mcp@beta"],
+      "env": {
+        "TAPTAP_MCP_ENV": "rnd",
+        "TAPTAP_MCP_CLIENT_ID": "your_rnd_client_id",
+        "TAPTAP_MCP_CLIENT_SECRET": "your_rnd_client_secret",
+        "TAPTAP_MCP_WORKSPACE_ROOT": "${workspaceFolder}"
+      }
+    }
+  }
+}
+```
+
+切换后需要重启 MCP 客户端或刷新 MCP server，再调用 `check_environment`
+确认 `TAPTAP_MCP_ENV` 已生效。`TAPTAP_MCP_CLIENT_SECRET` 是敏感信息，
+只应放在本地 MCP 配置或受控环境变量中，不要提交到仓库。
+
+> `@beta` 包也发布在 public npm registry 上，不能把 RND 凭证打进包里。
+> RND 凭证只能由本地 MCP 配置或受控环境变量注入。
+
 ---
 
 ### 接入模式详解
@@ -219,6 +255,7 @@ console.log(result);
 
 - `get_current_app_info`: 获取当前选中的应用信息。**重要：操作前请先检查此项。**
 - `check_environment`: 检查环境变量配置和认证状态。
+- `get_environment_switch_guide`: 获取 production / RND 环境切换配置指引。
 - `start_oauth_authorization`: 开始 OAuth 2.0 授权流程（获取二维码）。
 - `complete_oauth_authorization`: 完成 OAuth 授权（用户扫码后调用）。
 - `list_developers_and_apps`: 列出当前账号下的所有开发者和应用，包含关卡游戏和非关卡游戏。

--- a/src/features/app/handlers.ts
+++ b/src/features/app/handlers.ts
@@ -620,7 +620,89 @@ export async function checkEnvironment(ctx: ResolvedContext): Promise<string> {
       '💡 如需授权，请使用 start_oauth_authorization 工具获取授权链接';
   }
 
+  if (EnvConfig.environment === 'rnd' && (!EnvConfig.clientId || !EnvConfig.clientSecret)) {
+    statusMessage +=
+      '\n\n⚠️  当前是 RND 环境，但 Client ID / Client Secret 未完整配置。\n' +
+      '💡 请调用 get_environment_switch_guide 工具查看 RND MCP 配置示例。';
+  }
+
   return `🔧 环境配置检查结果:\n\n${envResult}${statusMessage}`;
+}
+
+/**
+ * Explain how to switch MCP environment from client configuration.
+ */
+export async function getEnvironmentSwitchGuide(args: {
+  target_environment?: 'rnd' | 'production';
+  package_tag?: string;
+}): Promise<string> {
+  const targetEnv = args.target_environment || 'rnd';
+  const packageName = args.package_tag
+    ? `@taptap/instant-games-open-mcp@${args.package_tag}`
+    : '@taptap/instant-games-open-mcp';
+  const isRnd = targetEnv === 'rnd';
+  const envBlock = isRnd
+    ? `{
+        "TAPTAP_MCP_ENV": "rnd",
+        "TAPTAP_MCP_CLIENT_ID": "your_rnd_client_id",
+        "TAPTAP_MCP_CLIENT_SECRET": "your_rnd_client_secret",
+        "TAPTAP_MCP_WORKSPACE_ROOT": "\${workspaceFolder}"
+      }`
+    : `{
+        "TAPTAP_MCP_ENV": "production",
+        "TAPTAP_MCP_WORKSPACE_ROOT": "\${workspaceFolder}"
+      }`;
+
+  const configSnippet = `{
+  "mcpServers": {
+    "taptap-minigame": {
+      "command": "npx",
+      "args": ["-y", "${packageName}"],
+      "env": ${envBlock}
+    }
+  }
+}`;
+
+  let output = `🌍 TapTap MCP 环境切换指南\n\n`;
+  output += `目标环境：${targetEnv}\n`;
+  output += `当前运行环境：${EnvConfig.environment} (${EnvConfig.endpoints.apiBaseUrl})\n\n`;
+
+  output += `## 需要改哪里\n\n`;
+  output +=
+    '把下面配置写到 MCP 客户端的 server 配置里，也就是和 `command` / `args` 同一级的 `env` 字段。\n';
+  output +=
+    '常见位置：项目根目录 `.mcp.json`、Cursor/VS Code 的 MCP 配置、Claude Desktop 配置。\n\n';
+
+  output += `## 配置示例\n\n`;
+  output += '```json\n';
+  output += `${configSnippet}\n`;
+  output += '```\n\n';
+
+  output += `## AI Agent 操作步骤\n\n`;
+  output += '1. 先读取现有 MCP 配置文件，保留其他 `mcpServers` 配置。\n';
+  output += '2. 找到 TapTap MCP server 条目，只更新它的 `env` 字段。\n';
+  output += '3. 如果没有 TapTap MCP server 条目，按上面的示例新增一个。\n';
+  output += '4. 提醒用户重启 MCP 客户端或刷新 MCP server，会话中的运行环境不会原地热切换。\n';
+  output += '5. 重启后调用 `check_environment` 验证 `TAPTAP_MCP_ENV` 是否已生效。\n\n';
+
+  if (isRnd) {
+    output += `## RND 注意事项\n\n`;
+    output += '- RND 环境强制使用环境变量签名，不走 production native signer。\n';
+    output +=
+      '- `TAPTAP_MCP_CLIENT_ID` / `TAPTAP_MCP_CLIENT_SECRET` 是 RND 客户端凭证，不是用户账号密码。\n';
+    output +=
+      '- `TAPTAP_MCP_CLIENT_SECRET` 属于敏感信息，只能放在受控的本地 MCP 配置或安全环境变量里，不要提交到仓库。\n';
+    output +=
+      '- 如果使用 beta 预览包，可以把 `args` 改为 `["-y", "@taptap/instant-games-open-mcp@beta"]`。\n';
+  } else {
+    output += `## Production 注意事项\n\n`;
+    output +=
+      '- 正式 npm 包通常包含 production native signer，因此一般不需要配置 Client ID / Client Secret。\n';
+    output +=
+      '- 如果显式配置了 `TAPTAP_MCP_CLIENT_ID` / `TAPTAP_MCP_CLIENT_SECRET`，会优先使用环境变量模式。\n';
+  }
+
+  return output;
 }
 
 /**

--- a/src/features/app/tools.ts
+++ b/src/features/app/tools.ts
@@ -39,7 +39,7 @@ export const appTools: ToolRegistration[] = [
     definition: {
       name: 'check_environment',
       description:
-        'Check environment configuration and user authentication status. Use this to verify if TAPTAP_MCP_MAC_TOKEN and TAPTAP_MCP_CLIENT_ID are configured.',
+        'Check environment configuration and user authentication status. Use this to verify the current TAPTAP_MCP_ENV, signer mode, TAPTAP_MCP_MAC_TOKEN, and TAPTAP_MCP_CLIENT_ID configuration. If the user asks how to switch between production and RND, call get_environment_switch_guide.',
       inputSchema: {
         type: 'object',
         properties: {},
@@ -47,6 +47,34 @@ export const appTools: ToolRegistration[] = [
     },
     handler: async (args, context) => {
       return appHandlers.checkEnvironment(context);
+    },
+  },
+
+  // 🌍 Environment Switch Guide
+  {
+    definition: {
+      name: 'get_environment_switch_guide',
+      description:
+        '[Setup Guide] Explain how to switch this MCP server between production and RND environments from an MCP client configuration. Use this when the user asks to switch environment, use RND, test in RND, configure TAPTAP_MCP_ENV, or asks why RND needs TAPTAP_MCP_CLIENT_ID / TAPTAP_MCP_CLIENT_SECRET. This tool returns client config snippets and agent steps; it does not modify files by itself.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          target_environment: {
+            type: 'string',
+            enum: ['rnd', 'production'],
+            description:
+              'Target environment to explain. Use rnd for testing/internal preview. Default: rnd.',
+          },
+          package_tag: {
+            type: 'string',
+            description:
+              'Optional npm package tag or version to show in examples, such as beta, latest, or 1.21.0. Default: current package without tag.',
+          },
+        },
+      },
+    },
+    handler: async (args: { target_environment?: 'rnd' | 'production'; package_tag?: string }) => {
+      return appHandlers.getEnvironmentSwitchGuide(args);
     },
   },
 


### PR DESCRIPTION
## 改动内容
- 新增 Beta Release workflow，发布 npm @beta 并准备 native signer
- 从正式 release workflow 移除 beta 触发，避免影响 main 正式发版
- 新增 MCP 环境切换帮助工具与文档，支持 RND/production 配置指引

## 验证
- npm run format:check
- npm run lint
- npm run build
- npm test
- git diff --check

## 注意
- @beta 发布到 public npm，不能内置 RND 凭证
- RND 测试仍通过 MCP 客户端 env 注入 CLIENT_ID/CLIENT_SECRET