### PR TITLE
fix(maker): harden dev kit setup and app selection

### DIFF
--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -118,6 +118,9 @@ https://urhox-demo-platform.spark.xd.com/ai-dev-kit/pd/stable/ai-dev-kit.zip
 clone 工具负责确定性文件处理：
 
 - 解压开发环境文档、引擎 API、demo、Lua 工具和本地 AI skills 到当前目录。
+- 如果目标目录已经存在完整 dev kit（`CLAUDE.md`、`examples/`、`templates`、`urhox-libs`），clone 前会跳过下载和解压，并按目录中实际存在的 dev-kit 顶层条目刷新 `.gitignore` 管理块。
+- dev kit 准备失败不会阻塞 Maker 项目 clone；clone 结果会返回 `ai_dev_kit_error`，后续可通过 `maker_status` 重新恢复。
+- Windows 原生环境使用 PowerShell `Expand-Archive` 解压；Linux/macOS 先使用 `unzip`，失败时回退到 `python3`/`python` 标准库 `zipfile`。
 - 跳过 ZIP 顶层 `scripts` 目录，避免和 Maker 项目 clone 后的 `scripts` 冲突。
 - 删除下载完成并解压后的 `ai-dev-kit.zip`。
 - clone 前生成 `.gitignore.dev-kit-before-clone` 临时 block，把 dev-kit 顶层内容标记为 local-only。

--- a/skills/taptap-maker-local/SKILL.md
+++ b/skills/taptap-maker-local/SKILL.md
@@ -94,8 +94,9 @@ Workflow:
    Do not run editor-specific CLI install commands.
 5. If PAT is missing, ask the user to open the PAT page shown by `maker_status`, create a PAT, and send it back.
 6. When the user provides PAT, call `maker_exchange_pat(manual_pat)`.
-7. If the current directory is still unbound, show the returned Maker app list and ask the user to
-   choose. Do not auto-select, even if there is only one app.
+7. If the current directory is still unbound, show every returned Maker app entry to the user and
+   ask the user to choose. Do not summarize the list as only a count, category, or stage. Do not
+   auto-select, even if there is only one app.
 8. Run the working directory compliance check below.
 9. After the user chooses an app, call `maker_clone_to_current_directory(app_id)`. The clone
    tool prepares the AI dev kit automatically before project checkout.
@@ -170,8 +171,9 @@ If the current directory is already bound, app lists from `maker_exchange_pat`, 
 `maker_status` are reference only. Do not ask which app to clone. Continue operating on the current
 bound project unless the user explicitly requests a different project.
 
-When app selection is needed, display the app list and ask the user to choose by index, app id, or
-name.
+When app selection is needed, display every app entry from the tool result and ask the user to
+choose by index, app id, or name. Do not replace the list with a summary such as "10 apps are
+available".
 
 Do not auto-select:
 

--- a/skills/update-taptap-mcp/SKILL.md
+++ b/skills/update-taptap-mcp/SKILL.md
@@ -104,7 +104,7 @@ Get-ChildItem $NpxDir -Directory -ErrorAction SilentlyContinue | ForEach-Object 
 $env:TAPTAP_MCP_ENV = 'rnd'
 $log = Join-Path $env:TEMP 'taptap-mcp-warmup.log'
 $proc = Start-Process -FilePath npx `
-  -ArgumentList '-y','--prefer-online','-p','@taptap/instant-games-open-mcp@beta','taptap-maker' `
+  -ArgumentList '-y','-p','@taptap/instant-games-open-mcp@beta','taptap-maker' `
   -RedirectStandardOutput $log -RedirectStandardError "$log.err" `
   -WindowStyle Hidden -PassThru
 Start-Sleep -Seconds 25
@@ -189,7 +189,7 @@ done
 根据用户 MCP 配置选默认 bin 或指定 bin（`taptap-maker`）。下例以 `taptap-maker` 为例，默认 bin 去掉 `-p ... taptap-maker`，直接写 `@taptap/instant-games-open-mcp@beta`。
 
 ```bash
-TAPTAP_MCP_ENV=rnd npx -y --prefer-online -p @taptap/instant-games-open-mcp@beta taptap-maker \
+TAPTAP_MCP_ENV=rnd npx -y -p @taptap/instant-games-open-mcp@beta taptap-maker \
   < /dev/null > /tmp/taptap-mcp-warmup.log 2>&1 &
 PID=$!; sleep 25; kill $PID 2>/dev/null; wait 2>/dev/null
 ```

--- a/src/__tests__/makerDevKit.test.ts
+++ b/src/__tests__/makerDevKit.test.ts
@@ -7,6 +7,7 @@ import {
   finalizeStagedDevKitGitignore,
   inspectAiDevKit,
   installAiDevKit,
+  listPresentDevKitManagedEntries,
   mergeDevKitGitignore,
 } from '../maker/cli/devKit';
 
@@ -76,6 +77,21 @@ describe('Maker AI dev kit install', () => {
     expect(status.ready).toBe(false);
     expect(status.presentEntries).toEqual(['CLAUDE.md', 'urhox-libs']);
     expect(status.missingEntries).toEqual(['examples', 'templates']);
+  });
+
+  test('lists present managed dev kit entries beyond required readiness markers', () => {
+    fs.mkdirSync(path.join(targetDir, '.emmylua'), { recursive: true });
+    fs.mkdirSync(path.join(targetDir, 'engine-docs'), { recursive: true });
+    fs.mkdirSync(path.join(targetDir, 'examples'), { recursive: true });
+    fs.writeFileSync(path.join(targetDir, 'CLAUDE.md'), 'local guide\n', 'utf8');
+    fs.writeFileSync(path.join(targetDir, 'user-file.txt'), 'keep me\n', 'utf8');
+
+    expect(listPresentDevKitManagedEntries(targetDir)).toEqual([
+      '.emmylua',
+      'CLAUDE.md',
+      'engine-docs',
+      'examples',
+    ]);
   });
 
   test('restores missing dev kit files without overwriting existing local files', async () => {

--- a/src/maker/cli/devKit.ts
+++ b/src/maker/cli/devKit.ts
@@ -14,6 +14,14 @@ const DEV_KIT_IGNORE_BEGIN = '# >>> TapTap Maker AI dev kit (local only) >>>';
 const DEV_KIT_IGNORE_END = '# <<< TapTap Maker AI dev kit (local only) <<<';
 export const DEV_KIT_GITIGNORE_STAGING_FILE = '.gitignore.dev-kit-before-clone';
 export const DEV_KIT_REQUIRED_ENTRIES = ['CLAUDE.md', 'examples', 'templates', 'urhox-libs'];
+export const DEV_KIT_MANAGED_ENTRY_CANDIDATES = [
+  '.emmylua',
+  'CLAUDE.md',
+  'engine-docs',
+  'examples',
+  'templates',
+  'urhox-libs',
+];
 const SKIPPED_TOP_LEVEL_ENTRIES = new Set(['scripts', '.DS_Store', 'ai-dev-kit.zip']);
 
 export interface InstallAiDevKitOptions {
@@ -56,6 +64,13 @@ export function inspectAiDevKit(targetDir: string): AiDevKitStatus {
     missingEntries,
     ready: missingEntries.length === 0,
   };
+}
+
+export function listPresentDevKitManagedEntries(targetDir: string): string[] {
+  const resolvedTargetDir = path.resolve(targetDir);
+  return DEV_KIT_MANAGED_ENTRY_CANDIDATES.filter((entry) =>
+    fs.existsSync(path.join(resolvedTargetDir, entry))
+  );
 }
 
 export async function installAiDevKit(
@@ -186,7 +201,7 @@ async function downloadAndExtractDevKit(url: string): Promise<string> {
   return tempDir;
 }
 
-function extractZip(zipPath: string, targetDir: string): void {
+export function extractZip(zipPath: string, targetDir: string): void {
   if (process.platform === 'win32') {
     const result = spawnSync(
       'powershell.exe',
@@ -203,15 +218,60 @@ function extractZip(zipPath: string, targetDir: string): void {
       { encoding: 'utf8' }
     );
     if (result.status !== 0) {
-      throw new Error(`Failed to extract AI dev kit zip: ${result.stderr || result.stdout}`);
+      throw new Error(`Failed to extract AI dev kit zip: ${formatSpawnFailure(result)}`);
     }
     return;
   }
 
-  const result = spawnSync('unzip', ['-q', zipPath, '-d', targetDir], { encoding: 'utf8' });
-  if (result.status !== 0) {
-    throw new Error(`Failed to extract AI dev kit zip: ${result.stderr || result.stdout}`);
+  const unzipResult = spawnSync('unzip', ['-q', zipPath, '-d', targetDir], { encoding: 'utf8' });
+  if (unzipResult.status === 0) {
+    return;
   }
+
+  const pythonFailures: string[] = [];
+  for (const pythonCommand of ['python3', 'python']) {
+    const pythonResult = spawnSync(
+      pythonCommand,
+      ['-c', PYTHON_ZIP_EXTRACT_SCRIPT, zipPath, targetDir],
+      { encoding: 'utf8' }
+    );
+    if (pythonResult.status === 0) {
+      return;
+    }
+    pythonFailures.push(`${pythonCommand}: ${formatSpawnFailure(pythonResult)}`);
+  }
+
+  throw new Error(
+    [
+      `Failed to extract AI dev kit zip: unzip: ${formatSpawnFailure(unzipResult)}`,
+      ...pythonFailures,
+    ].join('; ')
+  );
+}
+
+const PYTHON_ZIP_EXTRACT_SCRIPT = String.raw`
+import os
+import sys
+import zipfile
+
+zip_path = sys.argv[1]
+target_dir = os.path.abspath(sys.argv[2])
+
+with zipfile.ZipFile(zip_path) as archive:
+    for member in archive.infolist():
+        destination = os.path.abspath(os.path.join(target_dir, member.filename))
+        if os.path.commonpath([target_dir, destination]) != target_dir:
+            raise RuntimeError("Blocked unsafe zip entry: " + member.filename)
+    archive.extractall(target_dir)
+`;
+
+function formatSpawnFailure(result: ReturnType<typeof spawnSync>): string {
+  return (
+    result.error?.message ||
+    String(result.stderr || '').trim() ||
+    String(result.stdout || '').trim() ||
+    `exit status ${result.status ?? 'unknown'}`
+  );
 }
 
 function resolveDevKitRoot(sourceDir: string): string {

--- a/src/maker/server/mcp.ts
+++ b/src/maker/server/mcp.ts
@@ -57,9 +57,12 @@ import {
 } from '../system/git.js';
 import { formatMakerSkillStatus } from '../cli/skill.js';
 import {
+  DEV_KIT_GITIGNORE_STAGING_FILE,
   finalizeStagedDevKitGitignore,
   inspectAiDevKit,
   installAiDevKit,
+  listPresentDevKitManagedEntries,
+  writeDevKitStagedGitignore,
   type AiDevKitStatus,
 } from '../cli/devKit.js';
 
@@ -75,7 +78,7 @@ export const tools = [
   {
     name: 'maker_exchange_pat',
     description:
-      'Save a Maker PAT for local Maker API, Git, and TapTap token operations. After saving PAT, this tool fetches TapTap token and lists available Maker apps.',
+      'Save a Maker PAT for local Maker API, Git, and TapTap token operations. After saving PAT, this tool fetches TapTap token and returns a user-facing Maker app list. If the current directory is unbound, show every returned app entry to the user and ask them to choose; do not summarize the list as a count only.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -91,7 +94,7 @@ export const tools = [
   {
     name: 'maker_list_apps',
     description:
-      'List Maker apps available to the cached or provided Maker PAT. Use this for unbound Maker directory initialization or explicit app-list requests. If maker_status already reports the current directory is bound, treat this list as reference only and do not ask which app to clone unless the user explicitly wants to switch or re-clone.',
+      'List Maker apps available to the cached or provided Maker PAT. Use this for unbound Maker directory initialization or explicit app-list requests. If the current directory is unbound, show every returned app entry to the user and ask them to choose; do not summarize the list as a count only. If maker_status already reports the current directory is bound, treat this list as reference only and do not ask which app to clone unless the user explicitly wants to switch or re-clone.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -106,7 +109,7 @@ export const tools = [
   {
     name: 'maker_status',
     description:
-      'Show local Maker MCP status for the user current working directory: Git availability, PAT/TapTap token status, project binding, AI dev kit status, bundled skill document paths, validation checklist, and available apps when the current directory is unbound and PAT exists. If the MCP process cwd differs from the user current working directory, pass target_dir with the user current working directory.',
+      'Show local Maker MCP status for the user current working directory: Git availability, PAT/TapTap token status, project binding, AI dev kit status, bundled skill document paths, validation checklist, and available apps when the current directory is unbound and PAT exists. If the current directory is unbound and apps are returned, show every app entry to the user; do not summarize the list as a count only. If the MCP process cwd differs from the user current working directory, pass target_dir with the user current working directory.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -308,7 +311,12 @@ export async function startMakerMcpServer(): Promise<void> {
         let nextText: string;
         try {
           const projects = await listMakerProjects({ pat: args.manual_pat });
-          nextText = ['已自动列出可用 Maker Apps：', '', formatProjectList(projects)].join('\n');
+          nextText = [
+            '已自动列出可用 Maker Apps。',
+            '当前目录未绑定时，请逐项展示下面完整列表，不要只总结数量；然后让用户选择编号或 app_id。',
+            '',
+            formatProjectList(projects),
+          ].join('\n');
         } catch (error) {
           nextText = [
             '自动列出 Maker Apps 失败。',
@@ -372,7 +380,16 @@ export async function startMakerMcpServer(): Promise<void> {
           'Maker clone'
         );
         let result: Awaited<ReturnType<typeof cloneMakerProject>>;
-        let devKitResult: Awaited<ReturnType<typeof installAiDevKit>>;
+        let devKitResult: Awaited<ReturnType<typeof installAiDevKit>> = {
+          targetDir,
+          sourceDir: targetDir,
+          installedEntries: [],
+          skippedEntries: [],
+          gitignorePath: path.join(targetDir, '.gitignore'),
+          stagedGitignorePath: path.join(targetDir, DEV_KIT_GITIGNORE_STAGING_FILE),
+        };
+        let devKitState = 'prepared';
+        let devKitError = '';
         let progressSummary: ToolProgressSummary;
         try {
           progressReporter.report({
@@ -381,14 +398,48 @@ export async function startMakerMcpServer(): Promise<void> {
             phase: 'dev_kit',
             message: 'Preparing local AI dev kit before Maker clone',
           });
-          devKitResult = await installAiDevKit({
-            targetDir,
-          });
+          const devKitStatus = inspectAiDevKit(targetDir);
+          if (devKitStatus.ready) {
+            const presentManagedEntries = listPresentDevKitManagedEntries(targetDir);
+            writeDevKitStagedGitignore(
+              path.join(targetDir, DEV_KIT_GITIGNORE_STAGING_FILE),
+              presentManagedEntries
+            );
+            devKitState = 'already_ready';
+            devKitResult = {
+              targetDir,
+              sourceDir: targetDir,
+              installedEntries: presentManagedEntries,
+              skippedEntries: [],
+              gitignorePath: path.join(targetDir, '.gitignore'),
+              stagedGitignorePath: path.join(targetDir, DEV_KIT_GITIGNORE_STAGING_FILE),
+            };
+          } else {
+            try {
+              devKitResult = await installAiDevKit({
+                targetDir,
+              });
+            } catch (error) {
+              const presentManagedEntries = listPresentDevKitManagedEntries(targetDir);
+              if (presentManagedEntries.length > 0) {
+                writeDevKitStagedGitignore(
+                  path.join(targetDir, DEV_KIT_GITIGNORE_STAGING_FILE),
+                  presentManagedEntries
+                );
+              }
+              devKitState = 'failed_non_blocking';
+              devKitError = error instanceof Error ? error.message : String(error);
+              devKitResult.installedEntries = presentManagedEntries;
+            }
+          }
           progressReporter.report({
             progress: 5,
             total: 100,
             phase: 'dev_kit',
-            message: 'Local AI dev kit prepared',
+            message:
+              devKitState === 'failed_non_blocking'
+                ? 'Local AI dev kit preparation failed; continuing Maker clone'
+                : 'Local AI dev kit prepared',
           });
           result = await cloneMakerProject({
             appId: args.app_id,
@@ -416,7 +467,13 @@ export async function startMakerMcpServer(): Promise<void> {
                 `- target_dir: ${result.targetDir}`,
                 `- status: ${result.status}`,
                 `- retried_with_new_pat: ${result.retriedWithNewPat ? 'yes' : 'no'}`,
-                '- ai_dev_kit: prepared',
+                `- ai_dev_kit: ${devKitState}`,
+                ...(devKitError
+                  ? [
+                      `- ai_dev_kit_error: ${devKitError}`,
+                      '- ai_dev_kit_next_step: run maker_status after clone to retry dev kit restoration',
+                    ]
+                  : []),
                 `- ai_dev_kit_installed_entries: ${devKitResult.installedEntries.join(', ') || '(none)'}`,
                 `- ai_dev_kit_skipped_entries: ${devKitResult.skippedEntries.join(', ') || '(none)'}`,
                 ...formatProgressSummary(progressSummary),
@@ -671,7 +728,7 @@ async function formatAutoProjectListFromPat(): Promise<string> {
     const projects = await listMakerProjects();
     return [
       '本地已有 Maker PAT，当前目录尚未绑定 Maker 项目。',
-      '当前目录未绑定时，可从下面的 Maker Apps 中选择一个进行 clone；选择、解释和 clone 顺序请参考 taptap-maker-local skill。',
+      '当前目录未绑定时，必须逐项展示下面完整 Maker Apps 列表，不要只总结数量；选择、解释和 clone 顺序请参考 taptap-maker-local skill。',
       '',
       formatProjectList(projects),
     ].join('\n');
@@ -712,6 +769,8 @@ function formatProjectList(
 
   return [
     'Maker apps',
+    '',
+    '请把下面每一个 app 条目展示给用户，不要只说共有多少个。',
     '',
     ...projects.map(
       (project, index) =>


### PR DESCRIPTION
## Summary
- add unzip fallback through Python zipfile on non-Windows environments
- let Maker clone continue when AI dev kit preparation fails, with recovery guidance through maker_status
- strengthen Maker app list instructions so agents show each app entry instead of only a count
- remove --prefer-online from taptap-maker MCP update warmup docs for Windows compatibility

## Verification
- npm run build
- npm run lint
- npm run format:check
- git diff --check