### PR TITLE
chore(release): sync 1.23.3 metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## <small>1.23.3 (2026-05-25)</small>
+
+* ci(release): publish stable package with latest tag (#185) ([60ef364](https://github.com/taptap/instant-games-open-mcp/commit/60ef364)), closes [#185](https://github.com/taptap/instant-games-open-mcp/issues/185)
+* fix(maker): harden dev kit setup and app selection (#178) ([a1c5323](https://github.com/taptap/instant-games-open-mcp/commit/a1c5323)), closes [#178](https://github.com/taptap/instant-games-open-mcp/issues/178)
+* fix(maker): harden Maker local workflow recovery ([b7a4cb7](https://github.com/taptap/instant-games-open-mcp/commit/b7a4cb7))
+* fix(release): prevent accidental major publishing ([7d4eb71](https://github.com/taptap/instant-games-open-mcp/commit/7d4eb71))
+* refactor(maker)!: move onboarding to cli-first workflow ([131e542](https://github.com/taptap/instant-games-open-mcp/commit/131e542))
+
+
+### BREAKING CHANGE
+
+* Maker MCP public initialization tools were removed.
+Use the taptap-maker CLI for PAT, app listing, clone, and onboarding.
+Use maker://status, maker_status_lite, and maker_build_current_directory
+for runtime status and submit, push, and build. Removed tools:
+maker_exchange_pat, maker_list_apps, maker_status,
+maker_clone_to_current_directory, maker_submit_current_directory.
+
+
 ## 1.21.0 (2026-05-08)
 
 * feat(debug-feedback): 支持按 moment_id 单查反馈并修复大整数精度丢失 (#154) ([1270ee4](https://github.com/taptap/instant-games-open-mcp/commit/1270ee4)), closes [#154](https://github.com/taptap/instant-games-open-mcp/issues/154)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@taptap/instant-games-open-mcp",
-  "version": "1.21.0",
+  "version": "1.23.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@taptap/instant-games-open-mcp",
-      "version": "1.21.0",
+      "version": "1.23.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@taptap/instant-games-open-mcp",
-  "version": "1.21.0",
+  "version": "1.23.3",
   "type": "module",
   "description": "TapTap Open API MCP Server - Documentation and Management APIs for TapTap Minigame and H5 Games (Leaderboard, and more features coming)",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary
- Update package metadata to 1.23.3
- Add generated CHANGELOG entries from the emergency release
- Recreate release metadata PR from a non-release branch so required CodeQL/review checks run

## Context
- npm latest is already restored to 1.23.3
- Supersedes #186, which is blocked because release/* PRs skip CodeQL

## Verification
- git diff --cached --check before commit
- lint-staged prettier during commit