### PR TITLE
fix(maker): avoid clone prompt for bound projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ maker_submit_current_directory
 - `maker_clone_to_current_directory` 不要求当前目录为空；clone 前会检查本地目录，忽略 `.claude`、`.mcp`、`.skill`、`.config`、`.ini` 等点开头配置项，只对普通本地文件输出提醒。clone 最终结果固定包含 `Pre-clone local directory check` 区块；已有本地文件会保留，若与 Maker 项目文件同路径冲突则失败并列出冲突文件。
 - `maker_list_apps` 会解析 Maker `/apps` 返回的创建时间、最近会话时间、游戏类型、阶段、图标、置顶/归档/删除时间等字段，并保留原始 `raw` 数据。
 - PAT 会保存到 `~/.taptap-maker/pat.json`，并兼容旧的 `~/.maker-pat`、`PAT` / `MAKER_PAT` 环境变量。
-- Maker app 必须先通过 `maker_list_apps` 展示给用户选择，再调用 clone。
+- 只有当前目录未绑定且用户要初始化或 clone 时，才通过 app 列表让用户选择并调用 clone；已绑定目录里的 app 列表只作账号项目参考，应继续当前项目，除非用户明确要求切换或重新 clone。
 - Maker 后端地址按 `TAPTAP_MCP_ENV` 从 `src/maker/config.ts` 的环境配置表读取，本地 MCP 配置只需要切 `rnd` / `production`。
 - 如果用户直接说“构建 / build / 重新构建游戏”，本地 Maker MCP 应调用 `maker_build_current_directory`。该工具会强制检查本地 Maker 项目是否有未提交改动。
 - 如果构建前发现本地有改动且尚未保存自动提交偏好，工具会停止并提示用户选择：`提交本地改动并触发构建（以后都是如此）`，或明确不提交、只构建云端已有版本。
@@ -361,7 +361,7 @@ maker_submit_current_directory
 测试时引导用户访问当前环境的 PAT 页面新建 Maker PAT，
 production 使用 `https://maker.taptap.cn/pat-tokens`，RND 使用 `https://fuping.agnt.xd.com/pat-tokens`，
 再作为 `manual_pat` 传给 `maker_exchange_pat`，工具会同步获取 TapTap token。
-APP_ID 应通过 `maker_exchange_pat` 自动返回的 app 列表让用户选择，再传给 clone 工具。
+当前目录未绑定时，APP_ID 应通过 `maker_exchange_pat` 自动返回的 app 列表让用户选择，再传给 clone 工具；当前目录已绑定时不要再次引导 clone。
 
 ```bash
 npm run build

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -74,7 +74,7 @@ maker_status
 
 - `maker_exchange_pat`：接收用户提供的 Maker PAT，以 `manual_pat` 传入后保存到本地 `~/.taptap-maker/pat.json`，并兼容旧的 `~/.maker-pat`；保存后会自动获取 TapTap token 并列出 app。
 - `maker_status`：统一输出本地 Maker 状态、Git 前置条件和初始化引导；如果发现本地已有 PAT 但缺少 TapTap token，会自动尝试获取；如果当前目录未绑定，会自动列出 app，不需要用户额外要求。
-- `maker_list_apps`：优先用 Maker PAT 拉取 app 列表，必须展示给用户选择。会解析 Maker `/apps` 返回的创建时间、最近会话时间、游戏类型、阶段、图标、置顶/归档/删除时间等字段，并保留原始 `raw` 数据。
+- `maker_list_apps`：优先用 Maker PAT 拉取 app 列表。只有当前目录未绑定且用户要初始化或 clone 时，才展示给用户选择并继续 clone；如果当前目录已绑定，app 列表只作账号项目参考，不要再引导 clone。会解析 Maker `/apps` 返回的创建时间、最近会话时间、游戏类型、阶段、图标、置顶/归档/删除时间等字段，并保留原始 `raw` 数据。
 - `maker_clone_to_current_directory`：把选中的 Maker app 仓库拉到当前目录并写 `.maker-mcp/config.json`。如果本机没有 Git，工具会在申请 PAT 和改动文件前停止。当前目录不要求为空；clone 前会检查本地目录，忽略 `.claude`、`.mcp`、`.skill`、`.config`、`.ini` 等点开头配置项，只对普通本地文件输出提醒。clone 最终结果固定包含 `Pre-clone local directory check` 区块；已有本地文件会保留，若与 Maker 项目文件同路径冲突则失败并列出冲突文件。
 - `maker_build_current_directory`：用户说“构建 / build / 重新构建游戏”时使用，转发调用远端 `build` tool。工具内部会强制检查本地 Maker 项目是否有未提交改动；如果有改动且没有确认提交或跳过提交，会停止并要求先询问用户。用户确认提交时，再次调用本工具并设置 `submit_local_changes_before_build=true` 和 `remember_build_submit_preference=true`，工具会完整执行 commit + push + build 并返回构建结果。构建转发会从 MCP 包自身定位 `dist/proxy.js`；`cwd` / `target_dir` 只用于识别 Maker 游戏项目，不要求游戏目录存在 MCP 的 `dist/proxy.js`。
 - `maker_submit_current_directory`：用户说“帮我提交”“提交代码”时使用，对当前 Maker 项目执行 commit + push + build；只有实际 push 成功后才继续远端 build。构建拦截里的 `提交本地改动并触发构建（以后都是如此）` 选项应继续调用 `maker_build_current_directory`，并传入 `submit_local_changes_before_build=true` 和 `remember_build_submit_preference=true`，由构建流程保存偏好并返回构建结果。如果本机没有 Git，工具会在 stage/commit/push/build 前停止。
@@ -333,6 +333,8 @@ maker_exchange_pat(manual_pat)
 用户选择 app
 maker_clone_to_current_directory(app_id)
 ```
+
+如果当前目录已经绑定 Maker 项目，app 列表只用于确认账号下有哪些项目；继续在当前绑定项目上提交、构建或检查状态，不要要求用户重新选择 clone。
 
 clone/push 默认会按 `TAPTAP_MCP_ENV` 读取 `src/maker/config.ts` 中对应环境的配置。需要临时覆盖时可设置：
 

--- a/skills/taptap-maker-local/SKILL.md
+++ b/skills/taptap-maker-local/SKILL.md
@@ -86,17 +86,21 @@ Workflow:
 
 1. Call `maker_status`. If the MCP process cwd differs from the user's current project directory,
    pass the user's current project directory as `target_dir`.
-2. If Git is missing, stop. Tell the user Git is required for clone/submit/build-side Git work.
-3. If `maker_status` lists bundled skill documents, just tell the user which skills are available.
+2. If `maker_status` reports the current directory is already bound to a Maker project, stop the
+   initialization/clone path. Continue with the user's current intent in that bound project. Do not
+   ask which app to clone unless the user explicitly asks to switch or re-clone.
+3. If Git is missing, stop. Tell the user Git is required for clone/submit/build-side Git work.
+4. If `maker_status` lists bundled skill documents, just tell the user which skills are available.
    Do not run editor-specific CLI install commands.
-4. If PAT is missing, ask the user to open the PAT page shown by `maker_status`, create a PAT, and send it back.
-5. When the user provides PAT, call `maker_exchange_pat(manual_pat)`.
-6. Show the returned Maker app list and ask the user to choose. Do not auto-select, even if there is only one app.
-7. Run the working directory compliance check below.
-8. After the user chooses an app, call `maker_clone_to_current_directory(app_id)`. The clone
+5. If PAT is missing, ask the user to open the PAT page shown by `maker_status`, create a PAT, and send it back.
+6. When the user provides PAT, call `maker_exchange_pat(manual_pat)`.
+7. If the current directory is still unbound, show the returned Maker app list and ask the user to
+   choose. Do not auto-select, even if there is only one app.
+8. Run the working directory compliance check below.
+9. After the user chooses an app, call `maker_clone_to_current_directory(app_id)`. The clone
    tool prepares the AI dev kit automatically before project checkout.
-9. After clone succeeds, call `maker_status` again or explain that `.maker-mcp/config.json` now binds the directory to the Maker project.
-10. Tell the local AI/Agent to use the `taptap-maker-dev-kit-guide` skill for the installed dev-kit
+10. After clone succeeds, call `maker_status` again or explain that `.maker-mcp/config.json` now binds the directory to the Maker project.
+11. Tell the local AI/Agent to use the `taptap-maker-dev-kit-guide` skill for the installed dev-kit
     resources, especially `CLAUDE.md`, `examples/`, `templates/`, and `urhox-libs/`.
 
 Keep the user-facing explanation short:
@@ -147,7 +151,9 @@ the user wants to retry or continue without the dev kit.
 ## PAT Handling
 
 If the user pastes a token-like string while the initialization flow is waiting for PAT, call
-`maker_exchange_pat(manual_pat)` and continue to app selection. Do not just say "received".
+`maker_exchange_pat(manual_pat)` and continue only if the current directory is unbound. Do not just
+say "received". If the directory is already bound, treat the returned app list as account reference
+only and continue the user's current bound-project task.
 
 If PAT exchange fails:
 
@@ -157,8 +163,15 @@ If PAT exchange fails:
 
 ## App Selection
 
-Always display the app list from `maker_exchange_pat` or `maker_list_apps` and ask the user to
-choose by index, app id, or name.
+Use app selection only when the current directory is unbound and the user is initializing or cloning
+a Maker project, or when the user explicitly asks to switch or re-clone.
+
+If the current directory is already bound, app lists from `maker_exchange_pat`, `maker_list_apps`, or
+`maker_status` are reference only. Do not ask which app to clone. Continue operating on the current
+bound project unless the user explicitly requests a different project.
+
+When app selection is needed, display the app list and ask the user to choose by index, app id, or
+name.
 
 Do not auto-select:
 

--- a/src/__tests__/makerBuildLocalChanges.test.ts
+++ b/src/__tests__/makerBuildLocalChanges.test.ts
@@ -223,12 +223,17 @@ describe('maker build local-change guard', () => {
   });
 
   test('initialization guidance is delegated to bundled skill', () => {
+    const listTool = tools.find((item) => item.name === 'maker_list_apps');
     const statusTool = tools.find((item) => item.name === 'maker_status');
     const cloneTool = tools.find((item) => item.name === 'maker_clone_to_current_directory');
 
+    expect(listTool?.description).toContain('unbound Maker directory initialization');
+    expect(listTool?.description).toContain('treat this list as reference only');
+    expect(listTool?.description).toContain('do not ask which app to clone');
     expect(statusTool?.description).toContain('bundled skill document paths');
     expect(statusTool?.description).toContain('target_dir');
     expect(statusTool?.description).toContain('AI dev kit status');
+    expect(statusTool?.description).toContain('current directory is unbound');
     expect(statusTool?.description).not.toContain('If PAT is missing');
     expect(statusTool?.description).not.toContain('ask them to open');
     expect(statusTool?.description).not.toContain('让用户选择');

--- a/src/__tests__/makerSkillInstall.test.ts
+++ b/src/__tests__/makerSkillInstall.test.ts
@@ -45,6 +45,10 @@ describe('Maker bundled workflow skill documents', () => {
     expect(skillText).toContain('maker_clone_to_current_directory');
     expect(skillText).toContain('tool prepares the AI dev kit automatically');
     expect(skillText).toContain(MAKER_DEV_KIT_GUIDE_SKILL_NAME);
+    expect(skillText).toContain('already bound to a Maker project');
+    expect(skillText).toContain('Do not ask which app to clone');
+    expect(skillText).toContain('app lists');
+    expect(skillText).toContain('reference only');
     expect(skillText).toContain('Do not auto-select');
     expect(skillText).toContain('Bundled Skills');
     expect(skillText).not.toContain('taptap-maker dev-kit install --target .');

--- a/src/maker/server/mcp.ts
+++ b/src/maker/server/mcp.ts
@@ -91,7 +91,7 @@ export const tools = [
   {
     name: 'maker_list_apps',
     description:
-      'List Maker apps available to the cached or provided Maker PAT. Use this to obtain app_id values for Maker project clone.',
+      'List Maker apps available to the cached or provided Maker PAT. Use this for unbound Maker directory initialization or explicit app-list requests. If maker_status already reports the current directory is bound, treat this list as reference only and do not ask which app to clone unless the user explicitly wants to switch or re-clone.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -106,7 +106,7 @@ export const tools = [
   {
     name: 'maker_status',
     description:
-      'Show local Maker MCP status for the user current working directory: Git availability, PAT/TapTap token status, project binding, AI dev kit status, bundled skill document paths, validation checklist, and available apps when PAT exists. If the MCP process cwd differs from the user current working directory, pass target_dir with the user current working directory.',
+      'Show local Maker MCP status for the user current working directory: Git availability, PAT/TapTap token status, project binding, AI dev kit status, bundled skill document paths, validation checklist, and available apps when the current directory is unbound and PAT exists. If the MCP process cwd differs from the user current working directory, pass target_dir with the user current working directory.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -566,6 +566,7 @@ async function formatStatus(options: { targetDir?: string } = {}): Promise<strin
   const projectSection = identify.projectId
     ? [
         '目标目录已绑定 Maker 项目。',
+        '请继续在当前绑定项目上执行状态、提交、构建等操作；不要再引导用户 clone，除非用户明确要求切换或重新拉取项目。',
         '本地 Maker 工作流请优先参考 taptap-maker-local skill；MCP tools 只负责保存 PAT、列 app、clone、submit 和 build 等机器动作。',
       ].join('\n')
     : pat
@@ -670,7 +671,7 @@ async function formatAutoProjectListFromPat(): Promise<string> {
     const projects = await listMakerProjects();
     return [
       '本地已有 Maker PAT，当前目录尚未绑定 Maker 项目。',
-      '已自动列出可用 Maker Apps。选择、解释和 clone 顺序请参考 taptap-maker-local skill。',
+      '当前目录未绑定时，可从下面的 Maker Apps 中选择一个进行 clone；选择、解释和 clone 顺序请参考 taptap-maker-local skill。',
       '',
       formatProjectList(projects),
     ].join('\n');
@@ -723,7 +724,8 @@ function formatProjectList(
         }`
     ),
     '',
-    '请让用户选择一个 app，然后调用 maker_clone_to_current_directory。',
+    '仅当当前目录未绑定且用户要初始化或 clone 时，才让用户选择 app 并调用 maker_clone_to_current_directory。',
+    '如果当前目录已绑定 Maker 项目，这个列表仅作账号项目参考；请继续当前项目，除非用户明确要求切换或重新 clone。',
   ].join('\n');
 }
 


### PR DESCRIPTION
## Summary
- Treat Maker app lists as reference only when the current directory is already bound
- Stop the local Maker skill initialization flow from asking users to clone again in bound projects
- Document the bound vs unbound app-selection workflow and add regression coverage

## Verification
- npm test -- --runInBand src/__tests__/makerBuildLocalChanges.test.ts src/__tests__/makerSkillInstall.test.ts
- npm run format:check
- npm run lint
- npm run build