### PR TITLE
chore(release): 1.23.4 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## <small>1.23.4 (2026-05-26)</small>
+
+* fix(maker): optimize Maker app list display and sync recovery ([3a98789](https://github.com/taptap/instant-games-open-mcp/commit/3a98789))
+
+
+
 ## <small>1.23.3 (2026-05-25)</small>
 
 * ci(release): publish stable package with latest tag (#185) ([60ef364](https://github.com/taptap/instant-games-open-mcp/commit/60ef364)), closes [#185](https://github.com/taptap/instant-games-open-mcp/issues/185)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@taptap/instant-games-open-mcp",
-  "version": "1.23.3",
+  "version": "1.23.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@taptap/instant-games-open-mcp",
-      "version": "1.23.3",
+      "version": "1.23.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@taptap/instant-games-open-mcp",
-  "version": "1.23.3",
+  "version": "1.23.4",
   "type": "module",
   "description": "TapTap Open API MCP Server - Documentation and Management APIs for TapTap Minigame and H5 Games (Leaderboard, and more features coming)",
   "main": "dist/server.js",


### PR DESCRIPTION
## Release 1.23.4

This PR carries the same release metadata generated by the release workflow, but uses a non-release/* branch so required CodeQL and review checks can run.

- Update package.json and package-lock.json to 1.23.4
- Update CHANGELOG.md
- npm package 1.23.4 is already published
- Native signer reused from previous release