### PR TITLE
feat(maker): improve local build flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,6 +341,8 @@ Maker 本地 MCP 的默认认证路径是 PAT-first：
 - `maker_status` 如果发现本地已有 PAT 但缺少 TapTap MAC token，会自动尝试获取；如果当前目录未绑定，也会自动列出 app，不需要用户额外要求。
 - `maker_list_apps` 优先使用 PAT 调 Maker API 获取 app 列表，并必须展示给用户选择。
 - `maker_clone_to_current_directory` 和 `maker_push_current_directory` 默认复用缓存 PAT 做 Maker git 认证。
+- 用户说“更新 mcp / 更新 taptap mcp / 刷新 mcp 缓存 / tap mcp 有新版本”时，调用 `maker_get_mcp_update_guide`。该工具只返回 Windows 或 macOS/Linux 的更新引导、安装检查、配置位置提醒和重启/新开窗口提示，不直接执行 `npm`、`npx`、删除缓存或自更新；由用户本地 AI 客户端按返回命令执行。
+- `maker_get_mcp_update_guide` 默认引导更新 `@taptap/instant-games-open-mcp@beta` 并预热 `taptap-maker`。更新后当前 MCP 会话通常不会热加载，必须提醒用户重启 MCP 客户端，或新开 Claude Code / Codex / Cursor 窗口，再调用 `maker_status` 验证。
 - `maker_build_current_directory` 会强制检查本地 Maker 项目是否有未提交改动；有改动且没有保存自动提交偏好时默认停止，提醒用户直接构建只会构建云端已有版本。
 - 拦截提示的首选项必须是 `提交本地改动并触发构建（以后都是如此）`。
 - 用户选择首选项时，调用 `maker_submit_current_directory` 并设置 `remember_build_submit_preference=true`；Maker 提交等于 commit + push，提交成功后自动触发构建，不要再额外手动构建。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,6 +341,13 @@ Maker 本地 MCP 的默认认证路径是 PAT-first：
 - `maker_status` 如果发现本地已有 PAT 但缺少 TapTap MAC token，会自动尝试获取；如果当前目录未绑定，也会自动列出 app，不需要用户额外要求。
 - `maker_list_apps` 优先使用 PAT 调 Maker API 获取 app 列表，并必须展示给用户选择。
 - `maker_clone_to_current_directory` 和 `maker_push_current_directory` 默认复用缓存 PAT 做 Maker git 认证。
+- `maker_build_current_directory` 会强制检查本地 Maker 项目是否有未提交改动；有改动且没有保存自动提交偏好时默认停止，提醒用户直接构建只会构建云端已有版本。
+- 拦截提示的首选项必须是 `提交本地改动并触发构建（以后都是如此）`。
+- 用户选择首选项时，调用 `maker_submit_current_directory` 并设置 `remember_build_submit_preference=true`；Maker 提交等于 commit + push，提交成功后自动触发构建，不要再额外手动构建。
+- 该偏好会保存到当前项目 `.maker-mcp/config.json`；后续构建遇到本地改动会默认自动提交并依赖 Maker 自动构建。
+- 用户明确说不提交、直接构建云端版本时，才允许调用 `maker_build_current_directory` 并设置 `confirm_remote_build_without_submit=true`。
+- 用户说“查看结果 / 预览 / 跑一下 / 验证一下 / 看看效果”时，也按构建前本地改动检查流程处理。
+- 构建时如果用户未指定入口且本地存在 `scripts/main.lua`，本地 Maker MCP 默认传 `scriptsPath="scripts"` 和 `entry="main.lua"`；用户显式传单机入口或多人入口时优先生效。
 - Tap OAuth 登录仅作为 legacy fallback；默认远端 Maker MCP tools 所需的 TapTap MAC token 也通过 PAT 获取。
 - `maker_exchange_jwt` / `JWT` / `MAKER_JWT` 仅作为 legacy fallback 保留，不再作为默认初始化路径。
 

--- a/README.md
+++ b/README.md
@@ -79,10 +79,16 @@ maker_push_current_directory
 - JWT 仅作为 legacy fallback 保留：`maker_exchange_jwt(manual_jwt)`、`JWT` / `MAKER_JWT` 仍可用于旧后端或创建新 PAT。
 - Maker app 必须先通过 `maker_list_apps` 展示给用户选择，再调用 clone。
 - Maker 后端地址按 `TAPTAP_MCP_ENV` 从 `src/maker/config.ts` 的环境配置表读取，本地 MCP 配置只需要切 `rnd` / `production`。
-- 如果用户直接说“构建 / build / 重新构建游戏”，本地 Maker MCP 应调用 `maker_build_current_directory` 转发到远端 `build` tool。
+- 如果用户直接说“构建 / build / 重新构建游戏”，本地 Maker MCP 应调用 `maker_build_current_directory`。该工具会强制检查本地 Maker 项目是否有未提交改动。
+- 如果构建前发现本地有改动且尚未保存自动提交偏好，工具会停止并提示用户选择：`提交本地改动并触发构建（以后都是如此）`，或明确不提交、只构建云端已有版本。
+- 用户选择 `提交本地改动并触发构建（以后都是如此）` 后，应调用 `maker_submit_current_directory` 并传入 `remember_build_submit_preference=true`；提交成功后会在当前项目 `.maker-mcp/config.json` 记住偏好。
+- 保存偏好后，后续用户说“构建”且本地有改动时，`maker_build_current_directory` 会默认自动提交并依赖 Maker 自动构建，不再重复询问。
+- 只有当用户明确说“不提交 / 直接构建云端版本”时，才可再次调用 `maker_build_current_directory` 并传入 `confirm_remote_build_without_submit=true`。
+- 用户说“查看结果 / 预览 / 跑一下 / 验证一下 / 看看效果”时，也按构建流程处理；如果本地有改动，先提醒提交后自动构建。
 - 构建转发会从 MCP 包自身定位 `dist/proxy.js`；`cwd` / `target_dir` 只用于识别 Maker 游戏项目，不要求游戏目录存在 MCP 的 `dist/proxy.js`。
+- 用户未指定构建入口且本地存在 `scripts/main.lua` 时，Maker MCP 默认向远端 build 传 `scriptsPath="scripts"` 和 `entry="main.lua"`，避免第一次构建多一轮“入口配置缺失”的提示；用户显式传入口或多人入口时优先生效。
 - 如需在当前游戏项目里直接暴露远端全量 `taptap-proxy` tools，再使用 `maker_configure_remote_proxy` 写入 `.mcp.json` 并重启 MCP 会话。
-- 用户说“帮我提交/提交代码”时使用 `maker_submit_current_directory`，会对当前 Maker 项目执行 commit + push。
+- 用户说“帮我提交/提交代码”时使用 `maker_submit_current_directory`，会对当前 Maker 项目执行 commit + push；Maker 提交成功后会自动触发构建，不需要再手动调用构建工具。
 - “帮我提交代码到maker / taptap制造 / tap制造 / tap”也应触发 `maker_submit_current_directory`。
 - Maker 项目提交不走通用 Git skill 的任务号、新分支规则；冲突时先和用户确认 pull/rebase 流程。
 - 如果 commit 已完成但 push 失败，Maker MCP 会返回 commit hash、ahead 状态、exit code、stderr/stdout 和下一步建议，便于开发期排查。

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ maker_push_current_directory
 说明：
 
 - Maker MCP 依赖用户本机已有 Git。工具只检测并给出安装引导，不会代替用户安装 Git。
+- 用户说“更新 mcp / 更新 taptap mcp / 刷新 mcp 缓存 / tap mcp 有新版本”时，应调用 `maker_get_mcp_update_guide`。该工具只返回 Windows 或 macOS/Linux 的更新引导、安装检查、配置位置提醒和重启提示，不直接执行更新命令；由用户本地 AI 客户端按返回命令操作。
 - 用户说“我要开发maker游戏 / 本地maker开发 / 拉取maker游戏到本地 / 把maker游戏代码拉到本地 / clone maker项目 / 下载maker游戏代码 / 初始化maker开发目录 / 配置maker本地开发 / 继续开发maker项目”时，应触发 Maker 本地开发初始化流程。
 - 如果 `maker_status` 或 `maker_check_environment` 显示 Git 缺失，必须持续提示用户自行安装 Git；在 `git --version` 可用前，不执行 clone、fetch、commit 或 push。
 - Maker API、git 和 TapTap token 默认走 PAT-first：如果用户还没有 PAT，引导用户打开临时 PAT 页面 `https://fuping.agnt.xd.com/pat-tokens` 新建 PAT；用户提供 PAT 后调用 `maker_exchange_pat(manual_pat)` 保存。
@@ -88,6 +89,7 @@ maker_push_current_directory
 - 构建转发会从 MCP 包自身定位 `dist/proxy.js`；`cwd` / `target_dir` 只用于识别 Maker 游戏项目，不要求游戏目录存在 MCP 的 `dist/proxy.js`。
 - 用户未指定构建入口且本地存在 `scripts/main.lua` 时，Maker MCP 默认向远端 build 传 `scriptsPath="scripts"` 和 `entry="main.lua"`，避免第一次构建多一轮“入口配置缺失”的提示；用户显式传入口或多人入口时优先生效。
 - 如需在当前游戏项目里直接暴露远端全量 `taptap-proxy` tools，再使用 `maker_configure_remote_proxy` 写入 `.mcp.json` 并重启 MCP 会话。
+- `maker_get_mcp_update_guide` 默认生成 `@taptap/instant-games-open-mcp@beta` 和 `taptap-maker` 的 npx 缓存更新步骤；更新后当前 MCP 会话通常不会热加载，必须重启 MCP 客户端或新开 Claude Code / Codex / Cursor 窗口，再调用 `maker_status` 验证。
 - 用户说“帮我提交/提交代码”时使用 `maker_submit_current_directory`，会对当前 Maker 项目执行 commit + push；Maker 提交成功后会自动触发构建，不需要再手动调用构建工具。
 - “帮我提交代码到maker / taptap制造 / tap制造 / tap”也应触发 `maker_submit_current_directory`。
 - Maker 项目提交不走通用 Git skill 的任务号、新分支规则；冲突时先和用户确认 pull/rebase 流程。

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -81,8 +81,8 @@ maker_status
 - `maker_list_apps`：优先用 Maker PAT 拉取 app 列表，必须展示给用户选择；JWT 仅作为 legacy fallback。会解析 Maker `/apps` 返回的创建时间、最近会话时间、游戏类型、阶段、图标、置顶/归档/删除时间等字段，并保留原始 `raw` 数据。
 - `maker_clone_to_current_directory`：把选中的 Maker app 仓库拉到当前目录并写 `.maker-mcp/config.json`。如果本机没有 Git，工具会在申请 PAT 和改动文件前停止。当前目录不要求为空；clone 前会检查本地目录，忽略 `.claude`、`.mcp`、`.skill`、`.config`、`.ini` 等点开头配置项，只对普通本地文件输出提醒。clone 最终结果固定包含 `Pre-clone local directory check` 区块；已有本地文件会保留，若与 Maker 项目文件同路径冲突则失败并列出冲突文件。
 - `maker_configure_remote_proxy`：按 server 测试脚本生成 `proxy_cfg`，写入当前项目 `.mcp.json`，连接远端 `taptap-proxy`。
-- `maker_build_current_directory`：用户说“构建 / build / 重新构建游戏”时使用，转发调用远端 `build` tool。构建转发会从 MCP 包自身定位 `dist/proxy.js`；`cwd` / `target_dir` 只用于识别 Maker 游戏项目，不要求游戏目录存在 MCP 的 `dist/proxy.js`。
-- `maker_submit_current_directory`：用户说“帮我提交”“提交代码”时使用，提交并推送当前 Maker 项目。如果本机没有 Git，工具会在 stage/commit/push 前停止。
+- `maker_build_current_directory`：用户说“构建 / build / 重新构建游戏”时使用，转发调用远端 `build` tool。工具内部会强制检查本地 Maker 项目是否有未提交改动；如果有改动且没有传入 `confirm_remote_build_without_submit=true`，会停止并要求先询问用户。构建转发会从 MCP 包自身定位 `dist/proxy.js`；`cwd` / `target_dir` 只用于识别 Maker 游戏项目，不要求游戏目录存在 MCP 的 `dist/proxy.js`。
+- `maker_submit_current_directory`：用户说“帮我提交”“提交代码”时使用，提交并推送当前 Maker 项目。Maker 提交等于 commit + push；提交成功后会自动触发构建。如果来自构建拦截首选项 `提交本地改动并触发构建（以后都是如此）`，必须传入 `remember_build_submit_preference=true`。如果本机没有 Git，工具会在 stage/commit/push 前停止。
 - `maker_push_current_directory`：把当前目录改动 commit 并 push 到 Maker git。如果本机没有 Git，工具会在 stage/commit/push 前停止。
 
 Maker app 列表关键字段：
@@ -197,6 +197,19 @@ TAPTAP_MCP_ENV=production
 maker_build_current_directory()
 ```
 
+构建前本地改动检查是工具层强制规则，不只是 Agent 文案约定：
+
+- `maker_build_current_directory` 会先读取当前 Maker git 状态。
+- 如果本地没有改动，继续转发远端 build。
+- 如果本地有改动且没有保存自动提交偏好，默认停止，不会静默构建云端旧版本。
+- 此时必须提示用户：直接构建只会使用 Maker 云端已有版本，可能看不到本地新修改。
+- 首选项文案必须是 `提交本地改动并触发构建（以后都是如此）`。
+- 用户选择首选项时，调用 `maker_submit_current_directory(remember_build_submit_preference=true)`；提交等于 commit + push，提交成功后 Maker 会自动触发构建，不要再额外调用 `maker_build_current_directory`。
+- `remember_build_submit_preference=true` 会把当前项目 `.maker-mcp/config.json` 的 `build_local_changes_policy` 保存为 `auto_submit`。
+- 保存偏好后，后续用户说“构建”且本地有改动时，`maker_build_current_directory` 会自动提交并依赖 Maker 自动构建，不再重复询问。
+- 用户明确说“不提交 / 直接构建 / 构建云端版本”时，才允许再次调用 `maker_build_current_directory(confirm_remote_build_without_submit=true)`。
+- 用户说“查看结果 / 预览 / 跑一下 / 验证一下 / 看看效果”时，也按这个构建检查流程处理。
+
 如需在当前 Maker 项目里直接暴露远端全量 `taptap-proxy` tools，可以执行：
 
 ```text
@@ -235,7 +248,8 @@ maker_configure_remote_proxy()
 
 本地工具会复用同一份 `proxy_cfg` 连接远端 MCP server，并转发到远端 `build` tool。默认不要求用户传参：
 
-- `entry` / `scriptsPath` / `entry_client` / `entry_server`：用户未指定时交给远端 build 默认推断。
+- `entry` / `scriptsPath`：用户未指定且本地存在 `scripts/main.lua`、也没有显式多人入口参数时，本地 Maker MCP 默认传 `scriptsPath="scripts"` 和 `entry="main.lua"`，减少远端第一次构建的“入口配置缺失”提示。
+- `entry_client` / `entry_server`：用户明确说明是多人游戏或给出入口文件时再传入；传入多人入口后不会自动补单机 `scripts/main.lua`。
 - `multiplayer`：用户未指定且本地不存在 `.project/settings.json` 时，默认传 `{ "enabled": false }`，用于第一次单机项目构建初始化。
 - 如果用户明确说明是多人游戏或给出入口文件，再把对应参数传入。
 

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -78,6 +78,7 @@ maker_status
 - `maker_tap_login_complete`：legacy fallback，用户扫码后轮询 Tap token，保存 MAC 认证数据。
 - `maker_exchange_pat`：接收用户提供的 Maker PAT，以 `manual_pat` 传入后保存到本地 `~/.taptap-maker/pat.json`，并兼容旧的 `~/.maker-pat`；保存后会自动获取 TapTap token 并列出 app。
 - `maker_status`：如果发现本地已有 PAT 但缺少 TapTap token，会自动尝试获取；如果当前目录未绑定，会自动列出 app，不需要用户额外要求。
+- `maker_get_mcp_update_guide`：用户说“更新 mcp / 更新 taptap mcp / 刷新 mcp 缓存”时使用。该工具只返回 Windows 或 macOS/Linux 的更新引导、安装检查、配置位置提醒和重启提示，不直接执行 `npm`、`npx`、删除缓存或自更新；由用户本地 AI 客户端按返回命令执行。
 - `maker_list_apps`：优先用 Maker PAT 拉取 app 列表，必须展示给用户选择；JWT 仅作为 legacy fallback。会解析 Maker `/apps` 返回的创建时间、最近会话时间、游戏类型、阶段、图标、置顶/归档/删除时间等字段，并保留原始 `raw` 数据。
 - `maker_clone_to_current_directory`：把选中的 Maker app 仓库拉到当前目录并写 `.maker-mcp/config.json`。如果本机没有 Git，工具会在申请 PAT 和改动文件前停止。当前目录不要求为空；clone 前会检查本地目录，忽略 `.claude`、`.mcp`、`.skill`、`.config`、`.ini` 等点开头配置项，只对普通本地文件输出提醒。clone 最终结果固定包含 `Pre-clone local directory check` 区块；已有本地文件会保留，若与 Maker 项目文件同路径冲突则失败并列出冲突文件。
 - `maker_configure_remote_proxy`：按 server 测试脚本生成 `proxy_cfg`，写入当前项目 `.mcp.json`，连接远端 `taptap-proxy`。
@@ -98,6 +99,36 @@ Maker app 列表关键字段：
 - `maker_push_current_directory` / `maker_submit_current_directory` 会在 stage、commit、push 阶段输出状态，并解析 Git push stderr 中的百分比进度。
 - `maker_build_current_directory` 会转发远端 build tool 的 progress notification。
 - 以上慢操作最终返回都会包含 `elapsed_ms`、`elapsed`、`progress_events` 和 `last_progress`。如果没有可用百分比进度，则至少返回耗时统计；长任务运行超过 3 分钟时会发送一次仍在运行的 progress heartbeat。
+
+## MCP 更新引导
+
+Maker MCP 内置更新引导工具，但不让 MCP 进程更新自己，避免 Windows 文件锁、当前 npx 缓存被占用和权限问题。
+
+触发话术：
+
+```text
+更新 mcp
+更新 taptap mcp
+刷新 mcp 缓存
+tap mcp 有新版本
+```
+
+Agent 应调用：
+
+```text
+maker_get_mcp_update_guide
+```
+
+工具返回内容会按当前平台生成：
+
+- Windows：PowerShell 命令。
+- macOS/Linux：bash/zsh 命令。
+- 默认更新包：`@taptap/instant-games-open-mcp@beta`。
+- 默认预热入口：`taptap-maker`。
+- 安装检查：`node --version`、`npm --version`、`npx --version`。
+- 配置提醒：检查常见 user/global 和 project/local MCP 配置；发现项目级配置时只提醒建议迁移，不阻塞更新。
+- 更新步骤：对比远端版本、扫描本地 npx 缓存、清理 TapTap MCP 缓存、预热下载、验证缓存版本。
+- 生效提示：当前 MCP 会话通常不会热加载；更新后必须提醒用户重启 MCP 客户端，或新开 Claude Code / Codex / Cursor 窗口，再调用 `maker_status` 验证。
 
 ## 当前 PAT 获取方式
 

--- a/src/__tests__/makerBuildLocalChanges.test.ts
+++ b/src/__tests__/makerBuildLocalChanges.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Maker build local-change guard tests.
+ */
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { buildCurrentDirectory, createBuildArgs } from '../maker/server/mcp';
+import { readMakerProjectLocalChanges } from '../maker/cli/projects';
+import { saveProjectConfig } from '../maker/storage';
+
+describe('maker build local-change guard', () => {
+  let tempDir: string;
+  const originalMakerHome = process.env.TAPTAP_MAKER_HOME;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'maker-build-local-changes-'));
+    process.env.TAPTAP_MAKER_HOME = path.join(tempDir, 'maker-home');
+    runGit(['init']);
+    runGit(['config', 'user.email', 'maker-test@example.test']);
+    runGit(['config', 'user.name', 'maker-test']);
+    fs.writeFileSync(path.join(tempDir, '.gitignore'), '.maker-mcp/\n', 'utf8');
+    fs.mkdirSync(path.join(tempDir, 'scripts'), { recursive: true });
+    fs.writeFileSync(path.join(tempDir, 'scripts', 'main.lua'), '-- initial\n', 'utf8');
+    runGit(['add', '.gitignore', 'scripts/main.lua']);
+    runGit(['commit', '-m', 'chore: initial maker project']);
+    saveProjectConfig(tempDir, {
+      project_id: 'app-1',
+      user_id: 'user-1',
+    });
+  });
+
+  afterEach(() => {
+    if (originalMakerHome === undefined) {
+      delete process.env.TAPTAP_MAKER_HOME;
+    } else {
+      process.env.TAPTAP_MAKER_HOME = originalMakerHome;
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('reports clean Maker project state', async () => {
+    const changes = await readMakerProjectLocalChanges(tempDir);
+
+    expect(changes.hasChanges).toBe(false);
+    expect(changes.files).toEqual([]);
+  });
+
+  test('reports local Maker project changes', async () => {
+    fs.writeFileSync(path.join(tempDir, 'scripts', 'main.lua'), '-- changed\n', 'utf8');
+
+    const changes = await readMakerProjectLocalChanges(tempDir);
+
+    expect(changes.hasChanges).toBe(true);
+    expect(changes.files).toEqual(['scripts/main.lua']);
+  });
+
+  test('blocks build before connecting to remote when local changes are not submitted', async () => {
+    fs.writeFileSync(path.join(tempDir, 'scripts', 'main.lua'), '-- changed\n', 'utf8');
+
+    await expect(buildCurrentDirectory({ targetDir: tempDir })).rejects.toThrow(
+      '提交本地改动并触发构建（以后都是如此）'
+    );
+  });
+
+  test('checks local changes from a Maker project subdirectory', async () => {
+    fs.writeFileSync(path.join(tempDir, 'scripts', 'main.lua'), '-- changed\n', 'utf8');
+
+    await expect(
+      buildCurrentDirectory({ targetDir: path.join(tempDir, 'scripts') })
+    ).rejects.toThrow('Current Maker project has local changes that are not submitted');
+  });
+
+  test('allows explicitly confirmed remote build to pass the local-change guard', async () => {
+    fs.writeFileSync(path.join(tempDir, 'scripts', 'main.lua'), '-- changed\n', 'utf8');
+
+    await expect(
+      buildCurrentDirectory({
+        targetDir: tempDir,
+        confirmRemoteBuildWithoutSubmit: true,
+      })
+    ).rejects.toThrow('Tap auth not found');
+  });
+
+  test('defaults single-player build entry to scripts/main.lua when present', () => {
+    const buildArgs = createBuildArgs(tempDir, {});
+
+    expect(buildArgs).toMatchObject({
+      scriptsPath: 'scripts',
+      entry: 'main.lua',
+      multiplayer: { enabled: false },
+    });
+  });
+
+  test('does not default build entry when scripts/main.lua is missing', () => {
+    fs.unlinkSync(path.join(tempDir, 'scripts', 'main.lua'));
+
+    const buildArgs = createBuildArgs(tempDir, {});
+
+    expect(buildArgs).not.toHaveProperty('scriptsPath');
+    expect(buildArgs).not.toHaveProperty('entry');
+    expect(buildArgs).toMatchObject({
+      multiplayer: { enabled: false },
+    });
+  });
+
+  test('keeps explicit build entry when user overrides the default', () => {
+    const buildArgs = createBuildArgs(tempDir, {
+      scriptsPath: 'custom',
+      entry: 'boot.lua',
+    });
+
+    expect(buildArgs).toMatchObject({
+      scriptsPath: 'custom',
+      entry: 'boot.lua',
+    });
+  });
+
+  test('auto submits local changes before build when project preference is saved', async () => {
+    saveProjectConfig(tempDir, {
+      project_id: 'app-1',
+      user_id: 'user-1',
+      build_local_changes_policy: 'auto_submit',
+    });
+    fs.writeFileSync(path.join(tempDir, 'scripts', 'main.lua'), '-- changed\n', 'utf8');
+    const submittedCwds: string[] = [];
+
+    const result = await buildCurrentDirectory({
+      targetDir: path.join(tempDir, 'scripts'),
+      submitLocalChanges: async (options) => {
+        submittedCwds.push(options.cwd);
+        return {
+          branch: 'main',
+          committed: true,
+          commitHash: 'abc1234',
+          message: 'chore: update maker project',
+          pushed: true,
+          status: 'pushed',
+        };
+      },
+    });
+
+    expect(result.mode).toBe('submitted_for_auto_build');
+    expect(submittedCwds).toEqual([fs.realpathSync(tempDir)]);
+  });
+
+  function runGit(args: string[]): void {
+    const result = spawnSync('git', args, {
+      cwd: tempDir,
+      encoding: 'utf8',
+    });
+    if (result.status !== 0) {
+      throw new Error(`git ${args.join(' ')} failed: ${result.stderr || result.stdout}`);
+    }
+  }
+});

--- a/src/__tests__/makerBuildLocalChanges.test.ts
+++ b/src/__tests__/makerBuildLocalChanges.test.ts
@@ -6,7 +6,7 @@ import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { buildCurrentDirectory, createBuildArgs } from '../maker/server/mcp';
+import { buildCurrentDirectory, createBuildArgs, formatBuildResult } from '../maker/server/mcp';
 import { readMakerProjectLocalChanges } from '../maker/cli/projects';
 import { saveProjectConfig } from '../maker/storage';
 
@@ -54,6 +54,16 @@ describe('maker build local-change guard', () => {
 
     expect(changes.hasChanges).toBe(true);
     expect(changes.files).toEqual(['scripts/main.lua']);
+  });
+
+  test('reports local Maker project changes when filenames contain arrow text', async () => {
+    const fileName = 'scripts/name -> arrow.lua';
+    fs.writeFileSync(path.join(tempDir, fileName), '-- changed\n', 'utf8');
+
+    const changes = await readMakerProjectLocalChanges(tempDir);
+
+    expect(changes.hasChanges).toBe(true);
+    expect(changes.files).toContain(fileName);
   });
 
   test('blocks build before connecting to remote when local changes are not submitted', async () => {
@@ -143,6 +153,44 @@ describe('maker build local-change guard', () => {
 
     expect(result.mode).toBe('submitted_for_auto_build');
     expect(submittedCwds).toEqual([fs.realpathSync(tempDir)]);
+  });
+
+  test('formats auto-submit build failure with actionable failure details', () => {
+    const output = formatBuildResult(
+      {
+        mode: 'submitted_for_auto_build',
+        projectRoot: tempDir,
+        projectId: 'app-1',
+        submitResult: {
+          branch: 'main',
+          committed: true,
+          commitHash: 'abc1234',
+          message: 'chore: update maker project',
+          pushed: false,
+          status: 'failed_after_commit',
+          failure: {
+            stage: 'push',
+            classification: 'remote_rejected',
+            exitCode: 1,
+            stdout: '',
+            stderr: 'rejected',
+            message: 'failed to push some refs',
+            nextAction: '先询问用户是否 pull/rebase 当前 Maker 远端变更，再重试 push。',
+          },
+        },
+      },
+      {
+        elapsedMs: 1000,
+        elapsed: '1s',
+        progressEvents: 1,
+      }
+    );
+
+    expect(output).toContain('failure:');
+    expect(output).toContain('- stage: push');
+    expect(output).toContain('- classification: remote_rejected');
+    expect(output).toContain('rejected');
+    expect(output).toContain('pull/rebase');
   });
 
   function runGit(args: string[]): void {

--- a/src/__tests__/makerUpdateGuide.test.ts
+++ b/src/__tests__/makerUpdateGuide.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Maker MCP update guide tests.
+ */
+
+import { createMakerMcpUpdateGuide } from '../maker/system/updateGuide';
+
+describe('maker MCP update guide', () => {
+  test('returns macOS/Linux shell instructions without self-updating', () => {
+    const guide = createMakerMcpUpdateGuide({ platform: 'darwin' });
+
+    expect(guide).toContain('TapTap Maker MCP update guide');
+    expect(guide).toContain('macOS / Linux');
+    expect(guide).toContain('node --version');
+    expect(guide).toContain('npm --version');
+    expect(guide).toContain('npx --version');
+    expect(guide).toContain('npm view @taptap/instant-games-open-mcp@beta version');
+    expect(guide).toContain('taptap-maker');
+    expect(guide).toContain('rm -rf "$d"');
+    expect(guide).toContain('maker_status');
+    expect(guide).toContain('重启 MCP 客户端');
+    expect(guide).toContain('本工具不会直接执行更新命令');
+  });
+
+  test('returns Windows PowerShell instructions', () => {
+    const guide = createMakerMcpUpdateGuide({ platform: 'win32' });
+
+    expect(guide).toContain('TapTap Maker MCP update guide');
+    expect(guide).toContain('Windows PowerShell');
+    expect(guide).toContain("npm view '@taptap/instant-games-open-mcp@beta' version");
+    expect(guide).toContain('Remove-Item -Recurse -Force');
+    expect(guide).toContain('Start-Process -FilePath npx');
+    expect(guide).toContain('taptap-maker');
+    expect(guide).toContain('新开 Claude Code / Codex / Cursor 窗口');
+    expect(guide).toContain('本工具不会直接执行更新命令');
+  });
+
+  test('supports default package bin update instructions', () => {
+    const guide = createMakerMcpUpdateGuide({
+      platform: 'linux',
+      packageSpec: '@taptap/instant-games-open-mcp',
+      bin: 'instant-games-open-mcp',
+      client: 'codex',
+    });
+
+    expect(guide).toContain('client: codex');
+    expect(guide).toContain('npm view @taptap/instant-games-open-mcp version');
+    expect(guide).toContain('npx -y --prefer-online @taptap/instant-games-open-mcp');
+    expect(guide).not.toContain('-p @taptap/instant-games-open-mcp instant-games-open-mcp');
+  });
+});

--- a/src/maker/cli/projects.ts
+++ b/src/maker/cli/projects.ts
@@ -629,7 +629,7 @@ export async function readMakerProjectLocalChanges(cwd: string): Promise<MakerPr
     );
   }
 
-  const rawStatus = await readGit(['status', '--porcelain'], projectRoot);
+  const rawStatus = await readGit(['status', '--porcelain', '-z'], projectRoot);
   const files = parseGitStatusFiles(rawStatus).filter(
     (file) => file !== '.maker-mcp' && !file.startsWith('.maker-mcp/')
   );
@@ -684,18 +684,23 @@ function generateCommitMessage(status: string): string {
 }
 
 function parseGitStatusFiles(status: string): string[] {
-  return status
-    .split('\n')
-    .map((line) => line.trimEnd())
-    .filter(Boolean)
-    .flatMap((line) => {
-      const file = line.slice(3).trim();
-      if (!file) {
-        return [];
-      }
-      const renameParts = file.split(' -> ');
-      return [renameParts[renameParts.length - 1]];
-    });
+  const entries = status.split('\0').filter(Boolean);
+  const files: string[] = [];
+
+  for (let index = 0; index < entries.length; index += 1) {
+    const entry = entries[index];
+    const statusCode = entry.slice(0, 2);
+    const file = entry.slice(3);
+    if (file) {
+      files.push(file);
+    }
+
+    if (statusCode.includes('R') || statusCode.includes('C')) {
+      index += 1;
+    }
+  }
+
+  return files;
 }
 
 async function readAheadState(cwd: string): Promise<string | undefined> {

--- a/src/maker/cli/projects.ts
+++ b/src/maker/cli/projects.ts
@@ -66,6 +66,13 @@ export interface PushMakerProjectResult {
   ahead?: string;
 }
 
+export interface MakerProjectLocalChanges {
+  hasChanges: boolean;
+  projectRoot: string;
+  files: string[];
+  rawStatus: string;
+}
+
 export interface MakerGitFailure {
   stage: string;
   command?: string;
@@ -607,6 +614,33 @@ export async function pushMakerProject(
   };
 }
 
+export async function readMakerProjectLocalChanges(cwd: string): Promise<MakerProjectLocalChanges> {
+  ensureGitAvailable();
+  const requestedDir = path.resolve(cwd);
+  if (!isGitRepo(requestedDir)) {
+    throw new Error(`${requestedDir} is not a git repository.`);
+  }
+
+  const projectRoot = (await readGit(['rev-parse', '--show-toplevel'], requestedDir)).trim();
+  const configPath = path.join(projectRoot, '.maker-mcp', 'config.json');
+  if (!fs.existsSync(configPath)) {
+    throw new Error(
+      `${projectRoot} is not bound to a Maker project. .maker-mcp/config.json is missing.`
+    );
+  }
+
+  const rawStatus = await readGit(['status', '--porcelain'], projectRoot);
+  const files = parseGitStatusFiles(rawStatus).filter(
+    (file) => file !== '.maker-mcp' && !file.startsWith('.maker-mcp/')
+  );
+  return {
+    hasChanges: files.length > 0,
+    projectRoot,
+    files,
+    rawStatus,
+  };
+}
+
 function ensureTargetCanBindApp(target: string, appId: string): void {
   const existingConfig = loadProjectConfig(target);
   if (!existingConfig?.project_id || existingConfig.project_id === appId) {
@@ -647,6 +681,21 @@ function generateCommitMessage(status: string): string {
   }
 
   return 'chore: update maker project';
+}
+
+function parseGitStatusFiles(status: string): string[] {
+  return status
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .flatMap((line) => {
+      const file = line.slice(3).trim();
+      if (!file) {
+        return [];
+      }
+      const renameParts = file.split(' -> ');
+      return [renameParts[renameParts.length - 1]];
+    });
 }
 
 async function readAheadState(cwd: string): Promise<string | undefined> {

--- a/src/maker/server/mcp.ts
+++ b/src/maker/server/mcp.ts
@@ -65,6 +65,7 @@ import {
   checkGitEnvironment,
   formatGitEnvironmentStatus,
 } from '../system/git.js';
+import { createMakerMcpUpdateGuide, type MakerMcpUpdateBin } from '../system/updateGuide.js';
 
 declare const __MAKER_VERSION__: string | undefined;
 declare const __MAKER_BUNDLE_URL__: string | undefined;
@@ -167,6 +168,32 @@ const tools = [
     inputSchema: {
       type: 'object',
       properties: {},
+    },
+  },
+  {
+    name: 'maker_get_mcp_update_guide',
+    description:
+      'Return platform-specific instructions for updating the local npx cache of @taptap/instant-games-open-mcp. Use when the user says "更新 mcp", "更新 taptap mcp", "刷新 mcp 缓存", or asks how to update Maker MCP. This tool only returns guidance and MUST NOT update npm cache by itself. After calling it, the AI client should run the returned commands in the user local shell, then tell the user to restart or open a new MCP client window for changes to take effect.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        package_spec: {
+          type: 'string',
+          description:
+            'Optional npm package spec to update. Defaults to @taptap/instant-games-open-mcp@beta.',
+        },
+        bin: {
+          type: 'string',
+          enum: ['taptap-maker', 'instant-games-open-mcp', 'taptap-mcp-proxy'],
+          description: 'Optional bin to warm up after cache cleanup. Defaults to taptap-maker.',
+        },
+        client: {
+          type: 'string',
+          enum: ['codex', 'claude', 'cursor', 'unknown'],
+          description:
+            'Optional current AI client name for tailored restart wording. Defaults to unknown.',
+        },
+      },
     },
   },
   {
@@ -430,6 +457,26 @@ export async function startMakerMcpServer(): Promise<void> {
             {
               type: 'text',
               text: formatEnvironment(),
+            },
+          ],
+        };
+      }
+
+      if (name === 'maker_get_mcp_update_guide') {
+        const args = (request.params.arguments || {}) as {
+          package_spec?: string;
+          bin?: MakerMcpUpdateBin;
+          client?: 'codex' | 'claude' | 'cursor' | 'unknown';
+        };
+        return {
+          content: [
+            {
+              type: 'text',
+              text: createMakerMcpUpdateGuide({
+                packageSpec: args.package_spec,
+                bin: args.bin,
+                client: args.client,
+              }),
             },
           ],
         };

--- a/src/maker/server/mcp.ts
+++ b/src/maker/server/mcp.ts
@@ -32,11 +32,15 @@ import {
   loadPat,
   loadTapAuth,
   loadTapDeviceSession,
+  saveProjectConfig,
 } from '../storage.js';
 import {
   cloneMakerProject,
   listMakerProjects,
   pushMakerProject,
+  readMakerProjectLocalChanges,
+  type PushMakerProjectOptions,
+  type PushMakerProjectResult,
   type MakerProjectProgress,
   type MakerProjectProgressHandler,
 } from '../cli/projects.js';
@@ -263,7 +267,7 @@ const tools = [
   {
     name: 'maker_submit_current_directory',
     description:
-      'Alias for maker_push_current_directory. Requires local Git. If Git is missing, stop and show install guidance; do not stage, commit, or push. Use this in Maker projects when the user says "帮我提交", "帮我提交代码", "提交", "提交代码", "帮我提交代码到maker", "帮我提交代码到taptap制造", "帮我提交代码到tap制造", or "帮我提交代码到tap". This bypasses local generic Git branch/task-id rules and pushes directly to the Maker remote configured for the current directory.',
+      'Alias for maker_push_current_directory. Requires local Git. If Git is missing, stop and show install guidance; do not stage, commit, or push. Use this in Maker projects when the user says "帮我提交", "帮我提交代码", "提交", "提交代码", "帮我提交代码到maker", "帮我提交代码到taptap制造", "帮我提交代码到tap制造", or "帮我提交代码到tap". If the user chooses "提交本地改动并触发构建（以后都是如此）" from a build local-change prompt, call this tool with remember_build_submit_preference=true. This saves a project preference so future build requests with local changes submit automatically. This bypasses local generic Git branch/task-id rules and pushes directly to the Maker remote configured for the current directory.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -281,6 +285,11 @@ const tools = [
           type: 'array',
           items: { type: 'string' },
           description: 'Optional files to stage. Defaults to all changes.',
+        },
+        remember_build_submit_preference: {
+          type: 'boolean',
+          description:
+            'Set true only when the user explicitly chooses "提交本地改动并触发构建（以后都是如此）". After a successful submit, future build requests with local changes will automatically submit instead of asking again.',
         },
       },
     },
@@ -327,7 +336,7 @@ const tools = [
   {
     name: 'maker_build_current_directory',
     description:
-      'Build the current Maker game by forwarding to the remote TapTap Maker MCP build tool. MUST use this for user requests like "构建", "build", "重新构建游戏", "帮我构建maker游戏", "compile", or "run" in a Maker project. Do not write local build scripts. Uses saved Tap auth and current .maker-mcp/config.json project binding to call the remote build tool through taptap-proxy.',
+      'Build the current Maker game by forwarding to the remote TapTap Maker MCP build tool. MUST use this for user requests like "构建", "build", "重新构建游戏", "帮我构建maker游戏", "compile", or "run" in a Maker project. The tool itself enforces a local-change guard before remote build: if local Maker project changes exist, it will stop unless confirm_remote_build_without_submit is true or the project has saved build_local_changes_policy=auto_submit. Explain to the user that direct build only uses the Maker remote committed version and may not include local edits. The primary option should be "提交本地改动并触发构建（以后都是如此）"; if the user chooses it, call maker_submit_current_directory with remember_build_submit_preference=true. Successful Maker submit is commit + push and automatically triggers build, so do not call manual build again unless the user explicitly asks. If auto_submit preference is already saved, this build tool will submit local changes automatically and rely on Maker auto build. If the user explicitly says not to submit and wants to build the remote version, call this tool with confirm_remote_build_without_submit=true. Do not write local build scripts. Uses saved Tap auth and current .maker-mcp/config.json project binding to call the remote build tool through taptap-proxy.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -339,12 +348,12 @@ const tools = [
         entry: {
           type: 'string',
           description:
-            'Optional single-player Lua entry file relative to scriptsPath, e.g. "main.lua". Omit to let the remote build tool infer/default.',
+            'Optional single-player Lua entry file relative to scriptsPath, e.g. "main.lua". If omitted and local scripts/main.lua exists with no explicit multiplayer entries, Maker MCP sends entry="main.lua" and scriptsPath="scripts" by default to avoid remote entry-missing prompts. Otherwise omit to let the remote build tool infer/default.',
         },
         scriptsPath: {
           type: 'string',
           description:
-            'Optional scripts directory relative to workspace. Remote build defaults to "scripts" when omitted.',
+            'Optional scripts directory relative to workspace. If omitted and local scripts/main.lua exists with no explicit entry overrides, Maker MCP sends scriptsPath="scripts" by default.',
         },
         entry_client: {
           type: 'string',
@@ -375,6 +384,11 @@ const tools = [
           type: 'number',
           description:
             'Optional remote build timeout in milliseconds. Defaults to 10 minutes. If timed out, do not retry blindly; inspect remote build logs first.',
+        },
+        confirm_remote_build_without_submit: {
+          type: 'boolean',
+          description:
+            'Set true only after the user explicitly confirms they do not want to submit local changes and want to build the current Maker remote committed version.',
         },
       },
     },
@@ -669,6 +683,7 @@ export async function startMakerMcpServer(): Promise<void> {
           pat?: string;
           jwt?: string;
           force_pat?: boolean;
+          remember_build_submit_preference?: boolean;
         };
 
         const targetDir = args.target_dir || process.cwd();
@@ -691,6 +706,9 @@ export async function startMakerMcpServer(): Promise<void> {
             forcePat: args.force_pat === true,
             onProgress: progressReporter.report,
           });
+          if (args.remember_build_submit_preference && !result.failure) {
+            rememberBuildSubmitPreference(targetDir);
+          }
           progressSummary = progressReporter.finish();
         } catch (error) {
           progressReporter.finish();
@@ -747,6 +765,7 @@ export async function startMakerMcpServer(): Promise<void> {
           server_url?: string;
           env?: 'rnd' | 'production';
           timeout_ms?: number;
+          confirm_remote_build_without_submit?: boolean;
         };
 
         const progressReporter = createToolProgressReporter(
@@ -767,6 +786,7 @@ export async function startMakerMcpServer(): Promise<void> {
             serverUrl: args.server_url,
             env: args.env,
             timeoutMs: args.timeout_ms,
+            confirmRemoteBuildWithoutSubmit: args.confirm_remote_build_without_submit,
             onProgress: progressReporter.report,
           });
           progressSummary = progressReporter.finish();
@@ -831,6 +851,10 @@ async function formatStatus(): Promise<string> {
     ? [
         '当前目录已绑定 Maker 项目。',
         '如果用户要求“帮我提交代码 / 提交并推送 / push / 帮我提交代码到maker / 帮我提交代码到taptap制造 / 帮我提交代码到tap制造 / 帮我提交代码到tap”，必须调用 maker_submit_current_directory 或 maker_push_current_directory。',
+        '如果用户要求“构建 / build / 重新构建 / 查看结果 / 预览 / 跑一下 / 验证一下”，必须先经过 maker_build_current_directory 的本地改动强制检查；有本地改动时不要静默构建云端旧版本，应询问用户是否提交。',
+        '优先选项文案应是“提交本地改动并触发构建（以后都是如此）”；用户选择后调用 maker_submit_current_directory，并设置 remember_build_submit_preference=true。',
+        'Maker 提交等于 commit + push，提交成功后会自动触发构建，不要再额外调用 build；保存偏好后，后续构建遇到本地改动会自动提交。',
+        '用户明确说不提交、直接构建云端版本时，才允许调用 maker_build_current_directory 并设置 confirm_remote_build_without_submit=true。',
         '不要套用本地通用 Git skill 的任务号、默认分支保护、新建分支规则；Maker push 按远端 Maker 仓库当前分支直接提交并推送。',
       ].join('\n')
     : pat
@@ -867,6 +891,21 @@ async function formatStatus(): Promise<string> {
   ]
     .filter(Boolean)
     .join('\n');
+}
+
+function rememberBuildSubmitPreference(targetDir: string): void {
+  const identify = identifyMakerProject({ cwd: targetDir });
+  if (!identify.projectRoot || !identify.projectId) {
+    throw new Error(
+      `${targetDir} is not bound to a Maker project. Cannot save build submit preference.`
+    );
+  }
+
+  saveProjectConfig(identify.projectRoot, {
+    ...(identify.config || { project_id: identify.projectId }),
+    project_id: identify.projectId,
+    build_local_changes_policy: 'auto_submit',
+  });
 }
 
 async function formatAutoProjectListFromPat(): Promise<string> {
@@ -1353,7 +1392,30 @@ function formatDuration(ms: number): string {
   return `${minutes}m ${seconds}s`;
 }
 
-async function buildCurrentDirectory(options: {
+type SubmitLocalChangesForBuild = (
+  options: PushMakerProjectOptions
+) => Promise<PushMakerProjectResult>;
+
+type BuildCurrentDirectoryResult =
+  | {
+      mode: 'remote_build';
+      projectRoot: string;
+      projectId: string;
+      projectPath: string;
+      serverUrl: string;
+      env: string;
+      timeoutMs: number;
+      buildArgs: Record<string, unknown>;
+      resultText: string;
+    }
+  | {
+      mode: 'submitted_for_auto_build';
+      projectRoot: string;
+      projectId: string;
+      submitResult: PushMakerProjectResult;
+    };
+
+export async function buildCurrentDirectory(options: {
   targetDir: string;
   entry?: string;
   scriptsPath?: string;
@@ -1363,17 +1425,35 @@ async function buildCurrentDirectory(options: {
   serverUrl?: string;
   env?: 'rnd' | 'production';
   timeoutMs?: number;
+  confirmRemoteBuildWithoutSubmit?: boolean;
+  submitLocalChanges?: SubmitLocalChangesForBuild;
   onProgress?: MakerProjectProgressHandler;
-}): Promise<{
-  projectRoot: string;
-  projectId: string;
-  projectPath: string;
-  serverUrl: string;
-  env: string;
-  timeoutMs: number;
-  buildArgs: Record<string, unknown>;
-  resultText: string;
-}> {
+}): Promise<BuildCurrentDirectoryResult> {
+  const localChanges = await readMakerProjectLocalChanges(options.targetDir);
+  if (localChanges.hasChanges && !options.confirmRemoteBuildWithoutSubmit) {
+    const config = loadProjectConfig(localChanges.projectRoot);
+    if (config?.build_local_changes_policy === 'auto_submit') {
+      options.onProgress?.({
+        progress: 0,
+        total: 100,
+        phase: 'auto_submit',
+        message: 'Auto-submitting local Maker changes before build',
+      });
+      const submitResult = await (options.submitLocalChanges || pushMakerProject)({
+        cwd: localChanges.projectRoot,
+        onProgress: options.onProgress,
+      });
+      return {
+        mode: 'submitted_for_auto_build',
+        projectRoot: localChanges.projectRoot,
+        projectId: config.project_id,
+        submitResult,
+      };
+    }
+
+    throw new Error(formatLocalChangesBeforeBuildMessage(localChanges.files));
+  }
+
   const proxy = createRemoteProxyContext({
     targetDir: options.targetDir,
     serverUrl: options.serverUrl,
@@ -1421,6 +1501,7 @@ async function buildCurrentDirectory(options: {
     );
 
     return {
+      mode: 'remote_build',
       projectRoot: proxy.projectRoot,
       projectId: proxy.projectId,
       projectPath: proxy.projectPath,
@@ -1435,7 +1516,24 @@ async function buildCurrentDirectory(options: {
   }
 }
 
-function createBuildArgs(
+function formatLocalChangesBeforeBuildMessage(files: string[]): string {
+  const visibleFiles = files.slice(0, 20);
+  const hiddenCount = Math.max(0, files.length - visibleFiles.length);
+  return [
+    'Current Maker project has local changes that are not submitted.',
+    '',
+    '当前有本地修改还没有提交。直接构建只会构建 Maker 云端已有版本，可能看不到这些新修改。',
+    '请先询问用户选择：',
+    '- 提交本地改动并触发构建（以后都是如此）：调用 maker_submit_current_directory，并设置 remember_build_submit_preference=true；提交会同时保存并推送到 Maker，提交成功后自动触发构建，不要再额外调用 build。后续构建遇到本地改动会默认自动提交。',
+    '- 如果用户明确说不提交、直接构建云端版本，再调用 maker_build_current_directory，并设置 confirm_remote_build_without_submit=true。',
+    '',
+    'local_changes:',
+    ...visibleFiles.map((file) => `- ${file}`),
+    ...(hiddenCount > 0 ? [`- ... and ${hiddenCount} more`] : []),
+  ].join('\n');
+}
+
+export function createBuildArgs(
   projectRoot: string,
   options: {
     entry?: string;
@@ -1451,6 +1549,17 @@ function createBuildArgs(
   }
   if (options.scriptsPath) {
     buildArgs.scriptsPath = options.scriptsPath;
+  }
+  if (
+    !options.entry &&
+    !options.scriptsPath &&
+    !options.entryClient &&
+    !options.entryServer &&
+    !options.multiplayer &&
+    fs.existsSync(path.join(projectRoot, 'scripts', 'main.lua'))
+  ) {
+    buildArgs.entry = 'main.lua';
+    buildArgs.scriptsPath = 'scripts';
   }
   if (options.entryClient) {
     buildArgs.entry_client = options.entryClient;
@@ -1505,18 +1614,34 @@ function formatRemoteToolResult(result: unknown): string {
 }
 
 function formatBuildResult(
-  result: {
-    projectRoot: string;
-    projectId: string;
-    projectPath: string;
-    serverUrl: string;
-    env: string;
-    timeoutMs: number;
-    buildArgs: Record<string, unknown>;
-    resultText: string;
-  },
+  result: BuildCurrentDirectoryResult,
   progressSummary: ToolProgressSummary
 ): string {
+  if (result.mode === 'submitted_for_auto_build') {
+    return [
+      result.submitResult.pushed
+        ? '✓ Maker project submitted; Maker auto build triggered'
+        : result.submitResult.status === 'clean'
+          ? 'Maker project has no changes to submit; Maker auto build was not triggered'
+          : '✗ Maker project submit failed; Maker auto build was not triggered',
+      '',
+      `- project_root: ${result.projectRoot}`,
+      `- project_id: ${result.projectId}`,
+      '- build_local_changes_policy: auto_submit',
+      `- branch: ${result.submitResult.branch}`,
+      `- status: ${result.submitResult.status}`,
+      `- committed: ${result.submitResult.committed ? 'yes' : 'no'}`,
+      result.submitResult.commitHash ? `- commit_hash: ${result.submitResult.commitHash}` : '',
+      result.submitResult.message ? `- commit_message: ${result.submitResult.message}` : '',
+      result.submitResult.ahead ? `- git_state: ${result.submitResult.ahead}` : '',
+      ...formatProgressSummary(progressSummary),
+      '',
+      'note: Maker submit is commit + push; successful submit automatically triggers build.',
+    ]
+      .filter(Boolean)
+      .join('\n');
+  }
+
   return [
     '✓ Remote Maker build finished',
     '',

--- a/src/maker/server/mcp.ts
+++ b/src/maker/server/mcp.ts
@@ -1660,7 +1660,7 @@ function formatRemoteToolResult(result: unknown): string {
     .join('\n');
 }
 
-function formatBuildResult(
+export function formatBuildResult(
   result: BuildCurrentDirectoryResult,
   progressSummary: ToolProgressSummary
 ): string {
@@ -1684,6 +1684,9 @@ function formatBuildResult(
       ...formatProgressSummary(progressSummary),
       '',
       'note: Maker submit is commit + push; successful submit automatically triggers build.',
+      ...(result.submitResult.failure
+        ? ['', ...formatMakerFailureLines(result.submitResult.failure)]
+        : []),
     ]
       .filter(Boolean)
       .join('\n');
@@ -1750,20 +1753,28 @@ function formatPushResult(
     return lines.join('\n');
   }
 
+  return [...lines, '', ...formatMakerFailureLines(result.failure)].filter(Boolean).join('\n');
+}
+
+function formatMakerFailureLines(failure: {
+  stage: string;
+  command?: string;
+  exitCode?: number | null;
+  stdout?: string;
+  stderr?: string;
+  classification: string;
+  nextAction: string;
+}): string[] {
   return [
-    ...lines,
-    '',
     'failure:',
-    `- stage: ${result.failure.stage}`,
-    `- classification: ${result.failure.classification}`,
-    `- exit_code: ${result.failure.exitCode ?? '(none)'}`,
-    result.failure.command ? `- command: ${result.failure.command}` : '',
-    result.failure.stderr ? `- stderr:\n${indent(result.failure.stderr)}` : '',
-    result.failure.stdout ? `- stdout:\n${indent(result.failure.stdout)}` : '',
-    `- next_action: ${result.failure.nextAction}`,
-  ]
-    .filter(Boolean)
-    .join('\n');
+    `- stage: ${failure.stage}`,
+    `- classification: ${failure.classification}`,
+    `- exit_code: ${failure.exitCode ?? '(none)'}`,
+    failure.command ? `- command: ${failure.command}` : '',
+    failure.stderr ? `- stderr:\n${indent(failure.stderr)}` : '',
+    failure.stdout ? `- stdout:\n${indent(failure.stdout)}` : '',
+    `- next_action: ${failure.nextAction}`,
+  ].filter(Boolean);
 }
 
 function formatToolException(toolName: string, error: unknown): string {

--- a/src/maker/system/updateGuide.ts
+++ b/src/maker/system/updateGuide.ts
@@ -1,0 +1,270 @@
+/**
+ * Platform-specific TapTap MCP update guidance.
+ */
+
+export type MakerMcpUpdateBin = 'taptap-maker' | 'instant-games-open-mcp' | 'taptap-mcp-proxy';
+
+export interface MakerMcpUpdateGuideOptions {
+  platform?: NodeJS.Platform;
+  packageSpec?: string;
+  bin?: MakerMcpUpdateBin;
+  client?: 'codex' | 'claude' | 'cursor' | 'unknown';
+}
+
+const DEFAULT_PACKAGE_SPEC = '@taptap/instant-games-open-mcp@beta';
+const DEFAULT_BIN: MakerMcpUpdateBin = 'taptap-maker';
+const UPDATE_BINS: MakerMcpUpdateBin[] = [
+  'taptap-maker',
+  'instant-games-open-mcp',
+  'taptap-mcp-proxy',
+];
+
+export function createMakerMcpUpdateGuide(options: MakerMcpUpdateGuideOptions = {}): string {
+  const platform = options.platform || process.platform;
+  const packageSpec = options.packageSpec || DEFAULT_PACKAGE_SPEC;
+  const bin = isMakerMcpUpdateBin(options.bin) ? options.bin : DEFAULT_BIN;
+  const client = options.client || 'unknown';
+  const isWindows = platform === 'win32';
+
+  return [
+    'TapTap Maker MCP update guide',
+    '',
+    `- platform: ${isWindows ? 'Windows PowerShell' : 'macOS / Linux'}`,
+    `- client: ${client}`,
+    `- package: ${packageSpec}`,
+    `- bin: ${bin}`,
+    '',
+    'Important',
+    '',
+    '- 本工具不会直接执行更新命令，只返回适合当前平台的更新引导。',
+    '- 请由当前本地 AI 客户端在用户机器的 shell 中执行下列命令。',
+    '- 推荐把 Maker MCP 安装到 user/global scope，不建议放在当前项目目录或仓库级配置。',
+    '- 如果现在是 project/local scope，也可以继续更新；后续可让 Claude Code / Codex / Cursor 迁移到 user/global scope。',
+    '- 更新 npx 缓存后，当前 MCP 会话通常不会热加载；请重启 MCP 客户端，或新开 Claude Code / Codex / Cursor 窗口。',
+    '- 重启后调用 maker_status，确认新 MCP 已生效。',
+    '',
+    isWindows ? createWindowsGuide(packageSpec, bin) : createPosixGuide(packageSpec, bin),
+  ].join('\n');
+}
+
+function createWindowsGuide(packageSpec: string, bin: MakerMcpUpdateBin): string {
+  return [
+    'Windows PowerShell',
+    '',
+    'Step 0: 安装检查和配置位置提醒',
+    '',
+    '```powershell',
+    'node --version',
+    'npm --version',
+    'npx --version',
+    '',
+    '# 1. 项目级 .mcp.json（Claude Code / Codex 都可能读取）',
+    'if (Test-Path .mcp.json) {',
+    "  if (Select-String -Path .mcp.json -Pattern 'taptap|instant-games-open-mcp|taptap-maker' -Quiet) {",
+    '    Write-Host "ℹ️  当前目录 .mcp.json 包含 TapTap MCP。更新可以继续；建议后续迁移到 user/global scope。"',
+    '  }',
+    '}',
+    '',
+    '# 2. Claude Code user/project scope',
+    '$cj = "$env:USERPROFILE\\.claude.json"',
+    'if (Test-Path $cj) {',
+    '  $json = Get-Content $cj -Raw | ConvertFrom-Json',
+    '  if ($json.mcpServers) {',
+    "    $json.mcpServers.PSObject.Properties | Where-Object { $_.Name -match 'taptap' } | ForEach-Object {",
+    '      Write-Host "✅ Claude Code user scope 已安装：$($_.Name)"',
+    '    }',
+    '  }',
+    '  if ($json.projects) {',
+    '    $json.projects.PSObject.Properties | ForEach-Object {',
+    '      $projectPath = $_.Name',
+    '      $servers = $_.Value.mcpServers',
+    '      if ($servers) {',
+    "        $servers.PSObject.Properties | Where-Object { $_.Name -match 'taptap' } | ForEach-Object {",
+    '          Write-Host "ℹ️  Claude Code project scope TapTap MCP：$($_.Name) under $projectPath。建议后续迁移到 user/global scope。"',
+    '        }',
+    '      }',
+    '    }',
+    '  }',
+    '}',
+    '',
+    '# 3. 常见项目级 MCP / AI 客户端配置。只查已知路径，避免扫到源码或游戏资源。',
+    "$projectConfigPaths = @('.codex\\config.toml', '.codex\\mcp.json', '.cursor\\mcp.json', '.vscode\\mcp.json', 'codex.toml')",
+    'foreach ($f in $projectConfigPaths) {',
+    "  if ((Test-Path $f) -and (Select-String -Path $f -Pattern 'taptap|instant-games-open-mcp|taptap-maker' -Quiet)) {",
+    '    Write-Host "ℹ️  $f 包含 TapTap MCP。更新可以继续；建议后续迁移到 user/global scope。"',
+    '  }',
+    '}',
+    '```',
+    '',
+    'Step 1: 对比远端和本地 npx 缓存版本',
+    '',
+    '```powershell',
+    `npm view ${quotePowerShell(packageSpec)} version`,
+    "$NpxDir = Join-Path (npm config get cache) '_npx'",
+    '$LocalVersions = @()',
+    'Get-ChildItem $NpxDir -Directory -ErrorAction SilentlyContinue | ForEach-Object {',
+    "  $p = Join-Path $_.FullName 'node_modules\\@taptap\\instant-games-open-mcp\\package.json'",
+    '  if (Test-Path $p) {',
+    '    $version = (Get-Content $p -Raw | ConvertFrom-Json).version',
+    '    $LocalVersions += "$($_.Name) -> $version"',
+    '  }',
+    '}',
+    '$LocalVersions',
+    '```',
+    '',
+    '如果远端和本地版本已经一致，可以结束更新缓存流程，但仍建议重启或新开窗口确认。',
+    '',
+    'Step 2: 清理 TapTap MCP 的 npx 缓存',
+    '',
+    '```powershell',
+    "$NpxDir = Join-Path (npm config get cache) '_npx'",
+    'Get-ChildItem $NpxDir -Directory -ErrorAction SilentlyContinue | ForEach-Object {',
+    "  if (Test-Path (Join-Path $_.FullName 'node_modules\\@taptap\\instant-games-open-mcp')) {",
+    '    Remove-Item -Recurse -Force $_.FullName',
+    '  }',
+    '}',
+    '```',
+    '',
+    'Step 3: 预热下载新版本',
+    '',
+    '```powershell',
+    "$env:TAPTAP_MCP_ENV = 'rnd'",
+    "$log = Join-Path $env:TEMP 'taptap-mcp-warmup.log'",
+    '$proc = Start-Process -FilePath npx `',
+    `  -ArgumentList ${formatPowerShellArgumentList(createNpxWarmupArgs(packageSpec, bin))} \``,
+    '  -RedirectStandardOutput $log -RedirectStandardError "$log.err" `',
+    '  -WindowStyle Hidden -PassThru',
+    'Start-Sleep -Seconds 25',
+    'Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue',
+    '```',
+    '',
+    'Step 4: 验证缓存版本',
+    '',
+    '```powershell',
+    "$NpxDir = Join-Path (npm config get cache) '_npx'",
+    'Get-ChildItem $NpxDir -Directory -ErrorAction SilentlyContinue | ForEach-Object {',
+    "  $p = Join-Path $_.FullName 'node_modules\\@taptap\\instant-games-open-mcp\\package.json'",
+    '  if (Test-Path $p) { "$($_.Name) -> $((Get-Content $p -Raw | ConvertFrom-Json).version)" }',
+    '}',
+    '```',
+    '',
+    'Step 5: 生效方式',
+    '',
+    '请重启 MCP 客户端，或新开 Claude Code / Codex / Cursor 窗口。当前会话通常不会热加载新 MCP；重启后调用 maker_status 验证。',
+  ].join('\n');
+}
+
+function createPosixGuide(packageSpec: string, bin: MakerMcpUpdateBin): string {
+  return [
+    'macOS / Linux',
+    '',
+    'Step 0: 安装检查和配置位置提醒',
+    '',
+    '```bash',
+    'node --version',
+    'npm --version',
+    'npx --version',
+    '',
+    '# 1. 项目级 .mcp.json',
+    '[ -f .mcp.json ] && grep -qiE "taptap|instant-games-open-mcp|taptap-maker" .mcp.json && \\',
+    '  echo "ℹ️  当前目录 .mcp.json 包含 TapTap MCP。更新可以继续；建议后续迁移到 user/global scope。"',
+    '',
+    '# 2. Claude Code user/project scope。没有 jq 时跳过，不阻塞更新。',
+    'CJ="$HOME/.claude.json"',
+    'if [ -f "$CJ" ] && command -v jq >/dev/null 2>&1; then',
+    "  jq -r '",
+    '    .mcpServers // {} | to_entries[]',
+    '    | select(.key | test("taptap"; "i"))',
+    '    | "✅ Claude Code user scope 已安装: \\(.key)"',
+    '  \' "$CJ"',
+    "  jq -r '",
+    '    .projects // {} | to_entries[]',
+    '    | . as $p | $p.value.mcpServers // {} | to_entries[]',
+    '    | select(.key | test("taptap"; "i"))',
+    '    | "ℹ️  Claude Code project scope TapTap MCP: \\($p.key) -> \\(.key)。建议后续迁移到 user/global scope。"',
+    '  \' "$CJ"',
+    'fi',
+    '',
+    '# 3. 常见项目级 MCP / AI 客户端配置。只查已知路径，避免扫到源码或游戏资源。',
+    'for f in .codex/config.toml .codex/mcp.json .cursor/mcp.json .vscode/mcp.json codex.toml; do',
+    '  [ -f "$f" ] && grep -qiE "taptap|instant-games-open-mcp|taptap-maker" "$f" && \\',
+    '    echo "ℹ️  $f 包含 TapTap MCP。更新可以继续；建议后续迁移到 user/global scope。"',
+    'done',
+    '```',
+    '',
+    'Step 1: 对比远端和本地 npx 缓存版本',
+    '',
+    '```bash',
+    `npm view ${quotePosix(packageSpec)} version`,
+    'NPX_DIR="$(npm config get cache)/_npx"',
+    'for d in "$NPX_DIR"/*/; do',
+    '  p="$d/node_modules/@taptap/instant-games-open-mcp/package.json"',
+    '  [ -f "$p" ] && echo "$(basename "$d") -> $(node -p "require(process.argv[1]).version" "$p")"',
+    'done',
+    '```',
+    '',
+    '如果远端和本地版本已经一致，可以结束更新缓存流程，但仍建议重启或新开窗口确认。',
+    '',
+    'Step 2: 清理 TapTap MCP 的 npx 缓存',
+    '',
+    '```bash',
+    'NPX_DIR="$(npm config get cache)/_npx"',
+    'for d in "$NPX_DIR"/*/; do',
+    '  [ -d "$d/node_modules/@taptap/instant-games-open-mcp" ] && rm -rf "$d"',
+    'done',
+    '```',
+    '',
+    'Step 3: 预热下载新版本',
+    '',
+    '```bash',
+    `TAPTAP_MCP_ENV=rnd ${formatPosixNpxWarmup(packageSpec, bin)} \\`,
+    '  < /dev/null > /tmp/taptap-mcp-warmup.log 2>&1 &',
+    'PID=$!; sleep 25; kill "$PID" 2>/dev/null; wait "$PID" 2>/dev/null',
+    '```',
+    '',
+    'Step 4: 验证缓存版本',
+    '',
+    '```bash',
+    'NPX_DIR="$(npm config get cache)/_npx"',
+    'for d in "$NPX_DIR"/*/; do',
+    '  p="$d/node_modules/@taptap/instant-games-open-mcp/package.json"',
+    '  [ -f "$p" ] && echo "$(basename "$d") -> $(node -p "require(process.argv[1]).version" "$p")"',
+    'done',
+    '```',
+    '',
+    'Step 5: 生效方式',
+    '',
+    '请重启 MCP 客户端，或新开 Claude Code / Codex / Cursor 窗口。当前会话通常不会热加载新 MCP；重启后调用 maker_status 验证。',
+  ].join('\n');
+}
+
+function createNpxWarmupArgs(packageSpec: string, bin: MakerMcpUpdateBin): string[] {
+  if (bin === 'instant-games-open-mcp') {
+    return ['-y', '--prefer-online', packageSpec];
+  }
+  return ['-y', '--prefer-online', '-p', packageSpec, bin];
+}
+
+function isMakerMcpUpdateBin(value: unknown): value is MakerMcpUpdateBin {
+  return typeof value === 'string' && UPDATE_BINS.includes(value as MakerMcpUpdateBin);
+}
+
+function quotePowerShell(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function formatPowerShellArgumentList(args: string[]): string {
+  return args.map(quotePowerShell).join(',');
+}
+
+function formatPosixNpxWarmup(packageSpec: string, bin: MakerMcpUpdateBin): string {
+  const args = createNpxWarmupArgs(packageSpec, bin);
+  return ['npx', ...args].map(quotePosix).join(' ');
+}
+
+function quotePosix(value: string): string {
+  if (/^[A-Za-z0-9_./:=@+-]+$/.test(value)) {
+    return value;
+  }
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}

--- a/src/maker/types.ts
+++ b/src/maker/types.ts
@@ -42,6 +42,7 @@ export interface MakerProjectConfig {
   user_id?: string;
   sce_endpoint?: string;
   custom_fields?: Record<string, string>;
+  build_local_changes_policy?: 'ask' | 'auto_submit';
   created_at?: string;
   updated_at?: string;
 }


### PR DESCRIPTION
## 改动内容
- 强制 Maker 构建前检查本地未提交改动，并引导用户提交本地改动并触发构建。
- 支持记住用户选择，后续构建遇到本地改动时自动提交并依赖 Maker 自动构建。
- 构建转发前在本地存在 scripts/main.lua 时默认传 scriptsPath=scripts 和 entry=main.lua，减少首次构建入口缺失提示。
- 新增 Maker MCP 更新引导工具，提供跨平台 npx 缓存更新说明。

## 影响面
- Maker 本地 MCP 的 build/submit 工具交互和转发参数。
- Maker 项目本地配置 .maker-mcp/config.json 新增 build_local_changes_policy。
- 文档与测试覆盖同步更新。

## 验证
- npm test -- --runInBand
- npm run lint
- npm run build