### PR TITLE
fix(maker): 精简 app 列表展示并兼容旧分页参数

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -340,7 +340,7 @@ Maker 本地开发的默认路径是 CLI-first + PAT-first：
 - 用户说“我要开发maker游戏 / 本地maker开发 / 拉取maker游戏到本地 / 把maker游戏代码拉到本地 / clone maker项目 / 下载maker游戏代码 / 初始化maker开发目录 / 配置maker本地开发 / 继续开发maker项目”时，应触发 `taptap-maker init`，不要让 Agent 逐个调用旧的初始化 MCP tools。
 - 如果本地没有 Maker PAT，CLI 会引导用户打开当前环境的 PAT 页面新建 PAT，并把 PAT 发给 Agent：production 使用 `https://maker.taptap.cn/pat-tokens`，RND 使用 `https://fuping.agnt.xd.com/pat-tokens`。
 - 用户提供 Maker PAT 后，运行 `taptap-maker pat set` 并在 prompt 中粘贴，或在 `taptap-maker init` 里粘贴；CLI 会保存到 `~/.taptap-maker/pat.json`，兼容旧路径 `~/.maker-pat`，并调用 `GET /api/v1/user/taptap-token` 获取 TapTap MAC token。兼容写法 `taptap-maker pat set <PAT>` 会让 PAT 进入 `ps`/shell history，仅在用户明确接受风险时使用。
-- `taptap-maker init` 会检查 Git、PAT、TapTap token、当前目录绑定状态、app 列表、AI dev kit，并在用户选择 app 后 clone 到当前目录。app 文本预览默认展示 40 个、`limit` 最大 100；账号 app 很多时用 `next` 或 `taptap-maker apps --offset 40 --limit 40` 翻页，`--json` 获取完整机器可读列表。AI 转述时宽屏可用两列紧凑布局，窄屏保持单列，但不要省略 app_id 或自动选择。
+- `taptap-maker init` 会检查 Git、PAT、TapTap token、当前目录绑定状态、app 列表、AI dev kit，并在用户选择 app 后 clone 到当前目录。app 文本预览默认展示前 40 个；账号 app 很多时在 init 交互中输入 `all` 一次性展开全部，或单独跑 `taptap-maker apps --all`；`taptap-maker apps --json` 仅给 AI / 脚本解析使用。AI 转述时宽屏可用两列紧凑布局，窄屏保持单列，但不要省略 app_id 或自动选择。
 - `taptap-maker init` 的 Git clone/fetch 会按错误内容判断是否自动重试：503、HTTP 5xx、超时、连接重置、RPC/HTTP2 中断等远端临时错误会重试；认证、权限、仓库不存在、远端拒绝和本地目录冲突不重试。
 - 首次 clone/fetch 前必须提示用户：Maker server 可能正在准备仓库，首次拉代码 20 秒以上是正常现象，不要中断当前命令。
 - CLI 写 MCP 配置时优先支持 Windows：Windows 使用 `npx.cmd`，Git 引导优先指向 Git for Windows；macOS 用户可通过 `git --version` 触发 Xcode Command Line Tools 或安装官方 Git。

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -397,10 +397,16 @@ Maker 后端默认地址集中在 `src/maker/config.ts`。兼容旧变量名：`
 production 使用 `https://maker.taptap.cn/pat-tokens`，RND 使用 `https://fuping.agnt.xd.com/pat-tokens`。
 再运行 `taptap-maker pat set` 并在 prompt 中粘贴 PAT 保存。
 APP_ID 不应要求用户手动输入，而是通过 `taptap-maker init` 或 `taptap-maker apps` 返回的
-app 预览让用户选择。账号 app 很多时，文本输出默认按最近活跃排序展示前 40 个和总数，
+app 预览让用户选择。
+
+CLI app 列表行为：账号 app 很多时，文本输出默认按最近活跃排序展示前 40 个和总数，
 `limit` 最大 100；`taptap-maker init` 交互中可输入 `next` 继续翻页，命令行查看更多时使用
 `taptap-maker apps --offset 40 --limit 40`。普通文本列表只展示名称、id 和最后活跃时间；
 完整机器可读字段使用 `taptap-maker apps --json`。
+
+MCP status 行为：`maker://status` 和 `maker_status_lite` 的 app 预览默认最多展示 40 个 app；
+超过 40 个时提示用户可以选择显示全部，并引导运行 `taptap-maker apps --json` 查看全部 app；
+40 个以内直接显示全部。
 
 推荐按 CLI 流程测试：
 

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -399,10 +399,10 @@ production 使用 `https://maker.taptap.cn/pat-tokens`，RND 使用 `https://fup
 APP_ID 不应要求用户手动输入，而是通过 `taptap-maker init` 或 `taptap-maker apps` 返回的
 app 预览让用户选择。
 
-CLI app 列表行为：账号 app 很多时，文本输出默认按最近活跃排序展示前 40 个和总数，
-`limit` 最大 100；`taptap-maker init` 交互中可输入 `next` 继续翻页，命令行查看更多时使用
-`taptap-maker apps --offset 40 --limit 40`。普通文本列表只展示名称、id 和最后活跃时间；
-完整机器可读字段使用 `taptap-maker apps --json`。
+CLI app 列表行为：账号 app 很多时，文本输出默认按最近活跃排序展示前 40 个和总数。
+`taptap-maker init` 交互中输入 `all` 一次性展开全部 app 再选择；命令行单独查看时使用
+`taptap-maker apps --all` 直接列出全部。普通文本列表只展示名称、id 和最后活跃时间，
+便于人类阅读；完整机器可读字段使用 `taptap-maker apps --json`，给 AI / 脚本解析。
 
 MCP status 行为：`maker://status` 和 `maker_status_lite` 的 app 预览默认最多展示 40 个 app；
 超过 40 个时提示用户可以选择显示全部，并引导运行 `taptap-maker apps --json` 查看全部 app；

--- a/skills/taptap-maker-local/SKILL.md
+++ b/skills/taptap-maker-local/SKILL.md
@@ -201,12 +201,13 @@ not ask which app to clone. Continue operating on the current bound project unle
 explicitly requests a different project.
 
 When app selection is needed, show the returned app preview and total count, then ask the user to
-choose by index, app id, or name. The default preview shows 40 apps and `limit` is capped at 100.
-If the target is not visible, ask the user to type `next`, provide app id/name keywords, or run
-`taptap-maker apps --offset 40 --limit 40` / `taptap-maker apps --json`. If the chat/client width
-is enough, you may present the preview as a compact two-column layout; otherwise keep a single
-column. Do not omit app_id, and do not replace the preview with only a summary such as "40 apps are
-available".
+choose by index, app id, or name. The default preview shows the 40 most recently active apps.
+If the target is not visible, ask the user to type `all` inside `taptap-maker init` to expand the
+full list, or run `taptap-maker apps --all` for a one-shot human-readable dump; use
+`taptap-maker apps --json` only when AI / scripts need the machine-readable list. If the
+chat/client width is enough, you may present the preview as a compact two-column layout;
+otherwise keep a single column. Do not omit app_id, and do not replace the preview with only a
+summary such as "40 apps are available".
 
 Do not auto-select:
 

--- a/src/__tests__/makerCliCommands.test.ts
+++ b/src/__tests__/makerCliCommands.test.ts
@@ -295,7 +295,7 @@ describe('Maker CLI commands', () => {
     expect(close).toHaveBeenCalled();
   });
 
-  test('init can page through hidden apps before selecting by index', async () => {
+  test('init expands hidden apps via "all" before selecting by index', async () => {
     jest.mocked(listMakerProjects).mockResolvedValueOnce(
       Array.from({ length: 42 }, (_, index) => ({
         id: `app-${index + 1}`,
@@ -304,7 +304,7 @@ describe('Maker CLI commands', () => {
       }))
     );
     Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: true });
-    const answers = ['next', '1'];
+    const answers = ['all', '41'];
     const close = jest.fn();
     const createInterfaceSpy = jest.spyOn(readline, 'createInterface').mockImplementation(
       () =>
@@ -348,6 +348,13 @@ describe('Maker CLI commands', () => {
 
     expect(stderrSpy.mock.calls.join('')).toContain('exposes it via ps/shell history');
     expect(listMakerProjects).toHaveBeenCalledWith({ pat: 'secret-maker-token' });
+  });
+
+  test('apps rejects removed --limit / --offset with a guidance error', async () => {
+    await expect(runMakerCli(['apps', '--offset', '40', '--limit', '40'])).rejects.toThrow(
+      /no longer supports --limit \/ --offset/
+    );
+    expect(listMakerProjects).not.toHaveBeenCalled();
   });
 
   test('pat set can read PAT from stdin without argv warning', async () => {

--- a/src/__tests__/makerProjectsResponse.test.ts
+++ b/src/__tests__/makerProjectsResponse.test.ts
@@ -98,40 +98,37 @@ describe('maker app list display', () => {
     expect(output).toContain('Maker apps (120)');
     expect(output).toContain('Showing 40 most recently active apps');
     expect(output).toContain('sorted by last activity');
+    expect(output).toContain('80 more hidden');
     expect(output).toContain('1. App 120  id=app-120  last_active=2026-04-30T08:00:00.000Z');
     expect(output).toContain('40. App 81  id=app-81  last_active=2026-03-22T08:00:00.000Z');
     expect(output).not.toContain('41. App 80');
-    expect(output).toContain('--offset 40 --limit 40');
-    expect(output).toContain('use --json to get the complete app list');
+    expect(output).toContain('taptap-maker apps --all');
+    expect(output).toContain('--json');
+    expect(output).not.toContain('--offset');
+    expect(output).not.toContain('--limit');
     expect(output).not.toContain('user_id=');
     expect(output).not.toContain('gameType=');
     expect(output).not.toContain('stage=');
     expect(output).not.toContain('createdAt=');
   });
 
-  test('supports showing the next CLI page while keeping recent activity order', () => {
-    const output = formatMakerProjectList(projects, { limit: 40, offset: 40 });
+  test('shows every app when showAll is set', () => {
+    const output = formatMakerProjectList(projects, { showAll: true });
 
-    expect(output).toContain('Showing apps 41-80 of 120');
-    expect(output).toContain('1. App 80  id=app-80  last_active=2026-03-21T08:00:00.000Z');
-    expect(output).toContain('40. App 41  id=app-41  last_active=2026-02-10T08:00:00.000Z');
-    expect(output).toContain('--offset 80 --limit 40');
+    expect(output).toContain('Maker apps (120)');
+    expect(output).toContain('Showing all 120 Maker apps');
+    expect(output).toContain('1. App 120  id=app-120');
+    expect(output).toContain('120. App 1  id=app-1');
+    expect(output).not.toContain('more hidden');
+    expect(output).not.toContain('--all');
   });
 
-  test('caps requested CLI text output at 100 apps', () => {
-    const output = formatMakerProjectList(projects, { limit: 120 });
+  test('hides the --all hint when the project count fits in one page', () => {
+    const output = formatMakerProjectList(projects.slice(0, 29));
 
-    expect(output).toContain('100. App 21  id=app-21  last_active=2026-01-21T08:00:00.000Z');
-    expect(output).not.toContain('101. App 20');
-    expect(output).toContain('--offset 100 --limit 100');
-  });
-
-  test('shows an out-of-range CLI page without misleading item bounds', () => {
-    const output = formatMakerProjectList(projects.slice(0, 35), { offset: 9999 });
-
-    expect(output).toContain('Showing apps 0-0 of 35');
-    expect(output).not.toContain('Showing apps 0-9999 of 35');
-    expect(output).toContain('No more apps in this view');
+    expect(output).toContain('Showing all 29 Maker apps');
+    expect(output).not.toContain('more hidden');
+    expect(output).not.toContain('--all');
   });
 
   test('limits status text output to the 40 most recently active apps', () => {

--- a/src/__tests__/makerProjectsResponse.test.ts
+++ b/src/__tests__/makerProjectsResponse.test.ts
@@ -138,13 +138,25 @@ describe('maker app list display', () => {
     const output = formatStatusProjectList(projects);
 
     expect(output).toContain('Maker apps (120)');
-    expect(output).toContain('Maker apps (120)\n\n默认按最近活跃排序展示前 40 个');
-    expect(output).toContain('默认按最近活跃排序展示前 40 个');
+    expect(output).toContain(
+      '为了保持友好的可读性，默认最多展示 40 个 app；如需完整列表，可以选择显示全部。'
+    );
+    expect(output).toContain('如需完整列表，请运行 taptap-maker apps --json 查看全部 app。');
     expect(output).toContain('1. app-120');
     expect(output).toContain('40. app-81');
     expect(output).not.toContain('41. app-80');
+    expect(output).not.toContain('offset');
+    expect(output).not.toContain('next');
     expect(output).toContain('AI 展示建议');
     expect(output).toContain('两列紧凑布局');
     expect(output).not.toContain('每一个 app 条目');
+  });
+
+  test('explains the status app page limit for readable output', () => {
+    const output = formatStatusProjectList(projects.slice(0, 29));
+
+    expect(output).toContain('已显示全部 app；请询问用户选择。');
+    expect(output).not.toContain('可以选择显示全部');
+    expect(output).not.toContain('taptap-maker apps --json');
   });
 });

--- a/src/maker/cli/commands.ts
+++ b/src/maker/cli/commands.ts
@@ -41,6 +41,7 @@ const BOOLEAN_OPTIONS = new Set([
   'skip_mcp_install',
   'pat_stdin',
   'pat_from_stdin',
+  'all',
   'h',
   'help',
 ]);
@@ -292,19 +293,19 @@ async function runDoctor(parsed: ParsedArgs, ctx: CliContext): Promise<void> {
 }
 
 async function runApps(parsed: ParsedArgs, ctx: CliContext): Promise<void> {
+  rejectRemovedAppsPaginationOptions(parsed);
   const pat = stringOption(parsed, 'pat');
   if (pat) {
     warnPatArgExposure();
   }
-  const limit = numberOption(parsed, 'limit');
-  const offset = numberOption(parsed, 'offset');
+  const showAll = booleanOption(parsed, 'all');
   const projects = await listMakerProjects({ pat });
   if (ctx.json) {
     writeJson(projects);
     return;
   }
 
-  process.stdout.write(`${formatMakerProjectList(projects, { limit, offset })}\n`);
+  process.stdout.write(`${formatMakerProjectList(projects, { showAll })}\n`);
 }
 
 async function runPatSet(parsed: ParsedArgs, ctx: CliContext): Promise<void> {
@@ -527,30 +528,26 @@ async function resolveProjectSelection(
   }
 
   const orderedProjects = sortProjectsByRecentActivity(projects);
-  const limit = MAKER_PROJECT_DEFAULT_TEXT_LIMIT;
-  let offset = 0;
+  let showAll = orderedProjects.length <= MAKER_PROJECT_DEFAULT_TEXT_LIMIT;
   for (;;) {
-    process.stdout.write(`${formatMakerProjectList(orderedProjects, { limit, offset })}\n`);
-    const answer = await promptRequired('Choose app by index, app_id, or next');
+    process.stdout.write(`${formatMakerProjectList(orderedProjects, { showAll })}\n`);
+    const answer = await promptRequired("Choose app by index, app_id, or 'all' to show all");
     const normalized = answer.trim().toLowerCase();
-    if (['n', 'next', 'more'].includes(normalized)) {
-      const nextOffset = offset + limit;
-      if (nextOffset >= orderedProjects.length) {
-        process.stdout.write('No more Maker apps in this list.\n');
+    if (['a', 'all'].includes(normalized)) {
+      if (showAll) {
+        process.stdout.write('Already showing all Maker apps.\n');
       } else {
-        offset = nextOffset;
+        showAll = true;
       }
       continue;
     }
-    if (['p', 'prev', 'previous'].includes(normalized)) {
-      offset = Math.max(offset - limit, 0);
-      continue;
-    }
 
+    const visibleCount = showAll
+      ? orderedProjects.length
+      : Math.min(MAKER_PROJECT_DEFAULT_TEXT_LIMIT, orderedProjects.length);
     const byIndex = Number(answer);
-    const visibleCount = Math.min(limit, orderedProjects.length - offset);
     if (Number.isInteger(byIndex) && byIndex >= 1 && byIndex <= visibleCount) {
-      return orderedProjects[offset + byIndex - 1];
+      return orderedProjects[byIndex - 1];
     }
     const selected = projects.find((project) => project.id === answer.trim());
     if (!selected) {
@@ -783,26 +780,10 @@ function saveInitState(targetDir: string, state: Record<string, unknown>): void 
 }
 
 const MAKER_PROJECT_DEFAULT_TEXT_LIMIT = 40;
-const MAKER_PROJECT_MAX_TEXT_LIMIT = 100;
 
 type MakerProjectListFormatOptions = {
-  limit?: number;
-  offset?: number;
+  showAll?: boolean;
 };
-
-function normalizeListLimit(limit?: number): number {
-  if (!Number.isFinite(limit) || limit === undefined) {
-    return MAKER_PROJECT_DEFAULT_TEXT_LIMIT;
-  }
-  return Math.min(Math.max(Math.trunc(limit), 1), MAKER_PROJECT_MAX_TEXT_LIMIT);
-}
-
-function normalizeListOffset(offset?: number): number {
-  if (!Number.isFinite(offset) || offset === undefined) {
-    return 0;
-  }
-  return Math.max(Math.trunc(offset), 0);
-}
 
 function getProjectActivityTime(project: MakerProjectSummary): number {
   const value = project.lastConversationAt || project.lastAccessedAt || project.createdAt;
@@ -831,6 +812,20 @@ function formatProjectListItem(project: MakerProjectSummary, index: number): str
   }`;
 }
 
+function rejectRemovedAppsPaginationOptions(parsed: ParsedArgs): void {
+  const removed = ['limit', 'offset'].filter((key) => parsed.options[key] !== undefined);
+  if (removed.length === 0) {
+    return;
+  }
+  throw new Error(
+    `taptap-maker apps no longer supports ${removed
+      .map((key) => `--${key}`)
+      .join(
+        ' / '
+      )}. Use --all for the full human-readable list, or --json for the machine-readable output.`
+  );
+}
+
 export function formatMakerProjectList(
   projects: MakerProjectSummary[],
   options: MakerProjectListFormatOptions = {}
@@ -838,24 +833,17 @@ export function formatMakerProjectList(
   if (projects.length === 0) {
     return 'No Maker apps found.';
   }
-  const limit = normalizeListLimit(options.limit);
-  const offset = normalizeListOffset(options.offset);
   const sortedProjects = sortProjectsByRecentActivity(projects);
-  const visibleProjects = sortedProjects.slice(offset, offset + limit);
-  const hiddenCount = projects.length - visibleProjects.length;
-  const nextOffset = offset + visibleProjects.length;
-  const hasNextPage = nextOffset < projects.length;
-  const startIndex = visibleProjects.length > 0 ? offset + 1 : 0;
-  const endIndex =
-    visibleProjects.length > 0 ? Math.min(offset + visibleProjects.length, projects.length) : 0;
+  const showAll = options.showAll === true;
+  const visibleProjects = showAll
+    ? sortedProjects
+    : sortedProjects.slice(0, MAKER_PROJECT_DEFAULT_TEXT_LIMIT);
+  const hiddenCount = sortedProjects.length - visibleProjects.length;
   return [
     `Maker apps (${projects.length})`,
-    visibleProjects.length > 0 && offset === 0
-      ? `Showing ${visibleProjects.length} most recently active apps, sorted by last activity. ${hiddenCount} more hidden.`
-      : `Showing apps ${startIndex}-${endIndex} of ${projects.length}, sorted by last activity.`,
-    hasNextPage
-      ? `To continue, run: taptap-maker apps --offset ${nextOffset} --limit ${limit}. If the target is hidden, enter its app_id directly or use --json to get the complete app list.`
-      : `No more apps in this view. If needed, use --json to get the complete app list.`,
+    hiddenCount > 0
+      ? `Showing ${visibleProjects.length} most recently active apps, sorted by last activity. ${hiddenCount} more hidden. Run \`taptap-maker apps --all\` to show all, or use \`--json\` for the complete machine-readable list.`
+      : `Showing all ${visibleProjects.length} Maker apps, sorted by last activity.`,
     '',
     ...visibleProjects.map((project, index) => formatProjectListItem(project, index)),
   ]
@@ -929,15 +917,6 @@ function stringOption(parsed: ParsedArgs, key: string): string | undefined {
   return typeof value === 'string' ? value : undefined;
 }
 
-function numberOption(parsed: ParsedArgs, key: string): number | undefined {
-  const value = stringOption(parsed, key);
-  if (value === undefined) {
-    return undefined;
-  }
-  const number = Number(value);
-  return Number.isFinite(number) ? number : undefined;
-}
-
 function booleanOption(parsed: ParsedArgs, key: string): boolean {
   return parsed.options[key] === true || parsed.options[key] === 'true';
 }
@@ -1002,7 +981,7 @@ function printHelp(): void {
       '                     [--skip-confirm] [--skip-mcp-install] [--register-mcp codex,cursor,claude]',
       '                     [--json]',
       '  taptap-maker doctor [--target-dir DIR] [--env rnd|production] [--json]',
-      '  taptap-maker apps [--pat PAT] [--limit N] [--offset N] [--json]',
+      '  taptap-maker apps [--pat PAT] [--all] [--json]',
       '                     # --pat warns: PAT appears in ps/history',
       '  taptap-maker pat set [--pat-stdin] [--json]',
       '  taptap-maker pat set [PAT|--pat PAT] [--json]  # warns: PAT appears in ps/history',

--- a/src/maker/index.ts
+++ b/src/maker/index.ts
@@ -35,7 +35,7 @@ function printHelp(): void {
       '                     [--skip-confirm] [--skip-mcp-install] [--register-mcp codex,cursor,claude]',
       '                     [--json]',
       '  taptap-maker doctor [--target-dir DIR] [--env rnd|production] [--json]',
-      '  taptap-maker apps [--pat PAT] [--limit N] [--offset N] [--json]',
+      '  taptap-maker apps [--pat PAT] [--all] [--json]',
       '                     # --pat warns: PAT appears in ps/history',
       '  taptap-maker pat set [--pat-stdin] [--json]',
       '  taptap-maker pat set [PAT|--pat PAT] [--json]  # warns: PAT appears in ps/history',

--- a/src/maker/server/mcp.ts
+++ b/src/maker/server/mcp.ts
@@ -604,11 +604,9 @@ export function formatStatusProjectList(projects: StatusProject[]): string {
     `Maker apps (${projects.length})`,
     '',
     hiddenCount > 0
-      ? `默认按最近活跃排序展示前 ${visibleProjects.length} 个；其余 ${hiddenCount} 个请不要逐条刷屏。`
-      : '已按最近活跃排序展示全部 app；请询问用户选择。',
-    hiddenCount > 0
-      ? '如果用户没有看到目标 app，请提示可以继续查看更多：在 taptap-maker init 交互中输入 next，或运行 taptap-maker apps --offset 40 --limit 40；也可以让用户提供 app_id，或运行 taptap-maker apps --json 做机器可读查询。'
-      : undefined,
+      ? `为了保持友好的可读性，默认最多展示 ${visibleProjects.length} 个 app；如需完整列表，可以选择显示全部。`
+      : '已显示全部 app；请询问用户选择。',
+    hiddenCount > 0 ? '如需完整列表，请运行 taptap-maker apps --json 查看全部 app。' : undefined,
     'AI 展示建议：如果聊天或客户端宽度足够，可把 app 预览整理成两列紧凑布局；每个 app 保留序号、app_id、名称，以及可用的最近活跃时间或 user_id。窄屏保持单列。不要省略 app_id，也不要在用户确认前自动选择 app。',
     '',
     ...visibleProjects.map(


### PR DESCRIPTION
## Summary

- MCP：精简 `maker://status` / `maker_status_lite` 输出的 app 列表提示语，超过 40 时只引导一条 `taptap-maker apps --json`，去掉 next/offset/limit 多路径混合描述。
- CLI：`taptap-maker apps` 删除 `--limit` / `--offset`，改为默认前 40 + `--all` 一次性展开；`taptap-maker init` 选 app 交互删除 next/prev 翻页，改为输入 `all` 一次性展开（≤40 个 app 默认就 showAll）。
- 兼容：旧的 `--limit` / `--offset` 显式抛错并指引改用 `--all` / `--json`，避免被通用 parser 静默接受导致用户拿到错误页面（这条是 review 第二轮新增）。
- `--all` 加入 `BOOLEAN_OPTIONS` 白名单，避免误输入跟参把布尔语义吞成字符串。
- 删除已无引用的 `MAKER_PROJECT_MAX_TEXT_LIMIT` / `normalizeListLimit` / `normalizeListOffset` / `numberOption` 工具。
- 同步 `docs/MAKER.md`、`AGENTS.md`、`taptap-maker-local` skill。

## Background

跟踪 PR #188 引入的 app 列表分页设计后续：实际场景中超过 40 个 app 的用户极少（仅内部少数老板/PM），分页选择路径给 AI 制造了不必要的不确定性。本次回到"默认 40 + 一键全部"的两态简化设计，降低 AI 在 app 选择阶段的不稳定性。

## Test plan

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test`（16 suites / 148 cases 全过）
- [x] 单测覆盖：默认前 40 / `showAll` 展开 / ≤40 不出现 --all 提示 / init 输 all 展开 / `apps --limit/--offset` 报错
- [ ] 合并后人工：`taptap-maker apps --offset 40 --limit 40` 报错指引 `--all`
- [ ] 合并后人工：`taptap-maker apps --all` 全列表
- [ ] 合并后人工：多账号 PAT 下 `taptap-maker init`，确认 ≤40 默认展开 / >40 提示输 all

## Related

- Follow-up to PR #188 (fix(maker): optimize Maker app list display and sync recovery)