### PR TITLE
fix(maker): scope client id fallback to rnd and beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ maker_push_current_directory
 - Maker MCP 依赖用户本机已有 Git。工具只检测并给出安装引导，不会代替用户安装 Git。
 - 如果 `maker_status` 或 `maker_check_environment` 显示 Git 缺失，必须持续提示用户自行安装 Git；在 `git --version` 可用前，不执行 clone、fetch、commit 或 push。
 - Tap 登录仍保留在默认初始化流程中，远端 Maker MCP tools 需要 Tap token 认证；`maker_list_apps` 和 `maker_clone_to_current_directory` 会在缺少 Tap auth 时停止并要求先登录。
+- Maker Tap 登录只需要 client id；`rnd` 环境或 npm `@beta` 包会使用内置 Maker client id 兜底，不要求产品配置 `TAPTAP_MCP_CLIENT_SECRET`。
 - 当前 JWT 过渡方案：引导用户在 Chrome 打开当前环境的 Maker 网页（production 为 `https://maker.taptap.cn/`，rnd 为 `https://fuping.agnt.xd.com`），进入 DevTools -> Application -> Local storage，找到 `taptap_access_token` 并拿到它的 value 给 Agent，再作为 `manual_jwt` 传给 `maker_exchange_jwt`。
 - MCP 会把 JWT 保存到用户级本地文件 `~/.taptap-maker/jwt.json`；也兼容 `JWT` / `MAKER_JWT` 环境变量。
 - Maker app 必须先通过 `maker_list_apps` 展示给用户选择，再调用 clone。

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -74,6 +74,16 @@ PAT-first 后端能力完成前，Maker 本地 MCP 需要准备两类授权：
 - Tap token：通过 `maker_tap_login_start` / `maker_tap_login_complete` 获取，供远端 Maker MCP tools 使用。
 - Maker JWT：从 Maker 网页已登录态中复制，供 Maker API、项目列表和 Git PAT 流程使用。
 
+Maker Tap 登录只需要 `client_id` 发起 device code flow，不需要 `CLIENT_SECRET` 参与
+`X-Tap-Sign`。默认情况下：
+
+- 如果显式配置了 `TAPTAP_MCP_CLIENT_ID`，直接使用它。
+- 如果配置了 `TAPTAP_MAKER_CLIENT_ID`，Maker 登录会把它作为 Maker 专用 client id。
+- 如果没有配置 client id，且当前是 `TAPTAP_MCP_ENV=rnd` 或 npm `@beta` 包，
+  Maker MCP 使用内置 Maker client id 兜底，方便内部 RND/beta 测试。
+- 稳定 production 包在 production 环境下不使用内置 Maker client id 兜底，会继续走
+  production native signer 或显式环境变量。
+
 JWT 获取步骤：
 
 ```text
@@ -237,6 +247,7 @@ push
 | `MAKER_PROJECT_ID`                   | MCP server 项目识别的环境变量覆盖                 |
 | `MAKER_JWT_EXCHANGE_URL`             | Tap OAuth token 换 Maker JWT 的接口               |
 | `TAPTAP_MCP_ENV`                     | Maker 环境选择，`production` 或 `rnd`             |
+| `TAPTAP_MAKER_CLIENT_ID`             | 可选：覆盖 Maker Tap 登录专用 client id           |
 | `TAPTAP_MAKER_API_BASE`              | 可选：覆盖当前环境的 Maker 项目列表接口 base URL  |
 | `TAPTAP_MAKER_PAT_URL`               | 可选：覆盖当前环境的 Maker PAT 换取接口           |
 | `TAPTAP_MAKER_GIT_BASE`              | 可选：覆盖当前环境的 Maker git base URL           |

--- a/src/__tests__/makerClientIdFallback.test.ts
+++ b/src/__tests__/makerClientIdFallback.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Maker client_id fallback tests.
+ */
+
+import { ensureMakerClientId, resolveMakerClientIdFallback } from '../maker/auth/oauth';
+
+describe('maker client id fallback', () => {
+  const originalTapTapClientId = process.env.TAPTAP_MCP_CLIENT_ID;
+  const originalMakerClientId = process.env.TAPTAP_MAKER_CLIENT_ID;
+  const originalEnv = process.env.TAPTAP_MCP_ENV;
+
+  afterEach(() => {
+    restoreEnv('TAPTAP_MCP_CLIENT_ID', originalTapTapClientId);
+    restoreEnv('TAPTAP_MAKER_CLIENT_ID', originalMakerClientId);
+    restoreEnv('TAPTAP_MCP_ENV', originalEnv);
+  });
+
+  test('uses explicit Maker client id before built-in fallback', () => {
+    expect(
+      resolveMakerClientIdFallback({
+        environment: 'rnd',
+        makerClientId: 'maker-client-from-env',
+      })
+    ).toBe('maker-client-from-env');
+  });
+
+  test('uses built-in Maker client id in RND', () => {
+    expect(resolveMakerClientIdFallback({ environment: 'rnd', version: '1.22.0' })).toBe(
+      'aznqn4vrze30loq6o8'
+    );
+  });
+
+  test('uses built-in Maker client id for beta packages', () => {
+    expect(
+      resolveMakerClientIdFallback({ environment: 'production', version: '1.22.0-beta.2' })
+    ).toBe('aznqn4vrze30loq6o8');
+  });
+
+  test('does not use built-in Maker client id for stable production packages', () => {
+    expect(
+      resolveMakerClientIdFallback({ environment: 'production', version: '1.22.0' })
+    ).toBeUndefined();
+  });
+
+  test('does not override an existing TapTap MCP client id', () => {
+    process.env.TAPTAP_MCP_ENV = 'rnd';
+    process.env.TAPTAP_MCP_CLIENT_ID = 'existing-client-id';
+    delete process.env.TAPTAP_MAKER_CLIENT_ID;
+
+    ensureMakerClientId();
+
+    expect(process.env.TAPTAP_MCP_CLIENT_ID).toBe('existing-client-id');
+  });
+
+  test('sets TapTap MCP client id from built-in Maker fallback in RND', () => {
+    process.env.TAPTAP_MCP_ENV = 'rnd';
+    delete process.env.TAPTAP_MCP_CLIENT_ID;
+    delete process.env.TAPTAP_MAKER_CLIENT_ID;
+
+    ensureMakerClientId();
+
+    expect(process.env.TAPTAP_MCP_CLIENT_ID).toBe('aznqn4vrze30loq6o8');
+  });
+});
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+
+  process.env[key] = value;
+}

--- a/src/maker/auth/oauth.ts
+++ b/src/maker/auth/oauth.ts
@@ -10,9 +10,12 @@ import { exchangeTapTokenForMakerJwt } from './jwt.js';
 import type { MakerTapAuth, MakerTapDeviceSession } from '../types.js';
 import { loadTapDeviceSession, saveTapAuth, saveTapDeviceSession } from '../storage.js';
 
-const DEFAULT_MAKER_CLIENT_ID = 'aznqn4vrze30loq6o8';
+declare const __MAKER_VERSION__: string | undefined;
+
+const BUILT_IN_MAKER_CLIENT_ID = 'aznqn4vrze30loq6o8';
 const MAKER_CLIENT_ID_ENV = 'TAPTAP_MAKER_CLIENT_ID';
 const TAPTAP_CLIENT_ID_ENV = 'TAPTAP_MCP_CLIENT_ID';
+const MAKER_VERSION = typeof __MAKER_VERSION__ !== 'undefined' ? __MAKER_VERSION__ : 'dev';
 
 export async function startTapDeviceLogin(): Promise<MakerTapDeviceSession> {
   ensureMakerClientId();
@@ -82,10 +85,36 @@ export async function loginWithTapDeviceFlow(): Promise<string> {
   return `✓ Logged in${jwt.user_name ? ` as ${jwt.user_name}` : ''}`;
 }
 
-function ensureMakerClientId(): void {
+export function resolveMakerClientIdFallback(options?: {
+  environment?: 'production' | 'rnd';
+  version?: string;
+  makerClientId?: string;
+}): string | undefined {
+  const explicitMakerClientId = options?.makerClientId || process.env[MAKER_CLIENT_ID_ENV];
+  if (explicitMakerClientId) {
+    return explicitMakerClientId;
+  }
+
+  const environment = options?.environment || EnvConfig.environment;
+  const version = options?.version || MAKER_VERSION;
+  if (environment === 'rnd' || isBetaMakerPackage(version)) {
+    return BUILT_IN_MAKER_CLIENT_ID;
+  }
+
+  return undefined;
+}
+
+export function ensureMakerClientId(): void {
   if (process.env[TAPTAP_CLIENT_ID_ENV]) {
     return;
   }
 
-  process.env[TAPTAP_CLIENT_ID_ENV] = process.env[MAKER_CLIENT_ID_ENV] || DEFAULT_MAKER_CLIENT_ID;
+  const makerClientId = resolveMakerClientIdFallback();
+  if (makerClientId) {
+    process.env[TAPTAP_CLIENT_ID_ENV] = makerClientId;
+  }
+}
+
+function isBetaMakerPackage(version: string): boolean {
+  return /-beta(?:\.|$)/.test(version);
 }


### PR DESCRIPTION
## Summary

- add a Maker-only client id fallback for RND and beta package runs
- keep explicit TAPTAP_MCP_CLIENT_ID and TAPTAP_MAKER_CLIENT_ID overrides
- avoid using the built-in fallback for stable production package runs
- document the Maker-only auth behavior and add regression tests

## Notes

- This does not hardcode CLIENT_SECRET.
- This does not change the main OpenAPI signer path.
- Maker Tap login only needs client_id for device authorization.

## Verification

- npm test -- --runTestsByPath src/__tests__/makerClientIdFallback.test.ts
- npm test
- npm run lint
- npm run format:check
- npm run build
