### PR TITLE
fix(maker): harden clone and proxy handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ maker_push_current_directory
 - “帮我提交代码到maker / taptap制造 / tap制造 / tap”也应触发 `maker_submit_current_directory`。
 - Maker 项目提交不走通用 Git skill 的任务号、新分支规则；冲突时先和用户确认 pull/rebase 流程。
 - 如果 commit 已完成但 push 失败，Maker MCP 会返回 commit hash、ahead 状态、exit code、stderr/stdout 和下一步建议，便于开发期排查。
+- clone/fetch、push 和远端 build 属于慢操作；工具会尽量发送 MCP progress notification，Git 阶段会解析 stderr 百分比，最终返回会包含耗时和最近进度。
 
 Git 引导：
 

--- a/README.md
+++ b/README.md
@@ -72,12 +72,15 @@ maker_push_current_directory
 - 保存 PAT 后会自动列出 app；`maker_status` 如果发现本地已有 PAT 且当前目录未绑定，也会自动列出 app，无需用户额外要求。
 - 保存 PAT 后会自动调用 `GET /api/v1/user/taptap-token` 获取并保存 TapTap MAC token；Tap OAuth 登录只作为 legacy fallback。
 - `maker_list_apps` 和 `maker_clone_to_current_directory` 不再要求先完成 Tap 登录。
+- `maker_clone_to_current_directory` 不要求当前目录为空；clone 前会检查本地目录，忽略 `.claude`、`.mcp`、`.skill`、`.config`、`.ini` 等点开头配置项，只对普通本地文件输出提醒。clone 最终结果固定包含 `Pre-clone local directory check` 区块；已有本地文件会保留，若与 Maker 项目文件同路径冲突则失败并列出冲突文件。
+- `maker_list_apps` 会解析 Maker `/apps` 返回的创建时间、最近会话时间、游戏类型、阶段、图标、置顶/归档/删除时间等字段，并保留原始 `raw` 数据。
 - Maker Tap 登录只需要 client id；`rnd` 环境或 npm `@beta` 包会使用内置 Maker client id 兜底，不要求产品配置 `TAPTAP_MCP_CLIENT_SECRET`。
 - PAT 会保存到 `~/.taptap-maker/pat.json`，并兼容旧的 `~/.maker-pat`、`PAT` / `MAKER_PAT` 环境变量。
 - JWT 仅作为 legacy fallback 保留：`maker_exchange_jwt(manual_jwt)`、`JWT` / `MAKER_JWT` 仍可用于旧后端或创建新 PAT。
 - Maker app 必须先通过 `maker_list_apps` 展示给用户选择，再调用 clone。
 - Maker 后端地址按 `TAPTAP_MCP_ENV` 从 `src/maker/config.ts` 的环境配置表读取，本地 MCP 配置只需要切 `rnd` / `production`。
 - 如果用户直接说“构建 / build / 重新构建游戏”，本地 Maker MCP 应调用 `maker_build_current_directory` 转发到远端 `build` tool。
+- 构建转发会从 MCP 包自身定位 `dist/proxy.js`；`cwd` / `target_dir` 只用于识别 Maker 游戏项目，不要求游戏目录存在 MCP 的 `dist/proxy.js`。
 - 如需在当前游戏项目里直接暴露远端全量 `taptap-proxy` tools，再使用 `maker_configure_remote_proxy` 写入 `.mcp.json` 并重启 MCP 会话。
 - 用户说“帮我提交/提交代码”时使用 `maker_submit_current_directory`，会对当前 Maker 项目执行 commit + push。
 - “帮我提交代码到maker / taptap制造 / tap制造 / tap”也应触发 `maker_submit_current_directory`。

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -85,6 +85,13 @@ maker_status
 - `maker_submit_current_directory`：用户说“帮我提交”“提交代码”时使用，提交并推送当前 Maker 项目。如果本机没有 Git，工具会在 stage/commit/push 前停止。
 - `maker_push_current_directory`：把当前目录改动 commit 并 push 到 Maker git。如果本机没有 Git，工具会在 stage/commit/push 前停止。
 
+进度和耗时：
+
+- `maker_clone_to_current_directory` 会解析 Git clone/fetch stderr 中的百分比进度；如果客户端支持 MCP progress notification，会实时显示进度。
+- `maker_push_current_directory` / `maker_submit_current_directory` 会在 stage、commit、push 阶段输出状态，并解析 Git push stderr 中的百分比进度。
+- `maker_build_current_directory` 会转发远端 build tool 的 progress notification。
+- 以上慢操作最终返回都会包含 `elapsed_ms`、`elapsed`、`progress_events` 和 `last_progress`。如果没有可用百分比进度，则至少返回耗时统计；长任务运行超过 3 分钟时会发送一次仍在运行的 progress heartbeat。
+
 ## 当前 PAT 获取方式
 
 Maker 本地 MCP 默认使用 PAT-first 流程：

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -78,12 +78,19 @@ maker_status
 - `maker_tap_login_complete`：legacy fallback，用户扫码后轮询 Tap token，保存 MAC 认证数据。
 - `maker_exchange_pat`：接收用户提供的 Maker PAT，以 `manual_pat` 传入后保存到本地 `~/.taptap-maker/pat.json`，并兼容旧的 `~/.maker-pat`；保存后会自动获取 TapTap token 并列出 app。
 - `maker_status`：如果发现本地已有 PAT 但缺少 TapTap token，会自动尝试获取；如果当前目录未绑定，会自动列出 app，不需要用户额外要求。
-- `maker_list_apps`：优先用 Maker PAT 拉取 app 列表，必须展示给用户选择；JWT 仅作为 legacy fallback。
-- `maker_clone_to_current_directory`：把选中的 Maker app 仓库拉到当前目录并写 `.maker-mcp/config.json`。如果本机没有 Git，工具会在申请 PAT 和改动文件前停止。
+- `maker_list_apps`：优先用 Maker PAT 拉取 app 列表，必须展示给用户选择；JWT 仅作为 legacy fallback。会解析 Maker `/apps` 返回的创建时间、最近会话时间、游戏类型、阶段、图标、置顶/归档/删除时间等字段，并保留原始 `raw` 数据。
+- `maker_clone_to_current_directory`：把选中的 Maker app 仓库拉到当前目录并写 `.maker-mcp/config.json`。如果本机没有 Git，工具会在申请 PAT 和改动文件前停止。当前目录不要求为空；clone 前会检查本地目录，忽略 `.claude`、`.mcp`、`.skill`、`.config`、`.ini` 等点开头配置项，只对普通本地文件输出提醒。clone 最终结果固定包含 `Pre-clone local directory check` 区块；已有本地文件会保留，若与 Maker 项目文件同路径冲突则失败并列出冲突文件。
 - `maker_configure_remote_proxy`：按 server 测试脚本生成 `proxy_cfg`，写入当前项目 `.mcp.json`，连接远端 `taptap-proxy`。
-- `maker_build_current_directory`：用户说“构建 / build / 重新构建游戏”时使用，转发调用远端 `build` tool。
+- `maker_build_current_directory`：用户说“构建 / build / 重新构建游戏”时使用，转发调用远端 `build` tool。构建转发会从 MCP 包自身定位 `dist/proxy.js`；`cwd` / `target_dir` 只用于识别 Maker 游戏项目，不要求游戏目录存在 MCP 的 `dist/proxy.js`。
 - `maker_submit_current_directory`：用户说“帮我提交”“提交代码”时使用，提交并推送当前 Maker 项目。如果本机没有 Git，工具会在 stage/commit/push 前停止。
 - `maker_push_current_directory`：把当前目录改动 commit 并 push 到 Maker git。如果本机没有 Git，工具会在 stage/commit/push 前停止。
+
+Maker app 列表关键字段：
+
+- `id`：Maker app id。
+- `name`：游戏名称。
+- `createdAt`：创建时间，可用于获取最新创建的游戏。
+- `lastConversationAt`：最后修改时间，可用于获取最近活跃的游戏。
 
 进度和耗时：
 

--- a/scripts/bundle-maker.js
+++ b/scripts/bundle-maker.js
@@ -65,6 +65,7 @@ try {
 // TapTap Maker MCP - Standalone Bundle
 import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
+const __MAKER_BUNDLE_URL__ = import.meta.url;
 `,
     },
     define: {

--- a/src/__tests__/makerCloneBinding.test.ts
+++ b/src/__tests__/makerCloneBinding.test.ts
@@ -10,12 +10,20 @@ import { saveProjectConfig } from '../maker/storage';
 
 describe('maker clone binding safety', () => {
   let tempDir: string;
+  const originalGitBin = process.env.TAPTAP_MAKER_GIT_BIN;
+  const originalGitBase = process.env.TAPTAP_MAKER_GIT_BASE;
+  const originalMakerHome = process.env.TAPTAP_MAKER_HOME;
+  const originalPat = process.env.PAT;
 
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'maker-clone-binding-'));
   });
 
   afterEach(() => {
+    restoreEnv('TAPTAP_MAKER_GIT_BIN', originalGitBin);
+    restoreEnv('TAPTAP_MAKER_GIT_BASE', originalGitBase);
+    restoreEnv('TAPTAP_MAKER_HOME', originalMakerHome);
+    restoreEnv('PAT', originalPat);
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -33,4 +41,152 @@ describe('maker clone binding safety', () => {
       'Please switch to the directory for the existing project, or create/open a new empty directory for the new project.'
     );
   });
+
+  test('warns for non-config local files without blocking clone', async () => {
+    const gitLog = path.join(tempDir, '.test-tools', 'git.log');
+    const fakeGit = createFakeGit(gitLog);
+    process.env.TAPTAP_MAKER_GIT_BIN = fakeGit;
+    process.env.TAPTAP_MAKER_GIT_BASE = 'https://maker.example.test/git';
+    process.env.TAPTAP_MAKER_HOME = path.join(tempDir, 'maker-home');
+    process.env.PAT = 'tmpct_test_pat';
+    fs.mkdirSync(path.join(tempDir, '.claude'), { recursive: true });
+    fs.writeFileSync(path.join(tempDir, '.claude', 'settings.json'), '{}\n', 'utf8');
+    fs.writeFileSync(path.join(tempDir, 'tap.zip'), 'local zip\n', 'utf8');
+
+    const result = await cloneMakerProject({
+      appId: 'new-app',
+      targetDir: tempDir,
+      userId: 'user-1',
+    });
+
+    expect(result.status).toBe('cloned');
+    expect(result.warnings.join('\n')).toContain('Pre-clone notice');
+    expect(result.warnings.join('\n')).toContain('tap.zip');
+    expect(result.warnings.join('\n')).not.toContain('.claude');
+    expect(fs.existsSync(path.join(tempDir, '.git'))).toBe(true);
+    const commands = fs.readFileSync(gitLog, 'utf8');
+    expect(commands).toContain('init ');
+    expect(commands).toContain('fetch origin');
+    expect(commands).toContain('checkout -B main origin/main');
+  });
+
+  test('does not warn for ignored dot-prefixed config entries', async () => {
+    const gitLog = path.join(tempDir, '.test-tools', 'git.log');
+    const fakeGit = createFakeGit(gitLog);
+    process.env.TAPTAP_MAKER_GIT_BIN = fakeGit;
+    process.env.TAPTAP_MAKER_GIT_BASE = 'https://maker.example.test/git';
+    process.env.TAPTAP_MAKER_HOME = path.join(tempDir, 'maker-home');
+    process.env.PAT = 'tmpct_test_pat';
+    fs.mkdirSync(path.join(tempDir, '.claude'), { recursive: true });
+    fs.mkdirSync(path.join(tempDir, '.mcp'), { recursive: true });
+    fs.mkdirSync(path.join(tempDir, '.skill'), { recursive: true });
+    fs.mkdirSync(path.join(tempDir, '.config'), { recursive: true });
+    fs.writeFileSync(path.join(tempDir, '.ini'), 'local config\n', 'utf8');
+
+    const result = await cloneMakerProject({
+      appId: 'new-app',
+      targetDir: tempDir,
+      userId: 'user-1',
+    });
+
+    expect(result.status).toBe('cloned');
+    expect(result.warnings).toEqual([]);
+    expect(fs.existsSync(path.join(tempDir, '.git'))).toBe(true);
+  });
+
+  test('fails when checkout cannot complete after fetch', async () => {
+    const gitLog = path.join(tempDir, '.test-tools', 'git.log');
+    const fakeGit = createFakeGit(gitLog, { remoteFiles: ['scripts/main.lua'] });
+    process.env.TAPTAP_MAKER_GIT_BIN = fakeGit;
+    process.env.TAPTAP_MAKER_GIT_BASE = 'https://maker.example.test/git';
+    process.env.TAPTAP_MAKER_HOME = path.join(tempDir, 'maker-home');
+    process.env.PAT = 'tmpct_test_pat';
+    fs.mkdirSync(path.join(tempDir, 'scripts'), { recursive: true });
+    fs.writeFileSync(path.join(tempDir, 'scripts', 'main.lua'), '-- local file\n', 'utf8');
+
+    await expect(
+      cloneMakerProject({
+        appId: 'new-app',
+        targetDir: tempDir,
+        userId: 'user-1',
+      })
+    ).rejects.toThrow('Conflicting local files:');
+  });
 });
+
+function createFakeGit(logPath: string, options: { remoteFiles?: string[] } = {}): string {
+  fs.mkdirSync(path.dirname(logPath), { recursive: true });
+  const fakeGit = path.join(path.dirname(logPath), 'fake-git.js');
+  fs.writeFileSync(
+    fakeGit,
+    `#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(logPath)}, args.join(' ') + '\\n');
+if (args[0] === '--version') {
+  console.log('git version 2.50.0');
+  process.exit(0);
+}
+let cwd = process.cwd();
+let commandArgs = args;
+if (args[0] === '-C') {
+  cwd = args[1];
+  commandArgs = args.slice(2);
+}
+if (commandArgs[0] === 'rev-parse' && commandArgs[1] === '--git-dir') {
+  if (fs.existsSync(path.join(cwd, '.git'))) {
+    console.log('.git');
+    process.exit(0);
+  }
+  process.exit(1);
+}
+if (commandArgs[0] === 'rev-parse' && commandArgs[1] === '--verify' && commandArgs[2] === 'HEAD') {
+  const headFile = path.join(cwd, '.git', 'FAKE_HEAD_COMMIT');
+  if (fs.existsSync(headFile)) {
+    console.log(fs.readFileSync(headFile, 'utf8'));
+    process.exit(0);
+  }
+  process.exit(1);
+}
+if (commandArgs[0] === 'init') {
+  fs.mkdirSync(path.join(commandArgs[1], '.git'), { recursive: true });
+  process.exit(0);
+}
+if (commandArgs[0] === 'remote' && commandArgs[1] === 'get-url') {
+  process.exit(1);
+}
+if (commandArgs[0] === 'remote' && (commandArgs[1] === 'add' || commandArgs[1] === 'set-url')) {
+  process.exit(0);
+}
+if (commandArgs[0] === 'fetch') {
+  process.exit(0);
+}
+if (commandArgs[0] === 'symbolic-ref') {
+  console.log('origin/main');
+  process.exit(0);
+}
+if (commandArgs[0] === 'ls-tree') {
+  console.log(${JSON.stringify(options.remoteFiles || [])}.join('\\n'));
+  process.exit(0);
+}
+if (commandArgs[0] === 'checkout') {
+  fs.writeFileSync(path.join(cwd, '.git', 'FAKE_HEAD_COMMIT'), '0000000000000000000000000000000000000001');
+  process.exit(0);
+}
+process.exit(0);
+`,
+    'utf8'
+  );
+  fs.chmodSync(fakeGit, 0o755);
+  return fakeGit;
+}
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+
+  process.env[key] = value;
+}

--- a/src/__tests__/makerCloneBinding.test.ts
+++ b/src/__tests__/makerCloneBinding.test.ts
@@ -94,6 +94,27 @@ describe('maker clone binding safety', () => {
     expect(fs.existsSync(path.join(tempDir, '.git'))).toBe(true);
   });
 
+  test('resolves remote default branch when origin head is not set after fetch', async () => {
+    const gitLog = path.join(tempDir, '.test-tools', 'git.log');
+    const fakeGit = createFakeGit(gitLog, { defaultBranch: 'beta', failSymbolicRef: true });
+    process.env.TAPTAP_MAKER_GIT_BIN = fakeGit;
+    process.env.TAPTAP_MAKER_GIT_BASE = 'https://maker.example.test/git';
+    process.env.TAPTAP_MAKER_HOME = path.join(tempDir, 'maker-home');
+    process.env.PAT = 'tmpct_test_pat';
+    fs.writeFileSync(path.join(tempDir, 'tap.zip'), 'local zip\n', 'utf8');
+
+    const result = await cloneMakerProject({
+      appId: 'new-app',
+      targetDir: tempDir,
+      userId: 'user-1',
+    });
+
+    expect(result.status).toBe('cloned');
+    const commands = fs.readFileSync(gitLog, 'utf8');
+    expect(commands).toContain('ls-remote --symref origin HEAD');
+    expect(commands).toContain('checkout -B beta origin/beta');
+  });
+
   test('fails when checkout cannot complete after fetch', async () => {
     const gitLog = path.join(tempDir, '.test-tools', 'git.log');
     const fakeGit = createFakeGit(gitLog, { remoteFiles: ['scripts/main.lua'] });
@@ -114,7 +135,10 @@ describe('maker clone binding safety', () => {
   });
 });
 
-function createFakeGit(logPath: string, options: { remoteFiles?: string[] } = {}): string {
+function createFakeGit(
+  logPath: string,
+  options: { defaultBranch?: string; failSymbolicRef?: boolean; remoteFiles?: string[] } = {}
+): string {
   fs.mkdirSync(path.dirname(logPath), { recursive: true });
   const fakeGit = path.join(path.dirname(logPath), 'fake-git.js');
   fs.writeFileSync(
@@ -163,7 +187,15 @@ if (commandArgs[0] === 'fetch') {
   process.exit(0);
 }
 if (commandArgs[0] === 'symbolic-ref') {
-  console.log('origin/main');
+  if (${JSON.stringify(options.failSymbolicRef === true)}) {
+    process.exit(1);
+  }
+  console.log('origin/${options.defaultBranch || 'main'}');
+  process.exit(0);
+}
+if (commandArgs[0] === 'ls-remote' && commandArgs[1] === '--symref') {
+  console.log('ref: refs/heads/${options.defaultBranch || 'main'}\\tHEAD');
+  console.log('0000000000000000000000000000000000000001\\tHEAD');
   process.exit(0);
 }
 if (commandArgs[0] === 'ls-tree') {

--- a/src/__tests__/makerGitProgress.test.ts
+++ b/src/__tests__/makerGitProgress.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Maker git progress parsing tests.
+ */
+
+import { parseGitProgressLine } from '../maker/cli/projects';
+
+describe('maker git progress parsing', () => {
+  test('parses percent progress from clone and push stderr lines', () => {
+    expect(parseGitProgressLine('Receiving objects: 42% (42/100), 1.23 MiB | 2.34 MiB/s')).toEqual({
+      progress: 42,
+      total: 100,
+      phase: 'git',
+      message: 'Receiving objects: 42% (42/100), 1.23 MiB | 2.34 MiB/s',
+    });
+
+    expect(parseGitProgressLine('Writing objects: 7% (2/28), 512 bytes | 512.00 KiB/s')).toEqual({
+      progress: 7,
+      total: 100,
+      phase: 'git',
+      message: 'Writing objects: 7% (2/28), 512 bytes | 512.00 KiB/s',
+    });
+  });
+
+  test('keeps useful git messages without inventing a percent', () => {
+    expect(parseGitProgressLine("Cloning into '/tmp/game'...")).toEqual({
+      phase: 'git',
+      message: "Cloning into '/tmp/game'...",
+    });
+  });
+});

--- a/src/__tests__/makerProjectsResponse.test.ts
+++ b/src/__tests__/makerProjectsResponse.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Maker app list response normalization tests.
+ */
+
+import { normalizeProjectsResponse } from '../maker/cli/projects';
+
+describe('maker projects response normalization', () => {
+  test('preserves all known app list fields returned by Maker API', () => {
+    const projects = normalizeProjectsResponse({
+      apps: [
+        {
+          archivedAt: null,
+          createdAt: '2026-05-20T08:00:00.000Z',
+          deletedAt: null,
+          gameType: 'single',
+          icon: 1,
+          iconColor: 2,
+          id: 'app-1',
+          lastAccessedAt: null,
+          lastConversationAt: '2026-05-21T08:00:00.000Z',
+          metadata: { source: 'test' },
+          name: 'Test App',
+          pinnedAt: null,
+          stage: 'development',
+          userId: 'user-1',
+        },
+      ],
+    });
+
+    expect(projects[0]).toMatchObject({
+      archivedAt: null,
+      createdAt: '2026-05-20T08:00:00.000Z',
+      deletedAt: null,
+      gameType: 'single',
+      icon: 1,
+      iconColor: 2,
+      id: 'app-1',
+      lastAccessedAt: null,
+      lastConversationAt: '2026-05-21T08:00:00.000Z',
+      metadata: { source: 'test' },
+      name: 'Test App',
+      pinnedAt: null,
+      stage: 'development',
+      userId: 'user-1',
+      user_id: 'user-1',
+    });
+  });
+});

--- a/src/__tests__/makerProxyBundle.test.ts
+++ b/src/__tests__/makerProxyBundle.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Maker proxy bundle resolution tests.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { resolveLocalProxyBundle } from '../maker/server/mcp';
+
+describe('maker proxy bundle resolution', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'maker-proxy-bundle-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('resolves proxy next to bundled maker even when cwd is a Maker game project', () => {
+    const packageDistDir = path.join(tempDir, 'node_modules', 'pkg', 'dist');
+    const gameDir = path.join(tempDir, 'game-project');
+    fs.mkdirSync(packageDistDir, { recursive: true });
+    fs.mkdirSync(gameDir, { recursive: true });
+    const makerBundle = path.join(packageDistDir, 'maker.js');
+    const proxyBundle = path.join(packageDistDir, 'proxy.js');
+    fs.writeFileSync(makerBundle, 'console.log("maker");\n', 'utf8');
+    fs.writeFileSync(proxyBundle, 'console.log("proxy");\n', 'utf8');
+
+    const result = resolveLocalProxyBundle({
+      currentModuleUrl: pathToFileURL(makerBundle).href,
+      makerEntry: path.join(gameDir, 'node_modules', '.bin', 'taptap-maker'),
+      cwd: gameDir,
+    });
+
+    expect(result).toBe(proxyBundle);
+  });
+
+  test('resolves package dist proxy when maker is started through npm bin entry', () => {
+    const binDir = path.join(tempDir, 'bin');
+    const distDir = path.join(tempDir, 'dist');
+    const gameDir = path.join(tempDir, 'game-project');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.mkdirSync(distDir, { recursive: true });
+    fs.mkdirSync(gameDir, { recursive: true });
+    const makerEntry = path.join(binDir, 'taptap-maker');
+    const makerBundle = path.join(tempDir, 'missing-dist', 'maker.js');
+    const proxyBundle = path.join(distDir, 'proxy.js');
+    fs.writeFileSync(makerEntry, '#!/usr/bin/env node\n', 'utf8');
+    fs.writeFileSync(proxyBundle, 'console.log("proxy");\n', 'utf8');
+
+    const result = resolveLocalProxyBundle({
+      currentModuleUrl: pathToFileURL(makerBundle).href,
+      makerEntry,
+      cwd: gameDir,
+    });
+
+    expect(result).toBe(proxyBundle);
+  });
+});

--- a/src/maker/cli/projects.ts
+++ b/src/maker/cli/projects.ts
@@ -1145,6 +1145,15 @@ async function resolveRemoteDefaultBranch(cwd: string): Promise<string> {
     const branch = await readGit(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], cwd);
     return branch.trim().replace(/^origin\//, '') || 'main';
   } catch {
+    // `git fetch origin` in an initialized directory does not always create
+    // refs/remotes/origin/HEAD, so ask the remote directly before falling back.
+  }
+
+  try {
+    const remoteHead = await readGit(['ls-remote', '--symref', 'origin', 'HEAD'], cwd);
+    const match = remoteHead.match(/^ref:\s+refs\/heads\/([^\s]+)\s+HEAD/m);
+    return match?.[1] || 'main';
+  } catch {
     return 'main';
   }
 }

--- a/src/maker/cli/projects.ts
+++ b/src/maker/cli/projects.ts
@@ -22,6 +22,7 @@ export interface CloneMakerProjectOptions {
   patName?: string;
   forcePat?: boolean;
   sceEndpoint?: string;
+  onProgress?: MakerProjectProgressHandler;
 }
 
 export interface CloneMakerProjectResult {
@@ -41,7 +42,17 @@ export interface PushMakerProjectOptions {
   jwt?: string;
   pat?: string;
   forcePat?: boolean;
+  onProgress?: MakerProjectProgressHandler;
 }
+
+export interface MakerProjectProgress {
+  progress?: number;
+  total?: number;
+  message: string;
+  phase?: string;
+}
+
+export type MakerProjectProgressHandler = (progress: MakerProjectProgress) => void;
 
 export interface PushMakerProjectResult {
   branch: string;
@@ -260,6 +271,12 @@ export async function cloneMakerProject(
   options: CloneMakerProjectOptions
 ): Promise<CloneMakerProjectResult> {
   ensureGitAvailable();
+  options.onProgress?.({
+    progress: 0,
+    total: 100,
+    phase: 'prepare',
+    message: `Preparing Maker project ${options.appId}`,
+  });
   const target = path.resolve(options.targetDir);
   ensureTargetCanBindApp(target, options.appId);
   let pat = await requestMakerPat({
@@ -267,6 +284,12 @@ export async function cloneMakerProject(
     pat: options.pat,
     name: options.patName || 'first-pat',
     force: options.forcePat,
+  });
+  options.onProgress?.({
+    progress: 5,
+    total: 100,
+    phase: 'auth',
+    message: 'Maker PAT ready for git authentication',
   });
   const gitBase = getMakerGitBase();
 
@@ -276,10 +299,17 @@ export async function cloneMakerProject(
   let transientRetries = 0;
 
   if (isGitRepo(target)) {
+    options.onProgress?.({
+      progress: 10,
+      total: 100,
+      phase: 'fetch',
+      message: 'Existing git repository found; fetching origin',
+    });
     await setOrigin(target, authUrl);
     try {
       transientRetries += await runGitWithTransientRetry(['fetch', 'origin'], {
         cwd: target,
+        onProgress: options.onProgress,
       });
     } catch (error) {
       if (options.forcePat) {
@@ -296,6 +326,7 @@ export async function cloneMakerProject(
       await setOrigin(target, authUrl);
       transientRetries += await runGitWithTransientRetry(['fetch', 'origin'], {
         cwd: target,
+        onProgress: options.onProgress,
       });
     }
 
@@ -303,6 +334,12 @@ export async function cloneMakerProject(
       project_id: options.appId,
       user_id: options.userId || (await resolveMakerProjectUserId(options)),
       sce_endpoint: options.sceEndpoint,
+    });
+    options.onProgress?.({
+      progress: 100,
+      total: 100,
+      phase: 'done',
+      message: 'Maker project fetch completed',
     });
     return {
       appId: options.appId,
@@ -324,8 +361,15 @@ export async function cloneMakerProject(
   }
 
   try {
+    options.onProgress?.({
+      progress: 10,
+      total: 100,
+      phase: 'clone',
+      message: `Cloning Maker project ${options.appId}`,
+    });
     transientRetries += await runGitCaptureWithTransientRetry(['clone', authUrl, target], {
       sanitize: pat.token,
+      onProgress: options.onProgress,
     });
   } catch (error) {
     if (options.forcePat) {
@@ -339,8 +383,15 @@ export async function cloneMakerProject(
     });
     authUrl = makeAuthenticatedGitUrl(gitUrl, pat.token);
     retriedWithNewPat = true;
+    options.onProgress?.({
+      progress: 10,
+      total: 100,
+      phase: 'clone',
+      message: `Retrying clone for Maker project ${options.appId} with refreshed PAT`,
+    });
     transientRetries += await runGitCaptureWithTransientRetry(['clone', authUrl, target], {
       sanitize: pat.token,
+      onProgress: options.onProgress,
     });
   }
 
@@ -348,6 +399,12 @@ export async function cloneMakerProject(
     project_id: options.appId,
     user_id: options.userId || (await resolveMakerProjectUserId(options)),
     sce_endpoint: options.sceEndpoint,
+  });
+  options.onProgress?.({
+    progress: 100,
+    total: 100,
+    phase: 'done',
+    message: 'Maker project clone completed',
   });
 
   return {
@@ -363,6 +420,12 @@ export async function pushMakerProject(
   options: PushMakerProjectOptions
 ): Promise<PushMakerProjectResult> {
   ensureGitAvailable();
+  options.onProgress?.({
+    progress: 0,
+    total: 100,
+    phase: 'prepare',
+    message: 'Preparing Maker project push',
+  });
   const cwd = path.resolve(options.cwd);
   if (!isGitRepo(cwd)) {
     throw new Error(`${cwd} is not a git repository.`);
@@ -383,11 +446,24 @@ export async function pushMakerProject(
     jwt: options.jwt,
     pat: options.pat,
     forcePat: options.forcePat,
+    onProgress: options.onProgress,
+  });
+  options.onProgress?.({
+    progress: 10,
+    total: 100,
+    phase: 'auth',
+    message: 'Authenticated Maker git origin ready',
   });
 
   const statusBefore = await readGit(['status', '--porcelain'], cwd);
   const branch = await currentBranch(cwd, options.branch);
   if (!statusBefore.trim() && !options.allowEmpty) {
+    options.onProgress?.({
+      progress: 100,
+      total: 100,
+      phase: 'done',
+      message: 'Maker project has no local changes to push',
+    });
     return {
       branch,
       committed: false,
@@ -398,8 +474,20 @@ export async function pushMakerProject(
   }
 
   if (options.files?.length) {
+    options.onProgress?.({
+      progress: 20,
+      total: 100,
+      phase: 'stage',
+      message: 'Staging selected files',
+    });
     await runGit(['add', ...options.files], { cwd });
   } else {
+    options.onProgress?.({
+      progress: 20,
+      total: 100,
+      phase: 'stage',
+      message: 'Staging all local changes',
+    });
     await runGit(['add', '-A'], { cwd });
   }
 
@@ -408,6 +496,12 @@ export async function pushMakerProject(
   let commitHash: string | undefined;
   const message = options.message || generateCommitMessage(statusBefore);
   if (staged.trim() || options.allowEmpty) {
+    options.onProgress?.({
+      progress: 45,
+      total: 100,
+      phase: 'commit',
+      message: 'Creating local Maker project commit',
+    });
     await runGit(
       [
         '-c',
@@ -426,7 +520,13 @@ export async function pushMakerProject(
   }
 
   try {
-    await pushGit(['push', 'origin', `HEAD:${branch}`], cwd);
+    options.onProgress?.({
+      progress: 65,
+      total: 100,
+      phase: 'push',
+      message: `Pushing Maker project to ${branch}`,
+    });
+    await pushGit(['push', 'origin', `HEAD:${branch}`], cwd, options.onProgress);
   } catch (error) {
     const failure = toMakerGitFailure(error, 'push');
     return {
@@ -440,6 +540,12 @@ export async function pushMakerProject(
       ahead: await readAheadState(cwd),
     };
   }
+  options.onProgress?.({
+    progress: 100,
+    total: 100,
+    phase: 'done',
+    message: 'Maker project push completed',
+  });
 
   return {
     branch,
@@ -586,7 +692,11 @@ function nextActionForFailure(classification: MakerGitFailure['classification'])
   }
 }
 
-function pushGit(args: string[], cwd: string): Promise<void> {
+function pushGit(
+  args: string[],
+  cwd: string,
+  onProgress?: MakerProjectProgressHandler
+): Promise<void> {
   return new Promise((resolve, reject) => {
     const gitCommand = getGitCommand();
     const child = spawn(gitCommand, args, {
@@ -597,6 +707,7 @@ function pushGit(args: string[], cwd: string): Promise<void> {
     let stderr = '';
     child.stderr.on('data', (chunk) => {
       stderr += String(chunk);
+      emitGitProgress(chunk, onProgress);
     });
     child.stdout.on('data', (chunk) => {
       stdout += String(chunk);
@@ -655,6 +766,7 @@ async function ensureAuthenticatedOrigin(options: {
   jwt?: string;
   pat?: string;
   forcePat?: boolean;
+  onProgress?: MakerProjectProgressHandler;
 }): Promise<void> {
   const pat = await requestMakerPat({
     jwt: options.jwt,
@@ -667,6 +779,12 @@ async function ensureAuthenticatedOrigin(options: {
   const authUrl = makeAuthenticatedGitUrl(gitUrl, pat.token);
 
   await setOrigin(options.cwd, authUrl);
+  options.onProgress?.({
+    progress: 8,
+    total: 100,
+    phase: 'auth',
+    message: 'Maker git origin updated with PAT authentication',
+  });
 }
 
 function makeAuthenticatedGitUrl(gitUrl: string, pat: string): string {
@@ -748,6 +866,7 @@ async function runGitWithTransientRetry(
   args: string[],
   options: {
     cwd: string;
+    onProgress?: MakerProjectProgressHandler;
   }
 ): Promise<number> {
   return runWithTransientRetry(() => runGit(args, options));
@@ -758,6 +877,7 @@ async function runGitCaptureWithTransientRetry(
   options: {
     cwd?: string;
     sanitize?: string;
+    onProgress?: MakerProjectProgressHandler;
   } = {}
 ): Promise<number> {
   return runWithTransientRetry(() => runGitCapture(args, options));
@@ -798,6 +918,7 @@ function runGitCapture(
   options: {
     cwd?: string;
     sanitize?: string;
+    onProgress?: MakerProjectProgressHandler;
   } = {}
 ): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -813,6 +934,7 @@ function runGitCapture(
     });
     child.stderr.on('data', (chunk) => {
       stderr += String(chunk);
+      emitGitProgress(chunk, options.onProgress, options.sanitize);
     });
     child.on('exit', (code) => {
       if (code === 0) {
@@ -838,6 +960,7 @@ function runGit(
   options: {
     cwd: string;
     quiet?: boolean;
+    onProgress?: MakerProjectProgressHandler;
   }
 ): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -853,6 +976,7 @@ function runGit(
     });
     child.stderr.on('data', (chunk) => {
       stderr += String(chunk);
+      emitGitProgress(chunk, options.onProgress);
     });
     child.on('exit', (code) => {
       if (code === 0) {
@@ -892,4 +1016,50 @@ function sanitize(value: string, secret?: string): string {
     return value;
   }
   return value.split(secret).join('***');
+}
+
+function emitGitProgress(
+  chunk: Buffer | string,
+  onProgress?: MakerProjectProgressHandler,
+  secret?: string
+): void {
+  if (!onProgress) {
+    return;
+  }
+
+  for (const rawLine of String(chunk).split(/\r\n|\n|\r/)) {
+    const line = sanitize(rawLine.trim(), secret);
+    const progress = parseGitProgressLine(line);
+    if (progress) {
+      onProgress(progress);
+    }
+  }
+}
+
+export function parseGitProgressLine(line: string): MakerProjectProgress | undefined {
+  const message = line.trim();
+  if (!message) {
+    return undefined;
+  }
+
+  const percentMatch = message.match(
+    /(?:remote:\s*)?(Counting objects|Compressing objects|Receiving objects|Resolving deltas|Writing objects):\s+(\d+)%/i
+  );
+  if (percentMatch) {
+    return {
+      progress: Math.max(0, Math.min(100, Number(percentMatch[2]))),
+      total: 100,
+      phase: 'git',
+      message,
+    };
+  }
+
+  if (/^(remote:\s*)?(Cloning into|Enumerating objects|Total )/i.test(message)) {
+    return {
+      phase: 'git',
+      message,
+    };
+  }
+
+  return undefined;
 }

--- a/src/maker/cli/projects.ts
+++ b/src/maker/cli/projects.ts
@@ -5,7 +5,7 @@
 import { spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import type { MakerProjectSummary } from '../types.js';
+import type { MakerPat, MakerProjectSummary } from '../types.js';
 import { loadPat, loadProjectConfig, saveProjectConfig } from '../storage.js';
 import { getUserIdFromMakerJwt, requireMakerJwt } from '../auth/jwt.js';
 import { getManualMakerPat, requestMakerPat, saveManualMakerPat } from '../git/pat.js';
@@ -31,6 +31,7 @@ export interface CloneMakerProjectResult {
   status: 'cloned' | 'fetched';
   retriedWithNewPat: boolean;
   transientRetries: number;
+  warnings: string[];
 }
 
 export interface PushMakerProjectOptions {
@@ -109,7 +110,40 @@ function getMakerGitBase(): string {
   return requireMakerEndpoint('gitBase', getConfiguredMakerGitBase()).replace(/\/$/, '');
 }
 
-function normalizeProjectsResponse(data: unknown): MakerProjectSummary[] {
+function stringField(item: Record<string, unknown>, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = item[key];
+    if (typeof value === 'string') {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function nullableStringField(
+  item: Record<string, unknown>,
+  ...keys: string[]
+): string | null | undefined {
+  for (const key of keys) {
+    const value = item[key];
+    if (typeof value === 'string' || value === null) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function numberField(item: Record<string, unknown>, ...keys: string[]): number | undefined {
+  for (const key of keys) {
+    const value = item[key];
+    if (typeof value === 'number') {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+export function normalizeProjectsResponse(data: unknown): MakerProjectSummary[] {
   const body = data as Record<string, unknown>;
   const list = Array.isArray(data)
     ? data
@@ -123,29 +157,29 @@ function normalizeProjectsResponse(data: unknown): MakerProjectSummary[] {
 
   return list
     .map((item) => item as Record<string, unknown>)
-    .map((item) => ({
-      id: String(item.id || item.app_id || item.project_id || ''),
-      name:
-        typeof item.name === 'string'
-          ? item.name
-          : typeof item.title === 'string'
-            ? item.title
-            : undefined,
-      user_id:
-        typeof item.user_id === 'string'
-          ? item.user_id
-          : typeof item.userId === 'string'
-            ? item.userId
-            : undefined,
-      sce_endpoint:
-        typeof item.sce_endpoint === 'string'
-          ? item.sce_endpoint
-          : typeof item.sce_mcp_url === 'string'
-            ? item.sce_mcp_url
-            : undefined,
-      git_url: typeof item.git_url === 'string' ? item.git_url : undefined,
-      raw: item,
-    }))
+    .map((item) => {
+      const userId = stringField(item, 'userId', 'user_id');
+      return {
+        id: String(item.id || item.app_id || item.project_id || ''),
+        name: stringField(item, 'name', 'title'),
+        userId,
+        user_id: userId,
+        createdAt: stringField(item, 'createdAt', 'created_at'),
+        archivedAt: nullableStringField(item, 'archivedAt', 'archived_at'),
+        deletedAt: nullableStringField(item, 'deletedAt', 'deleted_at'),
+        gameType: stringField(item, 'gameType', 'game_type'),
+        icon: numberField(item, 'icon'),
+        iconColor: numberField(item, 'iconColor', 'icon_color'),
+        lastAccessedAt: nullableStringField(item, 'lastAccessedAt', 'last_accessed_at'),
+        lastConversationAt: stringField(item, 'lastConversationAt', 'last_conversation_at'),
+        metadata: item.metadata,
+        pinnedAt: nullableStringField(item, 'pinnedAt', 'pinned_at'),
+        stage: stringField(item, 'stage'),
+        sce_endpoint: stringField(item, 'sce_endpoint', 'sce_mcp_url'),
+        git_url: stringField(item, 'git_url'),
+        raw: item,
+      };
+    })
     .filter((project) => project.id.length > 0);
 }
 
@@ -270,15 +304,22 @@ async function pushProject(flags: Record<string, string | boolean>): Promise<voi
 export async function cloneMakerProject(
   options: CloneMakerProjectOptions
 ): Promise<CloneMakerProjectResult> {
-  ensureGitAvailable();
+  const target = path.resolve(options.targetDir);
+  ensureTargetCanBindApp(target, options.appId);
+  const warnings = createPreCloneWarnings(target);
   options.onProgress?.({
     progress: 0,
+    total: 100,
+    phase: 'pre_clone_check',
+    message: formatPreCloneProgressMessage(options.appId, warnings),
+  });
+  ensureGitAvailable();
+  options.onProgress?.({
+    progress: 1,
     total: 100,
     phase: 'prepare',
     message: `Preparing Maker project ${options.appId}`,
   });
-  const target = path.resolve(options.targetDir);
-  ensureTargetCanBindApp(target, options.appId);
   let pat = await requestMakerPat({
     jwt: options.jwt,
     pat: options.pat,
@@ -298,7 +339,7 @@ export async function cloneMakerProject(
   let retriedWithNewPat = false;
   let transientRetries = 0;
 
-  if (isGitRepo(target)) {
+  if (isGitRepo(target) && hasGitHead(target)) {
     options.onProgress?.({
       progress: 10,
       total: 100,
@@ -312,14 +353,13 @@ export async function cloneMakerProject(
         onProgress: options.onProgress,
       });
     } catch (error) {
-      if (options.forcePat) {
-        throw error;
+      if (options.forcePat || !isAuthGitError(error)) {
+        throw withPreCloneWarnings(error, warnings);
       }
-      pat = await requestMakerPat({
+      pat = await refreshPatAfterAuthFailure(error, {
         jwt: options.jwt,
         pat: options.pat,
         name: options.patName || 'first-pat',
-        force: true,
       });
       authUrl = makeAuthenticatedGitUrl(gitUrl, pat.token);
       retriedWithNewPat = true;
@@ -327,6 +367,8 @@ export async function cloneMakerProject(
       transientRetries += await runGitWithTransientRetry(['fetch', 'origin'], {
         cwd: target,
         onProgress: options.onProgress,
+      }).catch((retryError) => {
+        throw withPreCloneWarnings(retryError, warnings);
       });
     }
 
@@ -347,16 +389,13 @@ export async function cloneMakerProject(
       status: 'fetched',
       retriedWithNewPat,
       transientRetries,
+      warnings,
     };
   }
 
-  if (fs.existsSync(target) && hasNonIgnorableFiles(target)) {
-    throw new Error(
-      [
-        `${target} is not empty and is not a git repository.`,
-        'Maker clone can be run multiple times after the directory is a git repo, but the first clone requires an empty target directory.',
-        'Please open an empty directory, or remove the unrelated files before cloning.',
-      ].join('\n')
+  if (isGitRepo(target)) {
+    warnings.push(
+      'Target directory already contained git metadata but no checked-out commit. Maker MCP will fetch and check out the remote Maker project branch before reporting success.'
     );
   }
 
@@ -367,19 +406,20 @@ export async function cloneMakerProject(
       phase: 'clone',
       message: `Cloning Maker project ${options.appId}`,
     });
-    transientRetries += await runGitCaptureWithTransientRetry(['clone', authUrl, target], {
-      sanitize: pat.token,
-      onProgress: options.onProgress,
-    });
+    transientRetries += await cloneOrInitializeTarget(
+      target,
+      authUrl,
+      pat.token,
+      options.onProgress
+    );
   } catch (error) {
-    if (options.forcePat) {
-      throw error;
+    if (options.forcePat || !isAuthGitError(error)) {
+      throw withPreCloneWarnings(error, warnings);
     }
-    pat = await requestMakerPat({
+    pat = await refreshPatAfterAuthFailure(error, {
       jwt: options.jwt,
       pat: options.pat,
       name: options.patName || 'first-pat',
-      force: true,
     });
     authUrl = makeAuthenticatedGitUrl(gitUrl, pat.token);
     retriedWithNewPat = true;
@@ -389,12 +429,21 @@ export async function cloneMakerProject(
       phase: 'clone',
       message: `Retrying clone for Maker project ${options.appId} with refreshed PAT`,
     });
-    transientRetries += await runGitCaptureWithTransientRetry(['clone', authUrl, target], {
-      sanitize: pat.token,
-      onProgress: options.onProgress,
+    transientRetries += await cloneOrInitializeTarget(
+      target,
+      authUrl,
+      pat.token,
+      options.onProgress
+    ).catch((retryError) => {
+      throw withPreCloneWarnings(retryError, warnings);
     });
   }
 
+  try {
+    ensureGitHeadCheckedOut(target);
+  } catch (error) {
+    throw withPreCloneWarnings(error, warnings);
+  }
   saveProjectConfig(target, {
     project_id: options.appId,
     user_id: options.userId || (await resolveMakerProjectUserId(options)),
@@ -413,6 +462,7 @@ export async function cloneMakerProject(
     status: 'cloned',
     retriedWithNewPat,
     transientRetries,
+    warnings,
   };
 }
 
@@ -791,12 +841,239 @@ function makeAuthenticatedGitUrl(gitUrl: string, pat: string): string {
   return gitUrl.replace(/^https:\/\//, `https://git:${encodeURIComponent(pat)}@`);
 }
 
-function hasNonIgnorableFiles(target: string): boolean {
+async function cloneOrInitializeTarget(
+  target: string,
+  authUrl: string,
+  pat: string,
+  onProgress?: MakerProjectProgressHandler
+): Promise<number> {
+  if (fs.existsSync(target) && hasDirectoryEntries(target)) {
+    onProgress?.({
+      progress: 10,
+      total: 100,
+      phase: 'clone',
+      message:
+        'Target directory is not empty; initializing git repository in place and keeping existing untracked files unless they conflict with Maker project files.',
+    });
+
+    let transientRetries = 0;
+    transientRetries += await runGitCaptureWithTransientRetry(['init', target], {
+      sanitize: pat,
+      onProgress,
+    });
+    await setOrigin(target, authUrl);
+    transientRetries += await runGitWithTransientRetry(['fetch', 'origin'], {
+      cwd: target,
+      onProgress,
+    });
+    const branch = await resolveRemoteDefaultBranch(target);
+    await assertNoCheckoutFileConflicts(target, branch);
+    try {
+      transientRetries += await runGitCaptureWithTransientRetry(
+        ['checkout', '-B', branch, `origin/${branch}`],
+        {
+          cwd: target,
+          sanitize: pat,
+          onProgress,
+        }
+      );
+    } catch (error) {
+      throw enhanceCheckoutConflictError(error, target);
+    }
+    return transientRetries;
+  }
+
+  return runGitCaptureWithTransientRetry(['clone', authUrl, target], {
+    sanitize: pat,
+    onProgress,
+  });
+}
+
+function hasDirectoryEntries(target: string): boolean {
   if (!fs.existsSync(target)) {
     return false;
   }
 
-  return fs.readdirSync(target).some((entry) => entry !== '.maker-mcp' && entry !== '.DS_Store');
+  return fs.readdirSync(target).length > 0;
+}
+
+function listLocalFiles(root: string): string[] {
+  if (!fs.existsSync(root)) {
+    return [];
+  }
+
+  const files: string[] = [];
+  const visit = (dir: string, relativeDir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
+      if (
+        entry.name === '.git' ||
+        relativePath === '.maker-mcp' ||
+        relativePath.startsWith('.maker-mcp/') ||
+        entry.name === '.DS_Store'
+      ) {
+        continue;
+      }
+
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        visit(fullPath, relativePath);
+        continue;
+      }
+
+      if (entry.isFile()) {
+        files.push(relativePath);
+      }
+    }
+  };
+
+  visit(root, '');
+  return files;
+}
+
+function listPreCloneNoticeFiles(root: string): string[] {
+  if (!fs.existsSync(root)) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(root, { withFileTypes: true })
+    .filter((entry) => !isIgnorablePreCloneEntry(entry.name))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function createPreCloneWarnings(target: string): string[] {
+  const preCloneLocalFiles = listPreCloneNoticeFiles(target);
+  if (preCloneLocalFiles.length === 0) {
+    return [];
+  }
+
+  const preview = preCloneLocalFiles.slice(0, 10);
+  return [
+    [
+      'Pre-clone notice: target directory already contains local files. Maker MCP will keep them and continue unless they conflict with Maker project files.',
+      `local_file_count: ${preCloneLocalFiles.length}`,
+      'local_files:',
+      ...preview.map((file) => `  - ${file}`),
+      preCloneLocalFiles.length > preview.length
+        ? `  - ... ${preCloneLocalFiles.length - preview.length} more`
+        : '',
+    ]
+      .filter(Boolean)
+      .join('\n'),
+  ];
+}
+
+function formatPreCloneProgressMessage(appId: string, warnings: string[]): string {
+  if (warnings.length === 0) {
+    return `Pre-clone local directory check passed for Maker project ${appId}`;
+  }
+
+  return [
+    `Pre-clone local directory check found existing local files for Maker project ${appId}.`,
+    ...warnings,
+  ].join('\n');
+}
+
+function isIgnorablePreCloneEntry(entryName: string): boolean {
+  return entryName === '.DS_Store' || entryName.startsWith('.');
+}
+
+function isAuthGitError(error: unknown): boolean {
+  return toMakerGitFailure(error, 'clone').classification === 'auth';
+}
+
+async function refreshPatAfterAuthFailure(
+  originalError: unknown,
+  options: {
+    jwt?: string;
+    pat?: string;
+    name?: string;
+  }
+): Promise<MakerPat> {
+  try {
+    return await requestMakerPat({
+      jwt: options.jwt,
+      pat: options.pat,
+      name: options.name || 'first-pat',
+      force: true,
+    });
+  } catch (refreshError) {
+    const originalMessage =
+      originalError instanceof Error ? originalError.message : String(originalError);
+    const refreshMessage =
+      refreshError instanceof Error ? refreshError.message : String(refreshError);
+    throw new Error(
+      [
+        'Maker git authentication failed and PAT refresh also failed.',
+        '',
+        'original_git_error:',
+        originalMessage,
+        '',
+        'pat_refresh_error:',
+        refreshMessage,
+      ].join('\n')
+    );
+  }
+}
+
+function withPreCloneWarnings(error: unknown, warnings: string[]): Error {
+  const original = error instanceof Error ? error : new Error(String(error));
+  if (warnings.length === 0) {
+    return original;
+  }
+
+  return new Error(
+    [
+      'Maker clone failed after pre-clone local directory check.',
+      '',
+      'Pre-clone notices:',
+      ...warnings.map((warning) => indentText(warning)),
+      '',
+      'original_error:',
+      original.message,
+    ].join('\n')
+  );
+}
+
+function indentText(text: string): string {
+  return text
+    .split('\n')
+    .map((line) => `  ${line}`)
+    .join('\n');
+}
+
+async function assertNoCheckoutFileConflicts(cwd: string, branch: string): Promise<void> {
+  const remoteTree = await readGit(['ls-tree', '-r', '--name-only', `origin/${branch}`], cwd);
+  const remoteFiles = new Set(
+    remoteTree
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+  );
+  if (remoteFiles.size === 0) {
+    return;
+  }
+
+  const conflicts = listLocalFiles(cwd)
+    .filter((file) => remoteFiles.has(file))
+    .sort();
+  if (conflicts.length === 0) {
+    return;
+  }
+
+  throw new Error(
+    [
+      'Maker clone cannot continue because existing local files have the same paths as files in the remote Maker project.',
+      `target_dir: ${cwd}`,
+      '',
+      'Conflicting local files:',
+      ...conflicts.map((file) => `- ${file}`),
+      '',
+      'Please move, rename, or delete these local files, then retry maker_clone_to_current_directory.',
+    ].join('\n')
+  );
 }
 
 async function setOrigin(cwd: string, authUrl: string): Promise<void> {
@@ -814,6 +1091,46 @@ function isGitRepo(repoDir: string): boolean {
   }
 }
 
+function hasGitHead(repoDir: string): boolean {
+  try {
+    const head = readGitSync(['-C', repoDir, 'rev-parse', '--verify', 'HEAD']);
+    return head.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function ensureGitHeadCheckedOut(repoDir: string): void {
+  if (hasGitHead(repoDir)) {
+    return;
+  }
+
+  throw new Error(
+    [
+      'Maker clone did not complete checkout: local git repository has no HEAD commit.',
+      `target_dir: ${repoDir}`,
+      'The remote fetch may have succeeded, but project files were not checked out. Please inspect git status and retry maker_clone_to_current_directory.',
+    ].join('\n')
+  );
+}
+
+function enhanceCheckoutConflictError(error: unknown, target: string): Error {
+  const message = error instanceof Error ? error.message : String(error);
+  if (!/untracked working tree files would be overwritten by checkout/i.test(message)) {
+    return error instanceof Error ? error : new Error(message);
+  }
+
+  return new Error(
+    [
+      'Maker clone could not check out project files because existing local files would be overwritten.',
+      `target_dir: ${target}`,
+      'Please move, rename, or delete the conflicting local files, then retry maker_clone_to_current_directory.',
+      '',
+      message,
+    ].join('\n')
+  );
+}
+
 async function currentBranch(cwd: string, explicitBranch?: string): Promise<string> {
   if (explicitBranch) {
     return explicitBranch;
@@ -821,6 +1138,15 @@ async function currentBranch(cwd: string, explicitBranch?: string): Promise<stri
 
   const branch = await readGit(['branch', '--show-current'], cwd);
   return branch.trim() || 'main';
+}
+
+async function resolveRemoteDefaultBranch(cwd: string): Promise<string> {
+  try {
+    const branch = await readGit(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], cwd);
+    return branch.trim().replace(/^origin\//, '') || 'main';
+  } catch {
+    return 'main';
+  }
 }
 
 function readGitSync(args: string[]): string {

--- a/src/maker/server/mcp.ts
+++ b/src/maker/server/mcp.ts
@@ -4,6 +4,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
@@ -62,6 +63,7 @@ import {
 } from '../system/git.js';
 
 declare const __MAKER_VERSION__: string | undefined;
+declare const __MAKER_BUNDLE_URL__: string | undefined;
 const VERSION = typeof __MAKER_VERSION__ !== 'undefined' ? __MAKER_VERSION__ : 'dev';
 const DEFAULT_PROXY_MCP_NAME = 'taptap-proxy';
 const DEFAULT_PROXY_PACKAGE = '@taptap/instant-games-open-mcp@1.22.0';
@@ -174,7 +176,7 @@ const tools = [
   {
     name: 'maker_clone_to_current_directory',
     description:
-      'Clone a Maker app repository into the current Codex/agent working directory. Use after the user chooses an app from the Maker app list for requests like "拉取maker游戏到本地", "把这个maker app拉下来", "clone maker项目", or "下载maker游戏代码". Call this only after maker_list_apps has listed apps and the user has chosen one. Requires local Git. If Git is missing, this tool stops before changing files and returns install guidance; do not retry clone until the user installs Git and git --version works. Requires the selected app_id; uses cached Maker PAT by default.',
+      'Clone a Maker app repository into the current Codex/agent working directory. Use after the user chooses an app from the Maker app list for requests like "拉取maker游戏到本地", "把这个maker app拉下来", "clone maker项目", or "下载maker游戏代码". Call this only after maker_list_apps has listed apps and the user has chosen one. Requires local Git. If Git is missing, this tool stops before changing files and returns install guidance; do not retry clone until the user installs Git and git --version works. The target directory does not have to be empty; before clone, the tool checks local entries and warns about non-config local files while ignoring dot-prefixed config entries such as .claude, .mcp, .skill, .config, and .ini. Existing local files are kept unless they conflict with Maker project files; conflicts fail with a file list. Requires the selected app_id; uses cached Maker PAT by default.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -312,7 +314,7 @@ const tools = [
         use_npx: {
           type: 'boolean',
           description:
-            'If true, write the script-style npx package command. Defaults to false for local development and uses local dist/proxy.js.',
+            'If true, write the script-style npx package command. Defaults to false and uses the proxy.js bundled with the Maker MCP package when available.',
         },
         pkg: {
           type: 'string',
@@ -644,6 +646,7 @@ export async function startMakerMcpServer(): Promise<void> {
               text: [
                 '✓ Maker project cloned',
                 '',
+                ...formatCloneWarnings(result.warnings),
                 `- app_id: ${args.app_id}`,
                 `- target_dir: ${result.targetDir}`,
                 `- status: ${result.status}`,
@@ -907,7 +910,15 @@ function mask(value: string): string {
 }
 
 function formatProjectList(
-  projects: Array<{ id: string; name?: string; user_id?: string }>
+  projects: Array<{
+    id: string;
+    name?: string;
+    user_id?: string;
+    createdAt?: string;
+    lastConversationAt?: string;
+    gameType?: string;
+    stage?: string;
+  }>
 ): string {
   if (projects.length === 0) {
     return [
@@ -924,11 +935,37 @@ function formatProjectList(
       (project, index) =>
         `${index + 1}. ${project.id}${project.name ? `  ${project.name}` : ''}${
           project.user_id ? `  user_id=${project.user_id}` : ''
+        }${project.gameType ? `  gameType=${project.gameType}` : ''}${
+          project.stage ? `  stage=${project.stage}` : ''
+        }${project.createdAt ? `  createdAt=${project.createdAt}` : ''}${
+          project.lastConversationAt ? `  lastConversationAt=${project.lastConversationAt}` : ''
         }`
     ),
     '',
     '请让用户选择一个 app，然后调用 maker_clone_to_current_directory。',
   ].join('\n');
+}
+
+function formatCloneWarnings(warnings: string[]): string[] {
+  if (warnings.length === 0) {
+    return [
+      'Pre-clone local directory check',
+      '',
+      '- result: checked',
+      '- local_files: none found before clone, ignoring dot-prefixed local config entries',
+      '',
+    ];
+  }
+
+  return [
+    'Pre-clone local directory check',
+    '',
+    '- result: found local files before clone',
+    '- action: kept local files and continued unless they conflicted with Maker project files',
+    '',
+    ...warnings.map((warning) => `- ${warning}`),
+    '',
+  ];
 }
 
 function createRemoteProxyContext(options: {
@@ -1075,21 +1112,31 @@ function configureRemoteProxy(options: {
   };
 }
 
-function resolveLocalProxyBundle(): string {
-  const makerEntry = process.argv[1] ? path.resolve(process.argv[1]) : '';
-  const alongsideMaker = makerEntry ? path.join(path.dirname(makerEntry), 'proxy.js') : '';
-  if (alongsideMaker && fs.existsSync(alongsideMaker)) {
-    return alongsideMaker;
+export function resolveLocalProxyBundle(options?: {
+  currentModuleUrl?: string;
+  makerEntry?: string;
+  cwd?: string;
+}): string {
+  const currentModuleUrl =
+    options?.currentModuleUrl ||
+    (typeof __MAKER_BUNDLE_URL__ !== 'undefined' ? __MAKER_BUNDLE_URL__ : undefined);
+  const currentModuleDir = currentModuleUrl ? path.dirname(fileURLToPath(currentModuleUrl)) : '';
+  const makerEntry = options?.makerEntry ?? process.argv[1];
+  const makerEntryDir = makerEntry ? path.dirname(path.resolve(makerEntry)) : '';
+  const cwd = options?.cwd ?? process.cwd();
+  const candidates = [
+    currentModuleDir ? path.join(currentModuleDir, 'proxy.js') : '',
+    makerEntryDir ? path.join(makerEntryDir, '..', 'dist', 'proxy.js') : '',
+    path.resolve(cwd, 'dist', 'proxy.js'),
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
   }
 
-  const cwdBundle = path.resolve(process.cwd(), 'dist', 'proxy.js');
-  if (fs.existsSync(cwdBundle)) {
-    return cwdBundle;
-  }
-
-  throw new Error(
-    'Local dist/proxy.js not found. Run npm run build before configuring remote proxy.'
-  );
+  throw new Error(`MCP proxy bundle not found. Checked: ${candidates.join(', ')}`);
 }
 
 function readMcpJson(filePath: string): {

--- a/src/maker/server/mcp.ts
+++ b/src/maker/server/mcp.ts
@@ -12,6 +12,12 @@ import {
   McpError,
   ErrorCode,
 } from '@modelcontextprotocol/sdk/types.js';
+import type {
+  ProgressToken,
+  ServerNotification,
+  ServerRequest,
+} from '@modelcontextprotocol/sdk/types.js';
+import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { identifyMakerProject, formatIdentifyHint } from './identify.js';
@@ -26,7 +32,13 @@ import {
   loadTapAuth,
   loadTapDeviceSession,
 } from '../storage.js';
-import { cloneMakerProject, listMakerProjects, pushMakerProject } from '../cli/projects.js';
+import {
+  cloneMakerProject,
+  listMakerProjects,
+  pushMakerProject,
+  type MakerProjectProgress,
+  type MakerProjectProgressHandler,
+} from '../cli/projects.js';
 import { startTapDeviceLogin, completeTapDeviceLogin } from '../auth/oauth.js';
 import { requestTapAuthWithPat } from '../auth/patTap.js';
 import { saveManualMakerPat } from '../git/pat.js';
@@ -54,6 +66,7 @@ const VERSION = typeof __MAKER_VERSION__ !== 'undefined' ? __MAKER_VERSION__ : '
 const DEFAULT_PROXY_MCP_NAME = 'taptap-proxy';
 const DEFAULT_PROXY_PACKAGE = '@taptap/instant-games-open-mcp@1.22.0';
 const DEFAULT_BUILD_TIMEOUT_MS = 10 * 60 * 1000;
+const LONG_OPERATION_HEARTBEAT_MS = 3 * 60 * 1000;
 const MAKER_WEB_URL = getMakerWebUrl();
 
 const tools = [
@@ -380,7 +393,7 @@ export async function startMakerMcpServer(): Promise<void> {
   );
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools }));
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
     const name = request.params.name;
 
     try {
@@ -600,15 +613,29 @@ export async function startMakerMcpServer(): Promise<void> {
         }
 
         const targetDir = args.target_dir || process.cwd();
-        const result = await cloneMakerProject({
-          appId: args.app_id,
-          targetDir,
-          pat: args.pat,
-          userId: args.user_id,
-          jwt: args.jwt,
-          forcePat: args.force_pat === true,
-          sceEndpoint: process.env.SCE_MCP_URL,
-        });
+        const progressReporter = createToolProgressReporter(
+          request.params._meta?.progressToken,
+          extra,
+          'Maker clone'
+        );
+        let result: Awaited<ReturnType<typeof cloneMakerProject>>;
+        let progressSummary: ToolProgressSummary;
+        try {
+          result = await cloneMakerProject({
+            appId: args.app_id,
+            targetDir,
+            pat: args.pat,
+            userId: args.user_id,
+            jwt: args.jwt,
+            forcePat: args.force_pat === true,
+            sceEndpoint: process.env.SCE_MCP_URL,
+            onProgress: progressReporter.report,
+          });
+          progressSummary = progressReporter.finish();
+        } catch (error) {
+          progressReporter.finish();
+          throw error;
+        }
 
         return {
           content: [
@@ -621,6 +648,7 @@ export async function startMakerMcpServer(): Promise<void> {
                 `- target_dir: ${result.targetDir}`,
                 `- status: ${result.status}`,
                 `- retried_with_new_pat: ${result.retriedWithNewPat ? 'yes' : 'no'}`,
+                ...formatProgressSummary(progressSummary),
                 '- project config: .maker-mcp/config.json',
               ].join('\n'),
             },
@@ -641,22 +669,36 @@ export async function startMakerMcpServer(): Promise<void> {
         };
 
         const targetDir = args.target_dir || process.cwd();
-        const result = await pushMakerProject({
-          cwd: targetDir,
-          message: args.message,
-          branch: args.branch,
-          files: args.files,
-          allowEmpty: args.allow_empty === true,
-          pat: args.pat,
-          jwt: args.jwt,
-          forcePat: args.force_pat === true,
-        });
+        const progressReporter = createToolProgressReporter(
+          request.params._meta?.progressToken,
+          extra,
+          'Maker push'
+        );
+        let result: Awaited<ReturnType<typeof pushMakerProject>>;
+        let progressSummary: ToolProgressSummary;
+        try {
+          result = await pushMakerProject({
+            cwd: targetDir,
+            message: args.message,
+            branch: args.branch,
+            files: args.files,
+            allowEmpty: args.allow_empty === true,
+            pat: args.pat,
+            jwt: args.jwt,
+            forcePat: args.force_pat === true,
+            onProgress: progressReporter.report,
+          });
+          progressSummary = progressReporter.finish();
+        } catch (error) {
+          progressReporter.finish();
+          throw error;
+        }
 
         return {
           content: [
             {
               type: 'text',
-              text: formatPushResult(targetDir, result),
+              text: formatPushResult(targetDir, result, progressSummary),
             },
           ],
         };
@@ -704,23 +746,37 @@ export async function startMakerMcpServer(): Promise<void> {
           timeout_ms?: number;
         };
 
-        const result = await buildCurrentDirectory({
-          targetDir: args.target_dir || process.cwd(),
-          entry: args.entry,
-          scriptsPath: args.scriptsPath,
-          entryClient: args.entry_client,
-          entryServer: args.entry_server,
-          multiplayer: args.multiplayer,
-          serverUrl: args.server_url,
-          env: args.env,
-          timeoutMs: args.timeout_ms,
-        });
+        const progressReporter = createToolProgressReporter(
+          request.params._meta?.progressToken,
+          extra,
+          'Maker build'
+        );
+        let result: Awaited<ReturnType<typeof buildCurrentDirectory>>;
+        let progressSummary: ToolProgressSummary;
+        try {
+          result = await buildCurrentDirectory({
+            targetDir: args.target_dir || process.cwd(),
+            entry: args.entry,
+            scriptsPath: args.scriptsPath,
+            entryClient: args.entry_client,
+            entryServer: args.entry_server,
+            multiplayer: args.multiplayer,
+            serverUrl: args.server_url,
+            env: args.env,
+            timeoutMs: args.timeout_ms,
+            onProgress: progressReporter.report,
+          });
+          progressSummary = progressReporter.finish();
+        } catch (error) {
+          progressReporter.finish();
+          throw error;
+        }
 
         return {
           content: [
             {
               type: 'text',
-              text: formatBuildResult(result),
+              text: formatBuildResult(result, progressSummary),
             },
           ],
         };
@@ -1133,6 +1189,123 @@ function formatProxyEnv(envVars?: Record<string, string>): string {
     .join(' ');
 }
 
+interface ToolProgressSummary {
+  elapsedMs: number;
+  elapsed: string;
+  progressEvents: number;
+  lastProgress?: MakerProjectProgress;
+}
+
+interface ToolProgressReporter {
+  report: MakerProjectProgressHandler;
+  finish: () => ToolProgressSummary;
+}
+
+function createToolProgressReporter(
+  progressToken: ProgressToken | undefined,
+  extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
+  operationName: string
+): ToolProgressReporter {
+  const startedAt = Date.now();
+  let events = 0;
+  let lastProgress: MakerProjectProgress | undefined;
+  let lastSentProgress = 0;
+  let finished = false;
+
+  const sendProgress = (progress: MakerProjectProgress): void => {
+    if (finished || progressToken === undefined) {
+      return;
+    }
+
+    const elapsed = formatDuration(Date.now() - startedAt);
+    const numericProgress =
+      progress.progress !== undefined
+        ? Math.max(lastSentProgress, progress.progress)
+        : Math.max(lastSentProgress, Math.floor((Date.now() - startedAt) / 1000));
+    lastSentProgress = numericProgress;
+    const message = `${operationName}: ${progress.message} (elapsed ${elapsed})`;
+
+    void extra
+      .sendNotification({
+        method: 'notifications/progress',
+        params: {
+          progressToken,
+          progress: numericProgress,
+          ...(progress.total !== undefined ? { total: progress.total } : {}),
+          message,
+        },
+      } as ServerNotification)
+      .catch(() => {
+        // Progress notification failures should not fail Maker operations.
+      });
+  };
+
+  const heartbeat = setInterval(() => {
+    const elapsed = formatDuration(Date.now() - startedAt);
+    sendProgress({
+      progress: lastProgress?.progress,
+      total: lastProgress?.total,
+      phase: lastProgress?.phase,
+      message: `still running; elapsed ${elapsed}; last status: ${
+        lastProgress?.message || 'waiting for progress'
+      }`,
+    });
+  }, LONG_OPERATION_HEARTBEAT_MS);
+  heartbeat.unref?.();
+
+  return {
+    report(progress) {
+      events += 1;
+      lastProgress = progress;
+      sendProgress(progress);
+    },
+    finish() {
+      if (!finished) {
+        finished = true;
+        clearInterval(heartbeat);
+      }
+      const elapsedMs = Date.now() - startedAt;
+      return {
+        elapsedMs,
+        elapsed: formatDuration(elapsedMs),
+        progressEvents: events,
+        lastProgress,
+      };
+    },
+  };
+}
+
+function formatProgressSummary(summary: ToolProgressSummary): string[] {
+  return [
+    `- elapsed_ms: ${summary.elapsedMs}`,
+    `- elapsed: ${summary.elapsed}`,
+    `- progress_events: ${summary.progressEvents}`,
+    summary.lastProgress
+      ? `- last_progress: ${formatProgressMessage(summary.lastProgress)}`
+      : '- last_progress: (none)',
+  ];
+}
+
+function formatProgressMessage(progress: MakerProjectProgress): string {
+  const percent =
+    progress.progress !== undefined
+      ? `${progress.progress}${progress.total === 100 ? '%' : ''}`
+      : undefined;
+  return [progress.phase ? `[${progress.phase}]` : '', percent, progress.message]
+    .filter(Boolean)
+    .join(' ');
+}
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.round(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes === 0) {
+    return `${seconds}s`;
+  }
+  return `${minutes}m ${seconds}s`;
+}
+
 async function buildCurrentDirectory(options: {
   targetDir: string;
   entry?: string;
@@ -1143,6 +1316,7 @@ async function buildCurrentDirectory(options: {
   serverUrl?: string;
   env?: 'rnd' | 'production';
   timeoutMs?: number;
+  onProgress?: MakerProjectProgressHandler;
 }): Promise<{
   projectRoot: string;
   projectId: string;
@@ -1164,10 +1338,7 @@ async function buildCurrentDirectory(options: {
   const transport = new StdioClientTransport({
     command: proxy.command,
     args: proxy.args,
-    env: {
-      ...process.env,
-      ...proxy.envVars,
-    },
+    env: mergeStringEnv(process.env, proxy.envVars),
     stderr: 'pipe',
   });
   const client = new Client(
@@ -1191,6 +1362,14 @@ async function buildCurrentDirectory(options: {
       {
         timeout: timeoutMs,
         resetTimeoutOnProgress: true,
+        onprogress: (progress) => {
+          options.onProgress?.({
+            progress: progress.progress,
+            total: progress.total,
+            phase: 'remote_build',
+            message: progress.message || 'Remote Maker build progress',
+          });
+        },
       }
     );
 
@@ -1241,6 +1420,23 @@ function createBuildArgs(
   return buildArgs;
 }
 
+function mergeStringEnv(
+  ...sources: Array<NodeJS.ProcessEnv | Record<string, string> | undefined>
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const source of sources) {
+    if (!source) {
+      continue;
+    }
+    for (const [key, value] of Object.entries(source)) {
+      if (typeof value === 'string') {
+        result[key] = value;
+      }
+    }
+  }
+  return result;
+}
+
 function formatRemoteToolResult(result: unknown): string {
   if (!result || typeof result !== 'object') {
     return String(result);
@@ -1261,16 +1457,19 @@ function formatRemoteToolResult(result: unknown): string {
     .join('\n');
 }
 
-function formatBuildResult(result: {
-  projectRoot: string;
-  projectId: string;
-  projectPath: string;
-  serverUrl: string;
-  env: string;
-  timeoutMs: number;
-  buildArgs: Record<string, unknown>;
-  resultText: string;
-}): string {
+function formatBuildResult(
+  result: {
+    projectRoot: string;
+    projectId: string;
+    projectPath: string;
+    serverUrl: string;
+    env: string;
+    timeoutMs: number;
+    buildArgs: Record<string, unknown>;
+    resultText: string;
+  },
+  progressSummary: ToolProgressSummary
+): string {
   return [
     '✓ Remote Maker build finished',
     '',
@@ -1281,6 +1480,7 @@ function formatBuildResult(result: {
     `- env: ${result.env}`,
     `- timeout_ms: ${result.timeoutMs}`,
     `- build_args: ${JSON.stringify(result.buildArgs)}`,
+    ...formatProgressSummary(progressSummary),
     '',
     'remote_result:',
     indent(result.resultText),
@@ -1307,7 +1507,8 @@ function formatPushResult(
       classification: string;
       nextAction: string;
     };
-  }
+  },
+  progressSummary: ToolProgressSummary
 ): string {
   const lines = [
     result.pushed
@@ -1323,6 +1524,7 @@ function formatPushResult(
     result.commitHash ? `- commit_hash: ${result.commitHash}` : '',
     result.message ? `- commit_message: ${result.message}` : '',
     result.ahead ? `- git_state: ${result.ahead}` : '',
+    ...formatProgressSummary(progressSummary),
   ].filter(Boolean);
 
   if (!result.failure) {

--- a/src/maker/types.ts
+++ b/src/maker/types.ts
@@ -47,9 +47,25 @@ export interface MakerProjectConfig {
 }
 
 export interface MakerProjectSummary {
+  /** Maker app id. */
   id: string;
+  /** 游戏名称。 */
   name?: string;
+  userId?: string;
   user_id?: string;
+  /** 创建时间。 */
+  createdAt?: string;
+  archivedAt?: string | null;
+  deletedAt?: string | null;
+  gameType?: string;
+  icon?: number;
+  iconColor?: number;
+  lastAccessedAt?: string | null;
+  /** 最后修改时间，用于识别最近活跃的游戏。 */
+  lastConversationAt?: string;
+  metadata?: unknown;
+  pinnedAt?: string | null;
+  stage?: string;
   sce_endpoint?: string;
   git_url?: string;
   raw?: unknown;


### PR DESCRIPTION
## 改动内容
- 修复 Maker build 代理路径解析，避免在游戏目录查找 dist/proxy.js
- 扩展 Maker app 列表字段解析，保留创建时间和最近会话时间等字段
- 调整 Maker clone 对非空目录的处理：保留本地文件、固定输出本地目录检查、冲突时抛出具体原因
- 增加 clone、app 列表、proxy bundle 相关测试

## 验证
- npm run build
- npm run lint
- npm run format:check
- npm test -- --runInBand --no-cache src/__tests__/makerCloneBinding.test.ts