### PR TITLE
ci(release): publish stable package with latest tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -476,8 +476,8 @@ jobs:
           npm pack --dry-run
 
           # 尝试 OIDC provenance 发布，失败则 fallback 到 NPM_TOKEN
-          npm publish --access public --provenance 2>/dev/null \
-            || npm publish --access public
+          npm publish --access public --tag latest --provenance 2>/dev/null \
+            || npm publish --access public --tag latest
 
       # 生成 CHANGELOG
       - name: Generate CHANGELOG


### PR DESCRIPTION
## Summary
- Add explicit npm latest dist-tag to stable publish command
- Keep provenance publish and fallback publish behavior consistent
- Unblock emergency 1.23.3 publish after npm already has 2.0.0

## Verification
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'
- npm publish --help