### PR TITLE
fix(maker): use maker rnd client id fallback

### DIFF
--- a/src/__tests__/makerClientIdFallback.test.ts
+++ b/src/__tests__/makerClientIdFallback.test.ts
@@ -26,14 +26,14 @@ describe('maker client id fallback', () => {
 
   test('uses built-in Maker client id in RND', () => {
     expect(resolveMakerClientIdFallback({ environment: 'rnd', version: '1.22.0' })).toBe(
-      'aznqn4vrze30loq6o8'
+      'm2dnabebip3fpardnm'
     );
   });
 
   test('uses built-in Maker client id for beta packages', () => {
     expect(
       resolveMakerClientIdFallback({ environment: 'production', version: '1.22.0-beta.2' })
-    ).toBe('aznqn4vrze30loq6o8');
+    ).toBe('m2dnabebip3fpardnm');
   });
 
   test('does not use built-in Maker client id for stable production packages', () => {
@@ -59,7 +59,7 @@ describe('maker client id fallback', () => {
 
     ensureMakerClientId();
 
-    expect(process.env.TAPTAP_MCP_CLIENT_ID).toBe('aznqn4vrze30loq6o8');
+    expect(process.env.TAPTAP_MCP_CLIENT_ID).toBe('m2dnabebip3fpardnm');
   });
 });
 

--- a/src/maker/auth/oauth.ts
+++ b/src/maker/auth/oauth.ts
@@ -12,7 +12,7 @@ import { loadTapDeviceSession, saveTapAuth, saveTapDeviceSession } from '../stor
 
 declare const __MAKER_VERSION__: string | undefined;
 
-const BUILT_IN_MAKER_CLIENT_ID = 'aznqn4vrze30loq6o8';
+const BUILT_IN_MAKER_CLIENT_ID = 'm2dnabebip3fpardnm';
 const MAKER_CLIENT_ID_ENV = 'TAPTAP_MAKER_CLIENT_ID';
 const TAPTAP_CLIENT_ID_ENV = 'TAPTAP_MCP_CLIENT_ID';
 const MAKER_VERSION = typeof __MAKER_VERSION__ !== 'undefined' ? __MAKER_VERSION__ : 'dev';


### PR DESCRIPTION
## Summary

- update the Maker-only built-in RND client id fallback
- keep the fallback scoped to `taptap-maker`
- keep explicit `TAPTAP_MCP_CLIENT_ID` and `TAPTAP_MAKER_CLIENT_ID` overrides unchanged

## Scope

- `src/maker/auth/oauth.ts` is only referenced by the Maker MCP server and tests.
- This does not change the main MCP server, HttpClient, native signer, or OpenAPI signing flow.
- This does not hardcode `CLIENT_SECRET`.

## Verification

- npm test -- --runTestsByPath src/__tests__/makerClientIdFallback.test.ts
- npm run lint
- npm run format:check
- npm run build
