### PR TITLE
fix(release): ensure unique beta prerelease versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -670,8 +670,48 @@ jobs:
       - name: Check code formatting
         run: npm run format:check
 
+      - name: Resolve beta package version
+        id: beta_version
+        run: |
+          CURRENT_VERSION="${{ needs.analyze.outputs.version }}"
+
+          if ! npm view "@taptap/instant-games-open-mcp@${CURRENT_VERSION}" version >/dev/null 2>&1; then
+            echo "version=${CURRENT_VERSION}" >> "$GITHUB_OUTPUT"
+            echo "semantic_version=${CURRENT_VERSION}" >> "$GITHUB_OUTPUT"
+            echo "Using semantic-release beta version: ${CURRENT_VERSION}"
+            exit 0
+          fi
+
+          BASE_VERSION="${CURRENT_VERSION%%-beta.*}"
+          if [ "$BASE_VERSION" = "$CURRENT_VERSION" ]; then
+            echo "Expected beta prerelease version, got: ${CURRENT_VERSION}"
+            exit 1
+          fi
+
+          VERSIONS_JSON="$(npm view "@taptap/instant-games-open-mcp" versions --json)"
+          RESOLVED_VERSION="$(
+            BASE_VERSION="$BASE_VERSION" VERSIONS_JSON="$VERSIONS_JSON" node -e '
+              const versions = JSON.parse(process.env.VERSIONS_JSON || "[]");
+              const base = process.env.BASE_VERSION;
+              const escapedBase = base.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+              const pattern = new RegExp(`^${escapedBase}-beta\\.(\\d+)$`);
+              let max = 0;
+              for (const version of versions) {
+                const match = pattern.exec(version);
+                if (match) {
+                  max = Math.max(max, Number(match[1]));
+                }
+              }
+              console.log(`${base}-beta.${max + 1}`);
+            '
+          )"
+
+          echo "version=${RESOLVED_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "semantic_version=${CURRENT_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "semantic-release proposed ${CURRENT_VERSION}, already exists; using ${RESOLVED_VERSION}"
+
       - name: Set beta package version
-        run: npm version "${{ needs.analyze.outputs.version }}" --no-git-tag-version
+        run: npm version "${{ steps.beta_version.outputs.version }}" --no-git-tag-version
 
       - name: Build package
         run: npm run build
@@ -704,20 +744,20 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          VERSION="${{ needs.analyze.outputs.version }}"
+          VERSION="${{ steps.beta_version.outputs.version }}"
           TARBALL="${{ steps.pack.outputs.tarball }}"
 
           if npm view "@taptap/instant-games-open-mcp@${VERSION}" version >/dev/null 2>&1; then
-            echo "Version ${VERSION} already exists on npm, ensuring beta dist-tag"
-            npm dist-tag add "@taptap/instant-games-open-mcp@${VERSION}" beta
-          else
-            npm publish "$TARBALL" --access public --tag beta --provenance 2>/dev/null \
-              || npm publish "$TARBALL" --access public --tag beta
+            echo "Resolved beta version ${VERSION} already exists on npm"
+            exit 1
           fi
+
+          npm publish "$TARBALL" --access public --tag beta --provenance 2>/dev/null \
+            || npm publish "$TARBALL" --access public --tag beta
 
       - name: Create prerelease tag
         run: |
-          VERSION="${{ needs.analyze.outputs.version }}"
+          VERSION="${{ steps.beta_version.outputs.version }}"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -733,7 +773,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION="${{ needs.analyze.outputs.version }}"
+          VERSION="${{ steps.beta_version.outputs.version }}"
           TARBALL="${{ steps.pack.outputs.tarball }}"
 
           if gh release view "v${VERSION}" >/dev/null 2>&1; then
@@ -749,13 +789,15 @@ jobs:
 
       - name: Beta release summary
         run: |
-          VERSION="${{ needs.analyze.outputs.version }}"
+          VERSION="${{ steps.beta_version.outputs.version }}"
+          SEMANTIC_VERSION="${{ steps.beta_version.outputs.semantic_version }}"
           NATIVE_CHANGED="${{ needs.analyze.outputs.native_changed }}"
           HAS_ASSETS="${{ needs.analyze.outputs.has_native_assets }}"
 
           echo "## Beta Release Summary" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- Version: ${VERSION}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Semantic-release version: ${SEMANTIC_VERSION}" >> "$GITHUB_STEP_SUMMARY"
           echo "- npm dist-tag: beta" >> "$GITHUB_STEP_SUMMARY"
           echo "- Native changed: ${NATIVE_CHANGED}" >> "$GITHUB_STEP_SUMMARY"
           echo "- Reused native assets: ${HAS_ASSETS}" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -336,12 +336,13 @@ npx commitlint --from HEAD~1 --to HEAD
 
 **执行步骤**：
 
-1. 使用 semantic-release dry-run 计算下一个 beta 版本号
+1. 使用 semantic-release dry-run 计算候选 beta 版本号
 2. 构建或复用 native signer，使 beta 包的 production 体感与正式包一致
 3. 运行 lint、format check、build、test
-4. 将工作区版本临时设置为 beta 版本
-5. 打包并发布到 npm `@beta` dist-tag
-6. 创建 `vX.Y.Z-beta.N` Git tag 和 GitHub prerelease
+4. 如果候选 beta 版本已存在于 npm，自动递增到下一个 `beta.N`
+5. 将工作区版本临时设置为最终 beta 版本
+6. 打包并发布到 npm `@beta` dist-tag
+7. 创建 `vX.Y.Z-beta.N` Git tag 和 GitHub prerelease
 
 **设计约束**：
 
@@ -349,6 +350,7 @@ npx commitlint --from HEAD~1 --to HEAD
 - 不创建 release PR
 - 不提交 `package.json` / `CHANGELOG.md`
 - 复用现有 release workflow 文件名，以匹配 npm Trusted Publishing 配置
+- beta 版本号必须是 npm 上未发布过的新版本，不能只刷新 dist-tag
 - beta 包发布到 public npm，必须视为对外发布产物
 - 内置 production native signer，确保 production 环境开箱即用
 - 不内置 RND 凭证，RND 测试通过 MCP 配置的 `env` 注入


### PR DESCRIPTION
## Summary

- resolve a fresh npm beta version before packing and publishing
- prevent successful beta runs from only refreshing an existing dist-tag
- document the beta.N collision handling in CI/CD docs

## Verification

- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'
- ./node_modules/.bin/prettier --check .github/workflows/release.yml docs/CI_CD.md
- npm version resolver check returned 1.22.0-beta.2 for current npm state