### PR TITLE
fix(maker): 修复 Codex MCP 配置重复键问题

### DIFF
--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -97,7 +97,9 @@ CLI 命令：
 - `taptap-maker doctor`：检查 Git、PAT、TapTap token、项目绑定、dev-kit 和 MCP 配置状态。
 - `taptap-maker apps`：列出当前 PAT 可访问的 Maker app。
 - `taptap-maker pat set`：通过交互式 prompt 保存 PAT，并换取 TapTap token。
-- `taptap-maker mcp install`：写入当前机器的 AI 客户端 MCP 配置。
+- `taptap-maker mcp install`：写入当前机器的 AI 客户端 MCP 配置。Codex 配置写入
+  会同时清理 `[mcp_servers.taptap-maker]` 与 `[mcp_servers."taptap-maker"]`
+  两种 TOML 等价写法，重复运行或从旧配置升级时应保持幂等。
 - `taptap-maker mcp verify`：默认验证 AI 客户端 MCP 配置使用的 npx 包命令可启动；`--mode self` 只验证当前 CLI 二进制。验证失败时若出现 `failure_type` 或 `status: null`，表示本地启动命令还没正常退出，Maker MCP server 尚未启动，不要当作 PAT、项目或 Maker 业务接口错误。
 - `taptap-maker dev-kit update`：恢复或更新当前目录的 AI dev-kit。
 

--- a/src/__tests__/makerCliCommands.test.ts
+++ b/src/__tests__/makerCliCommands.test.ts
@@ -145,10 +145,96 @@ describe('Maker CLI commands', () => {
     await runMakerCli(['mcp', 'install', '--ide', 'codex', '--env', 'rnd']);
 
     const text = fs.readFileSync(configPath, 'utf8');
+    expect(text.match(/\[mcp_servers\."taptap-maker"\]/g)).toHaveLength(1);
     expect(text.match(/\[mcp_servers\."taptap-maker"\.env\]/g)).toHaveLength(1);
     expect(text).toContain('TAPTAP_MCP_ENV = "rnd"');
     expect(text).toContain('[mcp_servers."other".env]');
     expect(text).toContain('KEEP = "yes"');
+  });
+
+  test('codex mcp install replaces existing bare server table and env subtable', async () => {
+    const configPath = path.join(tempDir, '.codex', 'config.toml');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      [
+        'model = "gpt-5"',
+        '',
+        '[mcp_servers.taptap-maker]',
+        'command = "node"',
+        'args = ["/tmp/taptap-maker.js"]',
+        '',
+        '[mcp_servers.taptap-maker.env]',
+        'TAPTAP_MCP_VERBOSE = "true"',
+        '',
+        '[mcp_servers."other"]',
+        'command = "other"',
+        '',
+      ].join('\n'),
+      'utf8'
+    );
+
+    await runMakerCli(['mcp', 'install', '--ide', 'codex', '--env', 'rnd']);
+
+    const text = fs.readFileSync(configPath, 'utf8');
+    expect(text).not.toContain('[mcp_servers.taptap-maker]');
+    expect(text).not.toContain('[mcp_servers.taptap-maker.env]');
+    expect(text.match(/\[mcp_servers\."taptap-maker"\]/g)).toHaveLength(1);
+    expect(text.match(/\[mcp_servers\."taptap-maker"\.env\]/g)).toHaveLength(1);
+    expect(text).toContain('TAPTAP_MCP_ENV = "rnd"');
+    expect(text).toContain('[mcp_servers."other"]');
+  });
+
+  test('codex mcp install repairs mixed bare and quoted duplicate server tables', async () => {
+    const configPath = path.join(tempDir, '.codex', 'config.toml');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      [
+        'model = "gpt-5"',
+        '',
+        '[mcp_servers.taptap-maker]',
+        'command = "node"',
+        '',
+        '[mcp_servers.taptap-maker.env]',
+        'TAPTAP_MCP_VERBOSE = "true"',
+        '',
+        '[mcp_servers."other"]',
+        'command = "other"',
+        '',
+        '[mcp_servers."taptap-maker"]',
+        'command = "old-npx"',
+        '',
+        '[mcp_servers."taptap-maker".env]',
+        'TAPTAP_MCP_ENV = "production"',
+        '',
+      ].join('\n'),
+      'utf8'
+    );
+
+    await runMakerCli(['mcp', 'install', '--ide', 'codex', '--env', 'rnd']);
+
+    const text = fs.readFileSync(configPath, 'utf8');
+    expect(text).not.toContain('[mcp_servers.taptap-maker]');
+    expect(text).not.toContain('[mcp_servers.taptap-maker.env]');
+    expect(text.match(/\[mcp_servers\."taptap-maker"\]/g)).toHaveLength(1);
+    expect(text.match(/\[mcp_servers\."taptap-maker"\.env\]/g)).toHaveLength(1);
+    expect(text).toContain('TAPTAP_MCP_ENV = "rnd"');
+    expect(text).toContain('[mcp_servers."other"]');
+  });
+
+  test('codex mcp install is idempotent when repeated', async () => {
+    const configPath = path.join(tempDir, '.codex', 'config.toml');
+
+    await runMakerCli(['mcp', 'install', '--ide', 'codex', '--env', 'rnd']);
+    const once = fs.readFileSync(configPath, 'utf8');
+
+    await runMakerCli(['mcp', 'install', '--ide', 'codex', '--env', 'rnd']);
+    const twice = fs.readFileSync(configPath, 'utf8');
+
+    expect(twice).toBe(once);
+    expect(twice.match(/\[mcp_servers\."taptap-maker"\]/g)).toHaveLength(1);
+    expect(twice.match(/\[mcp_servers\."taptap-maker"\.env\]/g)).toHaveLength(1);
   });
 
   test('mcp install continues with later IDEs when one IDE config fails', async () => {

--- a/src/maker/cli/commands.ts
+++ b/src/maker/cli/commands.ts
@@ -665,12 +665,9 @@ function mergeCodexMcpConfig(
   configPath: string,
   options: { env: MakerEnvironment; pkg: string; mcpName: string }
 ): void {
-  backupIfExists(configPath);
+  const backupPath = backupIfExists(configPath);
   const existing = fs.existsSync(configPath) ? fs.readFileSync(configPath, 'utf8') : '';
-  const sectionPattern = new RegExp(
-    `\\n?\\[mcp_servers\\."${escapeRegExp(options.mcpName)}"(?:\\.[^\\]]+)?\\][\\s\\S]*?(?=\\n\\[(?!mcp_servers\\."${escapeRegExp(options.mcpName)}"(?:\\.|\\]))|$)`,
-    'g'
-  );
+  const sectionPattern = createCodexMcpSectionPattern(options.mcpName);
   const withoutOld = existing.replace(sectionPattern, '').trimEnd();
   const command = getNpxCommand();
   const section = [
@@ -684,6 +681,60 @@ function mergeCodexMcpConfig(
   ].join('\n');
   fs.mkdirSync(path.dirname(configPath), { recursive: true });
   fs.writeFileSync(configPath, [withoutOld, section].filter(Boolean).join('\n\n'), 'utf8');
+  const updated = fs.readFileSync(configPath, 'utf8');
+  const duplicates = findCodexMcpTableDuplicates(updated, options.mcpName);
+  if (duplicates.length > 0) {
+    restoreBackup(configPath, backupPath);
+    throw new Error(
+      `Codex MCP config update would create duplicate table(s): ${duplicates.join(
+        ', '
+      )}. Restored previous config.`
+    );
+  }
+}
+
+function createCodexMcpSectionPattern(mcpName: string): RegExp {
+  const keyPattern = createCodexMcpKeyPattern(mcpName);
+  return new RegExp(
+    `\\n?\\[mcp_servers\\.${keyPattern}(?:\\.[^\\]]+)?\\][\\s\\S]*?(?=\\n\\[(?!mcp_servers\\.${keyPattern}(?:\\.|\\]))|$)`,
+    'g'
+  );
+}
+
+function createCodexMcpKeyPattern(mcpName: string): string {
+  const quotedKey = `"${escapeRegExp(mcpName)}"`;
+  if (!isTomlBareKey(mcpName)) {
+    return quotedKey;
+  }
+  return `(?:${quotedKey}|${escapeRegExp(mcpName)})`;
+}
+
+function findCodexMcpTableDuplicates(text: string, mcpName: string): string[] {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  const headerPattern = /^\s*\[([^\]]+)\]\s*$/gm;
+  let match: RegExpExecArray | null;
+  while ((match = headerPattern.exec(text)) !== null) {
+    const normalized = normalizeCodexMcpTablePath(match[1], mcpName);
+    if (!normalized) {
+      continue;
+    }
+    if (seen.has(normalized)) {
+      duplicates.add(normalized);
+      continue;
+    }
+    seen.add(normalized);
+  }
+  return Array.from(duplicates);
+}
+
+function normalizeCodexMcpTablePath(tablePath: string, mcpName: string): string | undefined {
+  const keyPattern = createCodexMcpKeyPattern(mcpName);
+  const match = new RegExp(`^mcp_servers\\.${keyPattern}(\\..+)?$`).exec(tablePath);
+  if (!match) {
+    return undefined;
+  }
+  return `mcp_servers.${mcpName}${match[1] || ''}`;
 }
 
 function tryClaudeMcpAdd(options: { env: MakerEnvironment; pkg: string; mcpName: string }): {
@@ -757,12 +808,22 @@ function asObject(value: unknown): Record<string, unknown> {
   return {};
 }
 
-function backupIfExists(filePath: string): void {
+function backupIfExists(filePath: string): string | undefined {
   if (!fs.existsSync(filePath)) {
-    return;
+    return undefined;
   }
   const stamp = new Date().toISOString().replace(/[-:]/g, '').replace(/\..+$/, '');
-  fs.copyFileSync(filePath, `${filePath}.bak.${stamp}`);
+  const backupPath = `${filePath}.bak.${stamp}`;
+  fs.copyFileSync(filePath, backupPath);
+  return backupPath;
+}
+
+function restoreBackup(filePath: string, backupPath: string | undefined): void {
+  if (backupPath) {
+    fs.copyFileSync(backupPath, filePath);
+    return;
+  }
+  fs.rmSync(filePath, { force: true });
 }
 
 function saveInitState(targetDir: string, state: Record<string, unknown>): void {
@@ -957,6 +1018,10 @@ function escapeRegExp(value: string): string {
 
 function escapeToml(value: string): string {
   return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function isTomlBareKey(value: string): boolean {
+  return /^[A-Za-z0-9_-]+$/.test(value);
 }
 
 function indent(value: string): string {


### PR DESCRIPTION
## Summary

- `taptap-maker mcp install --ide codex` 之前只能匹配 quoted 形式 `[mcp_servers."taptap-maker"]`，老用户机器上若已存在 bare 形式 `[mcp_servers.taptap-maker]`，新条目追加后两种 TOML 等价写法并存，Codex 启动时报 `duplicate key`。
- 修复点：清旧段正则同时识别 bare/quoted 两种形式；写入后做 round-trip 表头去重校验，发现重复立即回滚备份，避免脏文件落盘。
- 同步更新 `docs/MAKER.md` 与单测覆盖：bare 残留、bare+quoted 混合脏文件、重复 install 幂等性。

## 根因

文件：`src/maker/cli/commands.ts` 函数 `mergeCodexMcpConfig`

旧正则 `\\["mcp_servers\\."<name>"...` 把双引号写死成字面量，只能擦掉 quoted 形式的旧段。TOML 规范里 `taptap-maker`（bare key）和 `"taptap-maker"`（quoted basic string）等价，但字符串层面是两种文本——结果旧 bare 段没被清，新 quoted 段被追加，两段在同一 table 路径下出现 → Codex 解析报 duplicate key。

## 实现要点

1. `createCodexMcpKeyPattern`：mcpName 满足 TOML bare key 字符集（`A-Za-z0-9_-`）时返回 `(?:"<name>"|<name>)`，否则强制 quoted，head 和 lookahead 共用同一份。
2. `mergeCodexMcpConfig`：写入后读回扫描所有 `[mcp_servers.<name>...]` 表头并 normalize，若存在重复立即 `restoreBackup` 回滚并抛错，非零退出。
3. `backupIfExists` 返回备份路径；新增 `restoreBackup` 处理"原文件存在 → 还原"与"原本无文件 → 删除新写入"两种回滚路径，避免首次 install 失败留下半成品。

## 影响范围

- 仅影响 Codex（TOML 字符串拼接）。Cursor / Claude 走 `mergeJsonMcpConfig`，以对象 key 覆盖，本身不存在该问题。
- 用户态：之前已被污染的 `~/.codex/config.toml`，再次跑 `mcp install --ide codex` 会被自动清理到单条 quoted 段。

## Test plan

- [x] `npx jest src/__tests__/makerCliCommands.test.ts -t codex` 全绿（4 个用例：原 quoted 替换、bare 段清理、bare+quoted 混合修复、重复 install 幂等）
- [ ] 本地手工：构造 `[mcp_servers.taptap-maker]` bare 形式配置，跑 `taptap-maker mcp install --ide codex`，确认 grep 后只剩单条 quoted 段
- [ ] Codex 重启加载新 config.toml 不再报 duplicate key

🤖 Generated with [Claude Code](https://claude.com/claude-code)