### PR TITLE
fix(maker): expose dev kit skill install results

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,19 +337,19 @@ TAPTAP_MCP_VERBOSE=true npm run serve:http   # HTTP 模式，启用日志
 Maker 本地开发的默认路径是 CLI-first + PAT-first：
 
 - Maker CLI-first 重构后的正式说明在 `docs/MAKER.md`；面向团队介绍的功能总览在 `docs/MAKER_CLI_MCP_SKILL_REWORK_OVERVIEW.md`。上下文压缩或长时间中断后，先读这两份文档再继续。
-- 用户说“我要开发maker游戏 / 本地maker开发 / 拉取maker游戏到本地 / 把maker游戏代码拉到本地 / clone maker项目 / 下载maker游戏代码 / 初始化maker开发目录 / 配置maker本地开发 / 继续开发maker项目”时，应触发 `taptap-maker init`，不要让 Agent 逐个调用旧的初始化 MCP tools。
+- 用户说“我要开发maker游戏 / 本地maker开发 / 拉取maker游戏到本地 / 把maker游戏代码拉到本地 / clone maker项目 / 下载maker游戏代码 / 初始化maker开发目录 / 配置maker本地开发 / 继续开发maker项目”时，应触发 `taptap-maker init`，由该 CLI 统一处理初始化流程。
 - 如果本地没有 Maker PAT，CLI 会引导用户打开当前环境的 PAT 页面新建 PAT，并把 PAT 发给 Agent：production 使用 `https://maker.taptap.cn/pat-tokens`，RND 使用 `https://fuping.agnt.xd.com/pat-tokens`。
 - 用户提供 Maker PAT 后，运行 `taptap-maker pat set` 并在 prompt 中粘贴，或在 `taptap-maker init` 里粘贴；CLI 会保存到 `~/.taptap-maker/pat.json`，兼容旧路径 `~/.maker-pat`，并调用 `GET /api/v1/user/taptap-token` 获取 TapTap MAC token。兼容写法 `taptap-maker pat set <PAT>` 会让 PAT 进入 `ps`/shell history，仅在用户明确接受风险时使用。
-- `taptap-maker init` 会检查 Git、PAT、TapTap token、当前目录绑定状态、app 列表、AI dev kit，并在用户选择 app 后 clone 到当前目录。app 文本预览默认展示前 40 个；账号 app 很多时在 init 交互中输入 `all` 一次性展开全部，或单独跑 `taptap-maker apps --all`；`taptap-maker apps --json` 仅给 AI / 脚本解析使用。AI 转述时宽屏可用两列紧凑布局，窄屏保持单列，但不要省略 app_id 或自动选择。
+- `taptap-maker init` 会检查 Git、PAT、TapTap token、当前目录绑定状态、app 列表、AI dev kit，并在用户选择 app 后 clone 到当前目录。app 文本预览默认展示前 40 个；账号 app 很多时在 init 交互中输入 `all` 一次性展开全部，或单独跑 `taptap-maker apps --all`；`taptap-maker apps --json` 仅给 AI / 脚本解析使用。AI 转述时宽屏可用两列紧凑布局，窄屏保持单列；每个 app 保留 app_id，并在用户确认后选择 app。
 - `taptap-maker init` 的 Git clone/fetch 会按错误内容判断是否自动重试：503、HTTP 5xx、超时、连接重置、RPC/HTTP2 中断等远端临时错误会重试；认证、权限、仓库不存在、远端拒绝和本地目录冲突不重试。
-- 首次 clone/fetch 前必须提示用户：Maker server 可能正在准备仓库，首次拉代码 20 秒以上是正常现象，不要中断当前命令。
+- 首次 clone/fetch 前必须提示用户：Maker server 可能正在准备仓库，首次拉代码 20 秒以上是正常现象，请保持当前命令运行。
 - CLI 写 MCP 配置时优先支持 Windows：Windows 使用 `npx.cmd`，Git 引导优先指向 Git for Windows；macOS 用户可通过 `git --version` 触发 Xcode Command Line Tools 或安装官方 Git。
 - `taptap-maker mcp verify` 默认验证 `mcp install` 写入配置的 npx 包命令能否启动；本地开发只验证当前 CLI 时使用 `--mode self`。
 - MCP 公共能力只保留 `maker://status`、`maker_status_lite` 和 `maker_build_current_directory`；初始化、PAT 保存、app 列表和 clone 由 CLI/skill 承担。
 - 新开对话、继续开发或检查 Maker 状态时，先读 `maker://status` 或调用 `maker_status_lite`。已绑定项目会输出 `Maker remote sync`，提示是否需要先 pull、是否本地 dirty、是否分叉或是否不在 main；按其中 `next_action` 引导用户，避免开发后才在 push 阶段遇到冲突。
 - 用户说“帮我提交 / 提交代码 / 提交并推送 / push / 构建 / 预览 / 跑一下 / 验证一下 / 看看效果”时，都调用 `maker_build_current_directory`。它会在本地有改动或 ahead commit 时先 commit/push，push 成功后才远端 build。
 - push 被拒绝、远端有新提交、认证失败或存在冲突时，`maker_build_current_directory` 必须停止在 build 前，并返回 `submit_failed_before_build`、本地 commit/ahead 状态、stderr/stdout 和下一步建议；Agent 必须根据 `classification` 选择恢复路径：`remote_rejected` 才协助 pull/rebase，`branch_not_allowed` 切回 main 并迁移本地 commit，`forbidden_path` 按远端 forbidden pattern 从未推送 commit 移除禁止路径，`auth` 才刷新 PAT。
-- push 遇到 503、HTTP 5xx、超时或连接中断会自动重试；最终失败时要读取 `classification`、`retryable`、`retry_reason` 和 `retry_attempts`，不要无脑手动执行通用 `git push`。
+- push 遇到 503、HTTP 5xx、超时或连接中断会自动重试；最终失败时要读取 `classification`、`retryable`、`retry_reason` 和 `retry_attempts`，按工具返回的恢复路径继续处理。
 - push 成功但远端 build 失败时，工具返回 `build_failed_after_submit`，必须同时说明代码已经提交到 Maker 远端和具体构建错误。
 - 用户明确说不提交、直接构建云端版本时，才允许调用 `maker_build_current_directory` 并设置 `confirm_remote_build_without_submit=true`。
 - 构建时如果用户未指定入口且本地存在 `scripts/main.lua`，本地 Maker MCP 默认传 `scriptsPath="scripts"` 和 `entry="main.lua"`；用户显式传单机入口或多人入口时优先生效。
@@ -406,6 +406,13 @@ npm run openclaw:pack
 - **允许进行网页查询和搜索**
 - **所有工具描述使用英文**，便于 AI Agent 理解
 - **工具处理函数必须返回 `Promise<string>` 类型**
+- **命名必须清晰区分能力边界**：新增 CLI 命令、MCP tool/resource、skill、脚本、
+  文档章节或用户可见流程名称时，使用带业务前缀/语义清晰的名称，让 Agent 能稳定区分
+  AI 客户端内置能力、本项目已有概念、通用 Skill 名称和常见命令；用户可见文案应明确标注
+  “CLI 命令”“MCP tool/resource”“workflow guide document/skill 文档”。
+- **`taptap-maker init` 是 Maker 初始化唯一主流程入口**：`init` 相关命名必须视为保留名。
+  新增能力使用业务前缀与完整语义命名，面向用户或 AI 的文案统一把 bundled workflow guide
+  document 表达为“文档/指南”，并把 Maker 初始化的正向下一步写成：执行 `taptap-maker init`。
 
 ### 代码规范
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -371,6 +371,13 @@ npm run format
 - **允许进行网页查询和搜索**
 - **所有工具描述使用英文**，便于 AI Agent 理解
 - **工具处理函数必须返回 `Promise<string>` 类型**
+- **命名必须清晰区分能力边界**：新增 CLI 命令、MCP tool/resource、skill、脚本、
+  文档章节或用户可见流程名称时，使用带业务前缀/语义清晰的名称，让 Agent 能稳定区分
+  AI 客户端内置能力、本项目已有概念、通用 Skill 名称和常见命令；用户可见文案应明确标注
+  “CLI 命令”“MCP tool/resource”“workflow guide document/skill 文档”。
+- **`taptap-maker init` 是 Maker 初始化唯一主流程入口**：`init` 相关命名必须视为保留名。
+  新增能力使用业务前缀与完整语义命名，面向用户或 AI 的文案统一把 bundled workflow guide
+  document 表达为“文档/指南”，并把 Maker 初始化的正向下一步写成：执行 `taptap-maker init`。
 
 ### 代码规范
 

--- a/README.md
+++ b/README.md
@@ -133,9 +133,9 @@ Maker 现在同时内置三个工作流 skill：
 
 初始化流程里，PAT 验证通过、用户选择 app 后，`taptap-maker init` 会自动准备本地 AI dev kit。
 
-CLI 会根据 `TAPTAP_MCP_ENV` 自动选择下载源：`production`（默认）使用 `https://urhox-demo-platform.spark.xd.com/ai-dev-kit/pd/stable/ai-dev-kit.zip`，`rnd` 使用 `https://urhox-demo-platform.spark.xd.com/ai-dev-kit/rnd/latest/ai-dev-kit.zip`，解压开发环境文档、引擎 API、demo 和本地 AI skills 到当前目录；会跳过 ZIP 里的顶层 `scripts` 目录并删除下载 ZIP，避免和 Maker 项目代码冲突。clone 前会先生成 `.gitignore.dev-kit-before-clone` 临时 block，clone 成功后自动合并到远端 `.gitignore`，防止这些本地开发环境文件和 `.maker/` 本地运行状态被提交到 Maker Git。
+CLI 会根据 `TAPTAP_MCP_ENV` 自动选择下载源：`production`（默认）使用 `https://urhox-demo-platform.spark.xd.com/ai-dev-kit/pd/stable/ai-dev-kit.zip`，`rnd` 使用 `https://urhox-demo-platform.spark.xd.com/ai-dev-kit/rnd/latest/ai-dev-kit.zip`，解压开发环境文档、引擎 API、demo、Lua 工具和本地 AI skills 到当前目录；解压复制完成后会自动运行 `tools/install-skills.sh all`（Linux/macOS）或 `tools/install-skills.ps1 all`（Windows），把 dev kit skills 安装到各 Agent 的发现目录。CLI 会先输出 `AI skills install started: <script>`，完成后输出 `AI skills install result: claude=N, codex=N, cursor=N, gemini=N`；脚本缺失、跳过或失败时也会输出原因，失败会带上平台、脚本、命令、stdout 和 stderr，方便 AI 与用户直接判断安装情况。流程会跳过 ZIP 里的顶层 `scripts` 目录并删除下载 ZIP，避免和 Maker 项目代码冲突。clone 前会先生成 `.gitignore.dev-kit-before-clone` 临时 block，clone 成功后自动合并到远端 `.gitignore`，防止这些本地开发环境文件、Agent skill 目录和 `.maker/` 本地运行状态被提交到 Maker Git。
 
-`maker://status` 和 `maker_status_lite` 会输出已随包内置的 skill 名称和文档路径：`taptap-maker-local`、`taptap-maker-dev-kit-guide` 与 `update-taptap-mcp`。Maker 操作目标是用户当前项目目录；若 MCP 进程 cwd 是临时对话目录，Agent 应把用户当前项目目录作为 `target_dir` 传入，不扫描其他项目。已绑定项目会检查 `CLAUDE.md`、`examples/`、`templates/`、`urhox-libs/`，缺失时用 `taptap-maker dev-kit update` 恢复本地 AI dev kit 并刷新 `.gitignore` 管理块。
+`maker://status` 和 `maker_status_lite` 会输出已随包内置的 skill 名称和文档路径：`taptap-maker-local`、`taptap-maker-dev-kit-guide` 与 `update-taptap-mcp`。Maker 操作目标是用户当前项目目录；若 MCP 进程 cwd 是临时对话目录，Agent 应把用户当前项目目录作为 `target_dir` 传入，不扫描其他项目。已绑定项目会检查 `CLAUDE.md`、`examples/`、`templates/`、`urhox-libs/`，并输出 `skill_install_status` 和 `skill_install_summary` 说明 `.claude/.codex/.cursor/.gemini` 下的 skill 安装状态；缺失时用 `taptap-maker dev-kit update` 恢复本地 AI dev kit 并刷新 `.gitignore` 管理块。
 
 Git 引导：
 

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -186,9 +186,24 @@ CLI 负责确定性文件处理：
 - dev kit 准备失败不会阻塞 Maker 项目 clone；CLI 会返回 `ai_dev_kit_error`，后续可通过 `taptap-maker dev-kit update` 重新恢复。
 - 如果目标目录位于外层 Git 仓库下，clone 只把目标目录自身的 `.git` 视为已有 Maker 仓库；父级 Git 仓库不会被复用，也不会被改 remote。
 - Windows 原生环境使用 PowerShell `Expand-Archive` 解压；Linux/macOS 先使用 `unzip`，失败时回退到 `python3`/`python` 标准库 `zipfile`。
+- 解压复制完成后，如果 dev kit 带有 `tools/install-skills.*`，CLI 会按平台执行
+  `install-skills.sh all`（Linux/macOS）或 `install-skills.ps1 all`（Windows），把
+  `skills/` 安装到 `.claude/skills/`、`.codex/skills/`、`.cursor/skills/` 和
+  `.gemini/skills/`。
+- skill 安装脚本开始执行时，普通 CLI 输出会追加 `AI skills install started:
+  <script>`；安装结束后会追加 `AI skills install result: claude=N, codex=N,
+  cursor=N, gemini=N`。如果目标目录已经存在完整 dev kit，clone/init 前也会重新执行
+  skill 安装脚本并输出结果，避免用户无法判断本地 skill 是否刷新。
+- JSON 输出会在 `data.skillInstaller` 中包含脚本路径、stdout、stderr 和摘要；脚本缺失或
+  被跳过时也会返回跳过原因。
+- 如果 skill 安装脚本失败，CLI 会在错误里输出平台、脚本路径、工作目录、命令、退出码、
+  stdout 和 stderr，方便 Agent 与用户直接看到失败原因。
+- `maker://status` 和 `maker_status_lite` 会输出 `skill_install_status` 与
+  `skill_install_summary`，用于检查 `.claude/.codex/.cursor/.gemini` 下的 skill 安装状态。
 - 跳过 ZIP 顶层 `scripts` 目录，避免和 Maker 项目 clone 后的 `scripts` 冲突。
 - 删除下载完成并解压后的 `ai-dev-kit.zip`。
-- clone 前生成 `.gitignore.dev-kit-before-clone` 临时 block，把 dev-kit 顶层内容标记为 local-only。
+- clone 前生成 `.gitignore.dev-kit-before-clone` 临时 block，把 dev-kit 顶层内容和
+  Agent skill 发现目录标记为 local-only。
 - clone 成功后自动把临时 block 合并到远端 `.gitignore`，并删除临时文件。
 - 该 managed block 也会固定包含 `.maker/`，因为 `.maker/logs/runtime/` 是本地运行日志和游标状态，
   不应该提交到 Maker Git。
@@ -231,7 +246,7 @@ Maker app 列表关键字段：
 进度和耗时：
 
 - `taptap-maker init` 会解析 Git clone/fetch stderr 中的百分比进度。
-- 首次 clone/fetch 前会明确提示用户：Maker server 可能正在准备仓库，首次拉代码 20 秒以上是正常现象，不要中断当前命令。
+- 首次 clone/fetch 前会明确提示用户：Maker server 可能正在准备仓库，首次拉代码 20 秒以上是正常现象，请保持当前命令运行。
 - `taptap-maker init` 会根据 Git stderr 判断是否自动重试：HTTP 5xx、503、超时、连接重置、HTTP2/RPC 中断、early EOF 等远端临时错误会重试；认证失败、权限不足、仓库不存在、远端拒绝、非空目录冲突、本地权限错误不会重试。
 - 首次 clone/fetch 默认最多自动重试 2 次；连续重试后仍失败时，错误会保留 `retryable`、`retry_reason` 和已重试次数，方便 Agent 判断是让用户稍后直接重试，还是先处理 PAT、权限或本地目录问题。
 - `maker_build_current_directory` 会在本地 commit、push 和远端 build 阶段输出状态，并解析 Git push stderr 中的百分比进度。

--- a/skills/taptap-maker-local/SKILL.md
+++ b/skills/taptap-maker-local/SKILL.md
@@ -194,18 +194,19 @@ output as account reference only and continue the user's current bound-project t
 
 If PAT exchange fails:
 
-1. Explain that the PAT may be invalid or expired.
-2. Ask the user to create a new PAT.
-3. Do not switch to JWT/OAuth fallback unless the user explicitly asks.
+1. Show the PAT page URL for the current environment:
+   production `https://maker.taptap.cn/pat-tokens`, RND `https://fuping.agnt.xd.com/pat-tokens`.
+2. Ask the user to create a new Maker PAT on that page.
+3. Run `taptap-maker pat set` and paste the PAT into the prompt.
 
 ## App Selection
 
 Use app selection only when the current directory is unbound and the user is initializing or cloning
 a Maker project, or when the user explicitly asks to switch or re-clone.
 
-If the current directory is already bound, app lists from `taptap-maker apps` are reference only. Do
-not ask which app to clone. Continue operating on the current bound project unless the user
-explicitly requests a different project.
+If the current directory is already bound, app lists from `taptap-maker apps` are reference only.
+Continue operating on the current bound project. When the user explicitly requests a different
+project, start the project selection flow for that request.
 
 When app selection is needed, show the returned app preview and total count, then ask the user to
 choose by index, app id, or name. The default preview shows the 40 most recently active apps.
@@ -213,17 +214,18 @@ If the target is not visible, ask the user to type `all` inside `taptap-maker in
 full list, or run `taptap-maker apps --all` for a one-shot human-readable dump; use
 `taptap-maker apps --json` only when AI / scripts need the machine-readable list. If the
 chat/client width is enough, you may present the preview as a compact two-column layout;
-otherwise keep a single column. Do not omit app_id, and do not replace the preview with only a
-summary such as "40 apps are available".
+otherwise keep a single column. Keep app_id visible in every app row, and include the preview
+details instead of only a summary such as "40 apps are available".
 
-Do not auto-select:
+Selection confirmation:
 
-- the first app
-- the most recent app
-- the only app
+- Ask the user to choose by index, app id, or name.
+- Treat the user's explicit reply as the selected app.
+- If there is only one app, still ask for confirmation before selecting it.
 
-After the user chooses, let `taptap-maker init` continue with the selected app. Do not ask the user
-to manually provide app_id unless the CLI is being run non-interactively.
+After the user chooses, route the next action to `taptap-maker init` so the Maker initialization
+workflow can continue with the selected app. For non-interactive CLI runs, pass the selected app id
+through the supported CLI option.
 
 ## Working Directory Compliance Check
 

--- a/src/__tests__/makerBuildLocalChanges.test.ts
+++ b/src/__tests__/makerBuildLocalChanges.test.ts
@@ -147,13 +147,21 @@ describe('maker build local-change guard', () => {
   });
 
   test('status fetch auth failures guide users to refresh Maker PAT', () => {
+    const nextAction = getMakerRemoteSyncFailureNextAction({
+      classification: 'auth',
+      retryable: false,
+      nextAction: '运行 `taptap-maker pat set` 并粘贴新的 Maker PAT。',
+    });
+
+    expect(nextAction).toContain('taptap-maker pat set');
+    expect(nextAction).toContain('https://maker.taptap.cn/pat-tokens');
     expect(
       getMakerRemoteSyncFailureNextAction({
         classification: 'auth',
         retryable: false,
         nextAction: '运行 `taptap-maker pat set` 并粘贴新的 Maker PAT。',
       })
-    ).toContain('taptap-maker pat set');
+    ).not.toContain('控制台');
   });
 
   test('pushes committed but unpushed Maker changes when workspace is clean', async () => {
@@ -622,10 +630,10 @@ describe('maker build local-change guard', () => {
     const statusTool = tools.find((item) => item.name === 'maker_status_lite');
     const buildTool = tools.find((item) => item.name === 'maker_build_current_directory');
 
-    expect(statusTool?.description).toContain('bundled workflow skill document paths');
+    expect(statusTool?.description).toContain('bundled workflow guide document paths');
     expect(statusTool?.inputSchema.properties).toHaveProperty('target_dir');
     expect(statusTool?.description).toContain('AI dev kit status');
-    expect(statusTool?.description).toContain('Compatibility fallback');
+    expect(statusTool?.description).toContain('Compatibility status surface');
     expect(statusTool?.description).not.toContain('If PAT is missing');
     expect(statusTool?.description).not.toContain('ask them to open');
     expect(statusTool?.description).not.toContain('让用户选择');

--- a/src/__tests__/makerCliCommands.test.ts
+++ b/src/__tests__/makerCliCommands.test.ts
@@ -9,6 +9,7 @@ import readline from 'node:readline/promises';
 import { spawnSync } from 'node:child_process';
 import { requestTapAuthWithPat } from '../maker/auth/patTap';
 import { cloneMakerProject, listMakerProjects } from '../maker/cli/projects';
+import { inspectAiDevKit, installAiDevKit, installAiDevKitSkills } from '../maker/cli/devKit';
 import { runMakerCli } from '../maker/cli/commands';
 
 jest.mock('node:child_process', () => ({
@@ -49,6 +50,7 @@ jest.mock('../maker/cli/devKit', () => ({
     ready: true,
   })),
   installAiDevKit: jest.fn(),
+  installAiDevKitSkills: jest.fn(),
   listPresentDevKitManagedEntries: jest.fn(() => []),
   writeDevKitStagedGitignore: jest.fn(),
 }));
@@ -319,6 +321,48 @@ describe('Maker CLI commands', () => {
     expect(requestTapAuthWithPat).toHaveBeenCalledWith('secret-maker-token');
   });
 
+  test('init PAT validation failures include the PAT URL', async () => {
+    jest
+      .mocked(requestTapAuthWithPat)
+      .mockRejectedValueOnce(
+        new Error('TapTap token request failed: HTTP 401 {"code":"PAT_INVALID"}')
+      );
+
+    await expect(
+      runMakerCli([
+        'init',
+        '--skip-confirm',
+        'app-1',
+        '--target-dir',
+        tempDir,
+        '--skip-mcp-install',
+        '--pat',
+        'invalid-maker-token',
+      ])
+    ).rejects.toThrow('https://maker.taptap.cn/pat-tokens');
+  });
+
+  test('init clone auth failures include the PAT URL', async () => {
+    jest
+      .mocked(cloneMakerProject)
+      .mockRejectedValueOnce(
+        new Error('git clone failed with exit code 128: The requested URL returned error: 401')
+      );
+
+    await expect(
+      runMakerCli([
+        'init',
+        '--skip-confirm',
+        'app-1',
+        '--target-dir',
+        tempDir,
+        '--skip-mcp-install',
+        '--pat',
+        'invalid-maker-token',
+      ])
+    ).rejects.toThrow('https://maker.taptap.cn/pat-tokens');
+  });
+
   test('boolean flags do not consume following positional app id', async () => {
     await runMakerCli([
       'init',
@@ -337,6 +381,135 @@ describe('Maker CLI commands', () => {
         targetDir: tempDir,
       })
     );
+  });
+
+  test('init prints AI dev kit preparation error details for human users', async () => {
+    jest.mocked(inspectAiDevKit).mockReturnValueOnce({
+      targetDir: tempDir,
+      requiredEntries: ['CLAUDE.md'],
+      presentEntries: [],
+      missingEntries: ['CLAUDE.md'],
+      ready: false,
+    });
+    jest
+      .mocked(installAiDevKit)
+      .mockRejectedValueOnce(
+        new Error('Failed to install AI dev kit skills\nstderr: installer failed')
+      );
+
+    await runMakerCli([
+      'init',
+      '--skip-confirm',
+      'app-1',
+      '--target-dir',
+      tempDir,
+      '--skip-mcp-install',
+      '--pat',
+      'secret-maker-token',
+    ]);
+
+    const output = stdoutSpy.mock.calls.join('');
+    expect(output).toContain('AI dev kit preparation failed; clone will continue');
+    expect(output).toContain('Failed to install AI dev kit skills');
+    expect(output).toContain('stderr: installer failed');
+    expect(cloneMakerProject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appId: 'app-1',
+        targetDir: tempDir,
+      })
+    );
+  });
+
+  test('init prints AI dev kit skill installer success summary for human users', async () => {
+    jest.mocked(inspectAiDevKit).mockReturnValueOnce({
+      targetDir: tempDir,
+      requiredEntries: ['CLAUDE.md'],
+      presentEntries: [],
+      missingEntries: ['CLAUDE.md'],
+      ready: false,
+    });
+    jest.mocked(installAiDevKit).mockImplementationOnce(async (options) => {
+      options.onSkillInstallerStart?.({
+        platform: process.platform,
+        script: path.join(tempDir, 'tools', 'install-skills.sh'),
+        cwd: path.join(tempDir, 'tools'),
+        command: ['bash', path.join(tempDir, 'tools', 'install-skills.sh'), 'all'],
+      });
+      return {
+        targetDir: tempDir,
+        sourceDir: path.join(tempDir, 'source'),
+        installedEntries: ['skills', 'tools'],
+        skippedEntries: [],
+        gitignorePath: path.join(tempDir, '.gitignore'),
+        stagedGitignorePath: path.join(tempDir, '.gitignore.dev-kit-before-clone'),
+        skillInstaller: {
+          ok: true,
+          status: 'installed',
+          script: path.join(tempDir, 'tools', 'install-skills.sh'),
+          summary: 'claude=13, codex=13, cursor=13, gemini=13',
+          stdout: '[install-skills] claude: installed=13 target=.claude/skills',
+          stderr: '',
+        },
+      };
+    });
+
+    await runMakerCli([
+      'init',
+      '--skip-confirm',
+      'app-1',
+      '--target-dir',
+      tempDir,
+      '--skip-mcp-install',
+      '--pat',
+      'secret-maker-token',
+    ]);
+
+    const output = stdoutSpy.mock.calls.join('');
+    expect(output).toContain('AI skills install started');
+    expect(output).toContain('AI dev kit prepared');
+    expect(output).toContain('AI skills install result: claude=13, codex=13, cursor=13, gemini=13');
+  });
+
+  test('init runs and prints AI skill installer result when dev kit is already present', async () => {
+    jest.mocked(inspectAiDevKit).mockReturnValueOnce({
+      targetDir: tempDir,
+      requiredEntries: ['CLAUDE.md', 'examples', 'templates', 'urhox-libs'],
+      presentEntries: ['CLAUDE.md', 'examples', 'templates', 'urhox-libs'],
+      missingEntries: [],
+      ready: true,
+    });
+    jest.mocked(installAiDevKitSkills).mockImplementationOnce((_targetDir, options) => {
+      options?.onStart?.({
+        platform: process.platform,
+        script: path.join(tempDir, 'tools', 'install-skills.sh'),
+        cwd: path.join(tempDir, 'tools'),
+        command: ['bash', path.join(tempDir, 'tools', 'install-skills.sh'), 'all'],
+      });
+      return {
+        ok: true,
+        status: 'installed',
+        script: path.join(tempDir, 'tools', 'install-skills.sh'),
+        summary: 'claude=13, codex=13, cursor=13, gemini=13',
+        stdout: '[install-skills] claude: installed=13 target=.claude/skills',
+        stderr: '',
+      };
+    });
+
+    await runMakerCli([
+      'init',
+      '--skip-confirm',
+      'app-1',
+      '--target-dir',
+      tempDir,
+      '--skip-mcp-install',
+      '--pat',
+      'secret-maker-token',
+    ]);
+
+    const output = stdoutSpy.mock.calls.join('');
+    expect(output).toContain('AI dev kit already present');
+    expect(output).toContain('AI skills install started');
+    expect(output).toContain('AI skills install result: claude=13, codex=13, cursor=13, gemini=13');
   });
 
   test('init selection index follows the recently active display order', async () => {
@@ -436,6 +609,18 @@ describe('Maker CLI commands', () => {
     expect(listMakerProjects).toHaveBeenCalledWith({ pat: 'secret-maker-token' });
   });
 
+  test('apps PAT validation failures include the PAT URL', async () => {
+    jest
+      .mocked(listMakerProjects)
+      .mockRejectedValueOnce(
+        new Error('Maker project list failed: HTTP 401 {"code":"PAT_INVALID"}')
+      );
+
+    await expect(runMakerCli(['apps', '--pat', 'invalid-maker-token'])).rejects.toThrow(
+      'https://maker.taptap.cn/pat-tokens'
+    );
+  });
+
   test('apps rejects removed --limit / --offset with a guidance error', async () => {
     await expect(runMakerCli(['apps', '--offset', '40', '--limit', '40'])).rejects.toThrow(
       /no longer supports --limit \/ --offset/
@@ -476,6 +661,18 @@ describe('Maker CLI commands', () => {
     expect(output).toContain('Create one at: https://maker.taptap.cn/pat-tokens');
     expect(requestTapAuthWithPat).toHaveBeenCalledWith('secret-maker-token');
     expect(close).toHaveBeenCalled();
+  });
+
+  test('pat set validation failures include the PAT URL', async () => {
+    jest
+      .mocked(requestTapAuthWithPat)
+      .mockRejectedValueOnce(
+        new Error('TapTap token request failed: HTTP 401 {"code":"PAT_INVALID"}')
+      );
+
+    await expect(runMakerCli(['pat', 'set', '--pat', 'invalid-maker-token'])).rejects.toThrow(
+      'https://maker.taptap.cn/pat-tokens'
+    );
   });
 
   test('mcp verify checks the configured npx package command by default', async () => {

--- a/src/__tests__/makerCliCommands.test.ts
+++ b/src/__tests__/makerCliCommands.test.ts
@@ -380,6 +380,34 @@ describe('Maker CLI commands', () => {
     ).rejects.toThrow('https://maker.taptap.cn/pat-tokens');
   });
 
+  test('init clone forbidden path failures do not include the PAT URL', async () => {
+    jest
+      .mocked(cloneMakerProject)
+      .mockRejectedValueOnce(
+        new Error('git push rejected: file matches forbidden pattern ".claude/skills/demo"')
+      );
+
+    let thrown: unknown;
+    try {
+      await runMakerCli([
+        'init',
+        '--skip-confirm',
+        'app-1',
+        '--target-dir',
+        tempDir,
+        '--skip-mcp-install',
+        '--pat',
+        'valid-maker-token',
+      ]);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toContain('matches forbidden pattern');
+    expect((thrown as Error).message).not.toContain('pat-tokens');
+  });
+
   test('boolean flags do not consume following positional app id', async () => {
     await runMakerCli([
       'init',

--- a/src/__tests__/makerCliCommands.test.ts
+++ b/src/__tests__/makerCliCommands.test.ts
@@ -342,6 +342,23 @@ describe('Maker CLI commands', () => {
     ).rejects.toThrow('https://maker.taptap.cn/pat-tokens');
   });
 
+  test('init Chinese PAT validation failures include the PAT URL', async () => {
+    jest.mocked(requestTapAuthWithPat).mockRejectedValueOnce(new Error('PAT 已过期'));
+
+    await expect(
+      runMakerCli([
+        'init',
+        '--skip-confirm',
+        'app-1',
+        '--target-dir',
+        tempDir,
+        '--skip-mcp-install',
+        '--pat',
+        'invalid-maker-token',
+      ])
+    ).rejects.toThrow('https://maker.taptap.cn/pat-tokens');
+  });
+
   test('init clone auth failures include the PAT URL', async () => {
     jest
       .mocked(cloneMakerProject)
@@ -468,6 +485,50 @@ describe('Maker CLI commands', () => {
     expect(output).toContain('AI skills install started');
     expect(output).toContain('AI dev kit prepared');
     expect(output).toContain('AI skills install result: claude=13, codex=13, cursor=13, gemini=13');
+  });
+
+  test('init prints prepared dev kit and skill failure details separately', async () => {
+    jest.mocked(inspectAiDevKit).mockReturnValueOnce({
+      targetDir: tempDir,
+      requiredEntries: ['CLAUDE.md'],
+      presentEntries: [],
+      missingEntries: ['CLAUDE.md'],
+      ready: false,
+    });
+    jest.mocked(installAiDevKit).mockResolvedValueOnce({
+      targetDir: tempDir,
+      sourceDir: path.join(tempDir, 'source'),
+      installedEntries: ['CLAUDE.md', 'skills', 'tools'],
+      skippedEntries: [],
+      gitignorePath: path.join(tempDir, '.gitignore'),
+      stagedGitignorePath: path.join(tempDir, '.gitignore.dev-kit-before-clone'),
+      skillInstaller: {
+        ok: false,
+        status: 'failed',
+        script: path.join(tempDir, 'tools', 'install-skills.sh'),
+        summary: 'failed: exit_status=42',
+        stdout: 'installer stdout detail',
+        stderr: 'installer stderr detail',
+        error: 'Failed to install AI dev kit skills\nstderr:\ninstaller stderr detail',
+      },
+    });
+
+    await runMakerCli([
+      'init',
+      '--skip-confirm',
+      'app-1',
+      '--target-dir',
+      tempDir,
+      '--skip-mcp-install',
+      '--pat',
+      'secret-maker-token',
+    ]);
+
+    const output = stdoutSpy.mock.calls.join('');
+    expect(output).toContain('AI dev kit prepared');
+    expect(output).toContain('AI skills install result: failed: exit_status=42');
+    expect(output).toContain('AI skills install failed; clone will continue');
+    expect(output).toContain('installer stderr detail');
   });
 
   test('init runs and prints AI skill installer result when dev kit is already present', async () => {

--- a/src/__tests__/makerDevKit.test.ts
+++ b/src/__tests__/makerDevKit.test.ts
@@ -9,6 +9,7 @@ import {
   inspectAiDevKit,
   inspectAiDevKitSkillInstallStatus,
   installAiDevKit,
+  installAiDevKitSkills,
   listPresentDevKitManagedEntries,
   mergeDevKitGitignore,
   resolveDefaultAiDevKitUrl,
@@ -131,7 +132,7 @@ describe('Maker AI dev kit install', () => {
     ]);
   });
 
-  test('throws visible script details when skill installer fails', async () => {
+  test('returns copied dev kit and staged gitignore when skill installer fails', async () => {
     fs.writeFileSync(
       path.join(sourceDir, 'tools', 'install-skills.sh'),
       [
@@ -144,26 +145,46 @@ describe('Maker AI dev kit install', () => {
       'utf8'
     );
 
-    let thrown: unknown;
-    try {
-      await installAiDevKit({
-        sourceDir,
-        targetDir,
-      });
-    } catch (error) {
-      thrown = error;
-    }
+    const result = await installAiDevKit({
+      sourceDir,
+      targetDir,
+    });
 
-    expect(thrown).toBeInstanceOf(Error);
-    const message = (thrown as Error).message;
-    expect(message).toContain('Failed to install AI dev kit skills');
-    expect(message).toContain('script:');
-    expect(message).toContain('platform:');
-    expect(message).toContain('exit_status: 42');
-    expect(message).toContain('stdout:');
-    expect(message).toContain('installer stdout detail');
-    expect(message).toContain('stderr:');
-    expect(message).toContain('installer stderr detail');
+    expect(result.installedEntries).toContain('CLAUDE.md');
+    expect(fs.existsSync(path.join(targetDir, 'CLAUDE.md'))).toBe(true);
+    expect(fs.existsSync(path.join(targetDir, DEV_KIT_GITIGNORE_STAGING_FILE))).toBe(true);
+    expect(result.skillInstaller).toEqual(
+      expect.objectContaining({
+        ok: false,
+        status: 'failed',
+        summary: 'failed: exit_status=42',
+        stdout: expect.stringContaining('installer stdout detail'),
+        stderr: expect.stringContaining('installer stderr detail'),
+        error: expect.stringContaining('Failed to install AI dev kit skills'),
+      })
+    );
+  });
+
+  test('throws visible script details when running skill installer directly fails', () => {
+    fs.mkdirSync(path.join(targetDir, 'tools'), { recursive: true });
+    fs.writeFileSync(
+      path.join(targetDir, 'tools', 'install-skills.sh'),
+      [
+        '#!/bin/sh',
+        'echo "installer stdout detail"',
+        'echo "installer stderr detail" >&2',
+        'exit 42',
+        '',
+      ].join('\n'),
+      'utf8'
+    );
+    fs.chmodSync(path.join(targetDir, 'tools', 'install-skills.sh'), 0o755);
+
+    expect(() => installAiDevKitSkills(targetDir)).toThrow(
+      expect.objectContaining({
+        message: expect.stringContaining('Failed to install AI dev kit skills'),
+      })
+    );
   });
 
   test('stages skill installer output directories as local-only entries', async () => {

--- a/src/__tests__/makerDevKit.test.ts
+++ b/src/__tests__/makerDevKit.test.ts
@@ -7,6 +7,7 @@ import {
   DEV_KIT_GITIGNORE_STAGING_FILE,
   finalizeStagedDevKitGitignore,
   inspectAiDevKit,
+  inspectAiDevKitSkillInstallStatus,
   installAiDevKit,
   listPresentDevKitManagedEntries,
   mergeDevKitGitignore,
@@ -22,11 +23,13 @@ describe('Maker AI dev kit install', () => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'maker-dev-kit-'));
     sourceDir = path.join(tempDir, 'ai-dev-kit');
     targetDir = path.join(tempDir, 'target');
+    fs.mkdirSync(path.join(sourceDir, '.cli'), { recursive: true });
     fs.mkdirSync(path.join(sourceDir, 'engine-docs'), { recursive: true });
     fs.mkdirSync(path.join(sourceDir, 'scripts'), { recursive: true });
     fs.mkdirSync(path.join(sourceDir, '.emmylua'), { recursive: true });
     fs.mkdirSync(path.join(sourceDir, 'examples'), { recursive: true });
     fs.mkdirSync(path.join(sourceDir, 'templates'), { recursive: true });
+    fs.mkdirSync(path.join(sourceDir, 'tools'), { recursive: true });
     fs.mkdirSync(path.join(sourceDir, 'urhox-libs'), { recursive: true });
     fs.writeFileSync(path.join(sourceDir, 'engine-docs', 'README.md'), 'docs\n', 'utf8');
     fs.writeFileSync(path.join(sourceDir, 'scripts', 'main.lua'), '-- should skip\n', 'utf8');
@@ -36,10 +39,31 @@ describe('Maker AI dev kit install', () => {
       '---@class Engine\n',
       'utf8'
     );
+    fs.writeFileSync(
+      path.join(sourceDir, '.cli', 'install-urhox-runtime.sh'),
+      '#!/bin/sh\n',
+      'utf8'
+    );
     fs.writeFileSync(path.join(sourceDir, 'examples', 'README.md'), 'examples\n', 'utf8');
     fs.writeFileSync(path.join(sourceDir, 'templates', 'README.md'), 'templates\n', 'utf8');
     fs.writeFileSync(path.join(sourceDir, 'urhox-libs', 'README.md'), 'libs\n', 'utf8');
     fs.writeFileSync(path.join(sourceDir, 'CLAUDE.md'), 'local agent docs\n', 'utf8');
+    fs.writeFileSync(
+      path.join(sourceDir, 'tools', 'install-skills.sh'),
+      [
+        '#!/bin/sh',
+        'set -eu',
+        'printf "%s\\n" "$1" > ../skill-install-agent.txt',
+        'mkdir -p ../.claude/skills/demo-skill ../.codex/skills/demo-skill ../.cursor/skills/demo-skill ../.gemini/skills/demo-skill',
+        'echo "[install-skills] claude: installed=13 target=../.claude/skills"',
+        'echo "[install-skills] codex: installed=13 target=../.codex/skills"',
+        'echo "[install-skills] cursor: installed=13 target=../.cursor/skills"',
+        'echo "[install-skills] gemini: installed=13 target=../.gemini/skills"',
+        '',
+      ].join('\n'),
+      'utf8'
+    );
+    fs.chmodSync(path.join(sourceDir, 'tools', 'install-skills.sh'), 0o755);
   });
 
   afterEach(() => {
@@ -53,20 +77,110 @@ describe('Maker AI dev kit install', () => {
     });
 
     expect(result.installedEntries).toEqual([
+      '.cli',
       '.emmylua',
       'CLAUDE.md',
       'engine-docs',
       'examples',
       'templates',
+      'tools',
       'urhox-libs',
     ]);
     expect(result.skippedEntries).toEqual(['ai-dev-kit.zip', 'scripts']);
     expect(fs.existsSync(path.join(targetDir, 'engine-docs', 'README.md'))).toBe(true);
+    expect(fs.existsSync(path.join(targetDir, '.cli', 'install-urhox-runtime.sh'))).toBe(true);
     expect(fs.existsSync(path.join(targetDir, '.emmylua', 'Engine.d.lua'))).toBe(true);
     expect(fs.existsSync(path.join(targetDir, 'examples', 'README.md'))).toBe(true);
     expect(fs.existsSync(path.join(targetDir, 'templates', 'README.md'))).toBe(true);
+    expect(fs.existsSync(path.join(targetDir, 'tools', 'install-skills.sh'))).toBe(true);
     expect(fs.existsSync(path.join(targetDir, 'scripts'))).toBe(false);
     expect(fs.existsSync(path.join(targetDir, 'ai-dev-kit.zip'))).toBe(false);
+  });
+
+  test('runs POSIX skill installer after copying dev kit tools', async () => {
+    const result = await installAiDevKit({
+      sourceDir,
+      targetDir,
+    });
+
+    expect(fs.readFileSync(path.join(targetDir, 'skill-install-agent.txt'), 'utf8')).toBe('all\n');
+    expect(result.skillInstaller).toEqual(
+      expect.objectContaining({
+        ok: true,
+        script: expect.stringContaining('install-skills.sh'),
+        summary: 'claude=13, codex=13, cursor=13, gemini=13',
+      })
+    );
+  });
+
+  test('inspects installed AI skill targets for post-clone status', async () => {
+    await installAiDevKit({
+      sourceDir,
+      targetDir,
+    });
+
+    const status = inspectAiDevKitSkillInstallStatus(targetDir);
+
+    expect(status.status).toBe('installed');
+    expect(status.summary).toBe('claude=1, codex=1, cursor=1, gemini=1');
+    expect(status.targets.map((target) => target.name)).toEqual([
+      'claude',
+      'codex',
+      'cursor',
+      'gemini',
+    ]);
+  });
+
+  test('throws visible script details when skill installer fails', async () => {
+    fs.writeFileSync(
+      path.join(sourceDir, 'tools', 'install-skills.sh'),
+      [
+        '#!/bin/sh',
+        'echo "installer stdout detail"',
+        'echo "installer stderr detail" >&2',
+        'exit 42',
+        '',
+      ].join('\n'),
+      'utf8'
+    );
+
+    let thrown: unknown;
+    try {
+      await installAiDevKit({
+        sourceDir,
+        targetDir,
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    const message = (thrown as Error).message;
+    expect(message).toContain('Failed to install AI dev kit skills');
+    expect(message).toContain('script:');
+    expect(message).toContain('platform:');
+    expect(message).toContain('exit_status: 42');
+    expect(message).toContain('stdout:');
+    expect(message).toContain('installer stdout detail');
+    expect(message).toContain('stderr:');
+    expect(message).toContain('installer stderr detail');
+  });
+
+  test('stages skill installer output directories as local-only entries', async () => {
+    await installAiDevKit({
+      sourceDir,
+      targetDir,
+    });
+
+    const stagedGitignore = fs.readFileSync(
+      path.join(targetDir, DEV_KIT_GITIGNORE_STAGING_FILE),
+      'utf8'
+    );
+    expect(stagedGitignore).toContain('.claude/');
+    expect(stagedGitignore).toContain('.cli/');
+    expect(stagedGitignore).toContain('.codex/');
+    expect(stagedGitignore).toContain('.cursor/');
+    expect(stagedGitignore).toContain('.gemini/');
   });
 
   test('detects required dev kit entries', async () => {
@@ -82,6 +196,7 @@ describe('Maker AI dev kit install', () => {
   });
 
   test('lists present managed dev kit entries beyond required readiness markers', () => {
+    fs.mkdirSync(path.join(targetDir, '.cli'), { recursive: true });
     fs.mkdirSync(path.join(targetDir, '.emmylua'), { recursive: true });
     fs.mkdirSync(path.join(targetDir, 'engine-docs'), { recursive: true });
     fs.mkdirSync(path.join(targetDir, 'examples'), { recursive: true });
@@ -89,6 +204,7 @@ describe('Maker AI dev kit install', () => {
     fs.writeFileSync(path.join(targetDir, 'user-file.txt'), 'keep me\n', 'utf8');
 
     expect(listPresentDevKitManagedEntries(targetDir)).toEqual([
+      '.cli',
       '.emmylua',
       'CLAUDE.md',
       'engine-docs',

--- a/src/__tests__/makerProjectsResponse.test.ts
+++ b/src/__tests__/makerProjectsResponse.test.ts
@@ -143,9 +143,11 @@ describe('maker app list display', () => {
     expect(output).toContain('40. app-81');
     expect(output).not.toContain('41. app-80');
     expect(output).not.toContain('offset');
-    expect(output).not.toContain('next');
+    expect(output).not.toContain('next_offset');
+    expect(output).not.toContain('next_page');
     expect(output).toContain('AI 展示建议');
     expect(output).toContain('两列紧凑布局');
+    expect(output).toContain('用户回复序号或 app_id 后，next_step: 执行 `taptap-maker init`');
     expect(output).not.toContain('每一个 app 条目');
   });
 

--- a/src/__tests__/makerSkillInstall.test.ts
+++ b/src/__tests__/makerSkillInstall.test.ts
@@ -24,11 +24,12 @@ describe('Maker bundled workflow skill documents', () => {
       projectRoot: tempDir,
     });
 
-    expect(status).toContain('TapTap bundled workflow skills');
+    expect(status).toContain('TapTap Maker workflow guide documents');
     expect(status).toContain(`skills/${MAKER_LOCAL_SKILL_NAME}/SKILL.md`);
     expect(status).toContain(`skills/${MAKER_DEV_KIT_GUIDE_SKILL_NAME}/SKILL.md`);
     expect(status).toContain(`skills/${UPDATE_TAPTAP_MCP_SKILL_NAME}/SKILL.md`);
-    expect(status).toContain('Let the current AI client decide whether and how to load them.');
+    expect(status).toContain('Use these documents as reading references');
+    expect(status).toContain('Maker initialization next_step: execute `taptap-maker init`');
     expect(status).not.toContain('Validation checklist for the local AI client');
     expect(status).not.toContain(`${MAKER_LOCAL_SKILL_NAME} / codex: missing`);
     expect(status).not.toContain('taptap-maker install-skill --ide codex');
@@ -52,7 +53,8 @@ describe('Maker bundled workflow skill documents', () => {
     expect(skillText).toContain('ask which app to clone');
     expect(skillText).toContain('app lists from `taptap-maker apps`');
     expect(skillText).toContain('reference only');
-    expect(skillText).toContain('Do not auto-select');
+    expect(skillText).toContain('Selection confirmation');
+    expect(skillText).toContain('Treat the user');
     expect(skillText).toContain('Bundled Skills');
     expect(skillText).toContain('Before every clone attempt, run `taptap-maker doctor`');
     expect(skillText).toContain('Directory Suitability Decision');

--- a/src/maker/cli/commands.ts
+++ b/src/maker/cli/commands.ts
@@ -801,7 +801,7 @@ function appendPatRecoveryUrl(error: unknown, parsed: ParsedArgs): Error {
 
 function isPatValidationFailure(message: string): boolean {
   return (
-    /\b(?:PAT_INVALID|401|403|unauthori[sz]ed|forbidden|invalid\s+PAT|PAT\s+invalid|expired)\b/i.test(
+    /\b(?:PAT_INVALID|HTTP\s*40[13]|40[13]|unauthori[sz]ed|invalid\s+PAT|PAT\s+invalid|expired)\b/i.test(
       message
     ) || /(?:过期|失效)/.test(message)
   );

--- a/src/maker/cli/commands.ts
+++ b/src/maker/cli/commands.ts
@@ -500,6 +500,7 @@ async function runDevKitUpdate(parsed: ParsedArgs, ctx: CliContext): Promise<voi
   });
   finalizeStagedDevKitGitignore(targetDir);
   emit(ctx, 'dev_kit', formatDevKitInstallMessage('AI dev kit updated', result), result);
+  emitDevKitSkillInstallerFailure(ctx, result.skillInstaller, 'AI skills install failed');
 }
 
 async function runLogsWatch(parsed: ParsedArgs, ctx: CliContext): Promise<void> {
@@ -740,6 +741,11 @@ async function prepareDevKit(targetDir: string, ctx: CliContext): Promise<void> 
       onSkillInstallerStart: (event) => emitSkillInstallerStart(ctx, event),
     });
     emit(ctx, 'dev_kit', formatDevKitInstallMessage('AI dev kit prepared', result), result);
+    emitDevKitSkillInstallerFailure(
+      ctx,
+      result.skillInstaller,
+      'AI skills install failed; clone will continue'
+    );
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
     emit(ctx, 'dev_kit_warning', `AI dev kit preparation failed; clone will continue\n${detail}`, {
@@ -762,6 +768,20 @@ function emitSkillInstallerStart(ctx: CliContext, event: AiDevKitSkillInstallerS
   emit(ctx, 'dev_kit_skill_install_start', `AI skills install started: ${event.script}`, event);
 }
 
+function emitDevKitSkillInstallerFailure(
+  ctx: CliContext,
+  result: { ok: boolean; status: string; error?: string } | undefined,
+  message: string
+): void {
+  if (!result || result.ok || result.status !== 'failed') {
+    return;
+  }
+  const detail = result.error || 'unknown installer failure';
+  emit(ctx, 'dev_kit_warning', `${message}\n${detail}`, {
+    error: detail,
+  });
+}
+
 function appendPatRecoveryUrl(error: unknown, parsed: ParsedArgs): Error {
   const message = error instanceof Error ? error.message : String(error);
   if (!isPatValidationFailure(message) || message.includes('/pat-tokens')) {
@@ -780,8 +800,10 @@ function appendPatRecoveryUrl(error: unknown, parsed: ParsedArgs): Error {
 }
 
 function isPatValidationFailure(message: string): boolean {
-  return /\b(?:PAT_INVALID|401|403|unauthori[sz]ed|forbidden|invalid\s+PAT|PAT\s+invalid|expired|过期|失效)\b/i.test(
-    message
+  return (
+    /\b(?:PAT_INVALID|401|403|unauthori[sz]ed|forbidden|invalid\s+PAT|PAT\s+invalid|expired)\b/i.test(
+      message
+    ) || /(?:过期|失效)/.test(message)
   );
 }
 

--- a/src/maker/cli/commands.ts
+++ b/src/maker/cli/commands.ts
@@ -27,8 +27,10 @@ import {
   finalizeStagedDevKitGitignore,
   inspectAiDevKit,
   installAiDevKit,
+  installAiDevKitSkills,
   listPresentDevKitManagedEntries,
   writeDevKitStagedGitignore,
+  type AiDevKitSkillInstallerStart,
 } from './devKit.js';
 import {
   MakerGitNotFoundError,
@@ -194,13 +196,17 @@ async function runInit(parsed: ParsedArgs, ctx: CliContext): Promise<void> {
   const pat = await resolvePat(parsed, ctx);
   emit(ctx, 'pat', 'Maker PAT ready', { saved: getPatPath() });
 
-  const tapAuth = await requestTapAuthWithPat(pat);
+  const tapAuth = await requestTapAuthWithPat(pat).catch((error) => {
+    throw appendPatRecoveryUrl(error, parsed);
+  });
   emit(ctx, 'tap_auth', 'TapTap token exchanged and saved', {
     kid: mask(tapAuth.kid),
     saved: getTapAuthPath(),
   });
 
-  const projects = await listMakerProjects({ pat });
+  const projects = await listMakerProjects({ pat }).catch((error) => {
+    throw appendPatRecoveryUrl(error, parsed);
+  });
   const selected = await resolveProjectSelection(parsed, projects, {
     skipConfirm,
   });
@@ -224,6 +230,8 @@ async function runInit(parsed: ParsedArgs, ctx: CliContext): Promise<void> {
     userId: selected.user_id,
     sceEndpoint: selected.sce_endpoint || process.env.SCE_MCP_URL,
     onProgress: (progress) => emitProgress(ctx, 'clone', progress),
+  }).catch((error) => {
+    throw appendPatRecoveryUrl(error, parsed);
   });
   emit(ctx, 'clone', 'Maker project cloned or fetched', cloneResult);
 
@@ -311,7 +319,9 @@ async function runApps(parsed: ParsedArgs, ctx: CliContext): Promise<void> {
     warnPatArgExposure();
   }
   const showAll = booleanOption(parsed, 'all');
-  const projects = await listMakerProjects({ pat });
+  const projects = await listMakerProjects({ pat }).catch((error) => {
+    throw appendPatRecoveryUrl(error, parsed);
+  });
   if (ctx.json) {
     writeJson(projects);
     return;
@@ -323,7 +333,9 @@ async function runApps(parsed: ParsedArgs, ctx: CliContext): Promise<void> {
 async function runPatSet(parsed: ParsedArgs, ctx: CliContext): Promise<void> {
   const pat = await resolvePatSet(parsed, ctx);
   saveManualMakerPat(pat);
-  const tapAuth = await requestTapAuthWithPat(pat);
+  const tapAuth = await requestTapAuthWithPat(pat).catch((error) => {
+    throw appendPatRecoveryUrl(error, parsed);
+  });
   emit(ctx, 'pat', 'Maker PAT and TapTap token saved', {
     pat_path: getPatPath(),
     tap_auth_path: getTapAuthPath(),
@@ -487,7 +499,7 @@ async function runDevKitUpdate(parsed: ParsedArgs, ctx: CliContext): Promise<voi
     preserveExisting: true,
   });
   finalizeStagedDevKitGitignore(targetDir);
-  emit(ctx, 'dev_kit', 'AI dev kit updated', result);
+  emit(ctx, 'dev_kit', formatDevKitInstallMessage('AI dev kit updated', result), result);
 }
 
 async function runLogsWatch(parsed: ParsedArgs, ctx: CliContext): Promise<void> {
@@ -700,18 +712,77 @@ async function prepareDevKit(targetDir: string, ctx: CliContext): Promise<void> 
       path.join(targetDir, DEV_KIT_GITIGNORE_STAGING_FILE),
       listPresentDevKitManagedEntries(targetDir)
     );
-    emit(ctx, 'dev_kit', 'AI dev kit already present', before);
+    try {
+      const skillInstaller = installAiDevKitSkills(targetDir, {
+        onStart: (event) => emitSkillInstallerStart(ctx, event),
+      });
+      emit(
+        ctx,
+        'dev_kit',
+        formatDevKitInstallMessage('AI dev kit already present', { skillInstaller }),
+        {
+          ...before,
+          skillInstaller,
+        }
+      );
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      emit(ctx, 'dev_kit_warning', `AI skills install failed; clone will continue\n${detail}`, {
+        error: detail,
+      });
+    }
     return;
   }
 
   try {
-    const result = await installAiDevKit({ targetDir });
-    emit(ctx, 'dev_kit', 'AI dev kit prepared', result);
+    const result = await installAiDevKit({
+      targetDir,
+      onSkillInstallerStart: (event) => emitSkillInstallerStart(ctx, event),
+    });
+    emit(ctx, 'dev_kit', formatDevKitInstallMessage('AI dev kit prepared', result), result);
   } catch (error) {
-    emit(ctx, 'dev_kit_warning', 'AI dev kit preparation failed; clone will continue', {
-      error: error instanceof Error ? error.message : String(error),
+    const detail = error instanceof Error ? error.message : String(error);
+    emit(ctx, 'dev_kit_warning', `AI dev kit preparation failed; clone will continue\n${detail}`, {
+      error: detail,
     });
   }
+}
+
+function formatDevKitInstallMessage(
+  message: string,
+  result: { skillInstaller?: { summary: string } }
+): string {
+  if (!result.skillInstaller) {
+    return message;
+  }
+  return `${message}\nAI skills install result: ${result.skillInstaller.summary}`;
+}
+
+function emitSkillInstallerStart(ctx: CliContext, event: AiDevKitSkillInstallerStart): void {
+  emit(ctx, 'dev_kit_skill_install_start', `AI skills install started: ${event.script}`, event);
+}
+
+function appendPatRecoveryUrl(error: unknown, parsed: ParsedArgs): Error {
+  const message = error instanceof Error ? error.message : String(error);
+  if (!isPatValidationFailure(message) || message.includes('/pat-tokens')) {
+    return error instanceof Error ? error : new Error(message);
+  }
+
+  const patPage = getMakerPatTokensUrl(makerEnvOption(parsed));
+  return new Error(
+    [
+      message,
+      '',
+      `PAT 页面：${patPage}`,
+      '请在该页面创建新的 Maker PAT，然后运行 `taptap-maker pat set` 并粘贴 PAT。',
+    ].join('\n')
+  );
+}
+
+function isPatValidationFailure(message: string): boolean {
+  return /\b(?:PAT_INVALID|401|403|unauthori[sz]ed|forbidden|invalid\s+PAT|PAT\s+invalid|expired|过期|失效)\b/i.test(
+    message
+  );
 }
 
 function installMcpConfigs(options: {

--- a/src/maker/cli/devKit.ts
+++ b/src/maker/cli/devKit.ts
@@ -34,20 +34,31 @@ export const DEV_KIT_GITIGNORE_STAGING_FILE = '.gitignore.dev-kit-before-clone';
 export const DEV_KIT_REQUIRED_ENTRIES = ['CLAUDE.md', 'examples', 'templates', 'urhox-libs'];
 const ALWAYS_IGNORED_LOCAL_ENTRIES = ['.DS_Store', '.maker'];
 export const DEV_KIT_MANAGED_ENTRY_CANDIDATES = [
+  '.claude',
+  '.cli',
+  '.codex',
+  '.cursor',
   '.emmylua',
+  '.gemini',
+  'AGENTS.md',
   'CLAUDE.md',
   'engine-docs',
   'examples',
+  'schemas',
+  'skills',
   'templates',
+  'tools',
   'urhox-libs',
 ];
 const SKIPPED_TOP_LEVEL_ENTRIES = new Set(['scripts', '.DS_Store', 'ai-dev-kit.zip']);
+const SKILL_INSTALLER_OUTPUT_ENTRIES = ['.claude', '.codex', '.cursor', '.gemini'];
 
 export interface InstallAiDevKitOptions {
   targetDir?: string;
   sourceDir?: string;
   url?: string;
   preserveExisting?: boolean;
+  onSkillInstallerStart?: (event: AiDevKitSkillInstallerStart) => void;
 }
 
 export interface InstallAiDevKitResult {
@@ -57,6 +68,35 @@ export interface InstallAiDevKitResult {
   skippedEntries: string[];
   gitignorePath: string;
   stagedGitignorePath: string;
+  skillInstaller?: AiDevKitSkillInstallerResult;
+}
+
+export interface AiDevKitSkillInstallerResult {
+  ok: boolean;
+  status: 'installed' | 'skipped';
+  script?: string;
+  stdout: string;
+  stderr: string;
+  summary: string;
+  reason?: string;
+}
+
+export interface AiDevKitSkillInstallerStart {
+  platform: NodeJS.Platform;
+  script: string;
+  cwd: string;
+  command: string[];
+}
+
+export interface AiDevKitSkillInstallStatus {
+  status: 'installed' | 'partial' | 'missing';
+  summary: string;
+  targets: Array<{
+    name: string;
+    path: string;
+    present: boolean;
+    skillCount: number;
+  }>;
 }
 
 export interface AiDevKitStatus {
@@ -118,8 +158,15 @@ export async function installAiDevKit(
     installedEntries.push(entry.name);
   }
 
+  const skillInstaller = installAiDevKitSkills(targetDir, {
+    onStart: options.onSkillInstallerStart,
+  });
+
   const stagedGitignorePath = path.join(targetDir, DEV_KIT_GITIGNORE_STAGING_FILE);
-  writeDevKitStagedGitignore(stagedGitignorePath, installedEntries);
+  writeDevKitStagedGitignore(stagedGitignorePath, [
+    ...installedEntries,
+    ...listPresentSkillInstallerOutputEntries(targetDir),
+  ]);
 
   return {
     targetDir,
@@ -128,6 +175,34 @@ export async function installAiDevKit(
     skippedEntries: skippedEntries.sort(),
     gitignorePath: path.join(targetDir, '.gitignore'),
     stagedGitignorePath,
+    skillInstaller,
+  };
+}
+
+export function inspectAiDevKitSkillInstallStatus(targetDir: string): AiDevKitSkillInstallStatus {
+  const resolvedTargetDir = path.resolve(targetDir);
+  const targets = SKILL_INSTALLER_OUTPUT_ENTRIES.map((entry) => {
+    const skillsDir = path.join(resolvedTargetDir, entry, 'skills');
+    const present = fs.existsSync(skillsDir) && fs.statSync(skillsDir).isDirectory();
+    const skillCount = present
+      ? fs
+          .readdirSync(skillsDir, { withFileTypes: true })
+          .filter((item) => item.isDirectory() || item.isSymbolicLink()).length
+      : 0;
+    return {
+      name: entry.replace(/^\./, ''),
+      path: skillsDir,
+      present,
+      skillCount,
+    };
+  });
+  const installedCount = targets.filter((target) => target.present && target.skillCount > 0).length;
+  const status =
+    installedCount === targets.length ? 'installed' : installedCount > 0 ? 'partial' : 'missing';
+  return {
+    status,
+    summary: targets.map((target) => `${target.name}=${target.skillCount}`).join(', '),
+    targets,
   };
 }
 
@@ -205,6 +280,81 @@ function copyEntry(
     fs.mkdirSync(path.dirname(target), { recursive: true });
     fs.copyFileSync(source, target);
   }
+}
+
+export function installAiDevKitSkills(
+  targetDir: string,
+  options: { onStart?: (event: AiDevKitSkillInstallerStart) => void } = {}
+): AiDevKitSkillInstallerResult {
+  const toolsDir = path.join(targetDir, 'tools');
+  if (!fs.existsSync(toolsDir) || !fs.statSync(toolsDir).isDirectory()) {
+    return {
+      ok: false,
+      status: 'skipped',
+      stdout: '',
+      stderr: '',
+      summary: 'skipped: tools directory not found',
+      reason: 'tools_not_found',
+    };
+  }
+
+  const isWindows = process.platform === 'win32';
+  const scriptName = isWindows ? 'install-skills.ps1' : 'install-skills.sh';
+  const scriptPath = path.join(toolsDir, scriptName);
+  if (!fs.existsSync(scriptPath)) {
+    return {
+      ok: false,
+      status: 'skipped',
+      script: scriptPath,
+      stdout: '',
+      stderr: '',
+      summary: `skipped: ${scriptName} not found`,
+      reason: 'script_not_found',
+    };
+  }
+  const command = isWindows
+    ? ['powershell.exe', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', scriptPath, 'all']
+    : ['bash', scriptPath, 'all'];
+
+  options.onStart?.({
+    platform: process.platform,
+    script: scriptPath,
+    cwd: toolsDir,
+    command,
+  });
+
+  const result = isWindows
+    ? spawnSync(command[0], command.slice(1), { cwd: toolsDir, encoding: 'utf8' })
+    : spawnSync(command[0], command.slice(1), { cwd: toolsDir, encoding: 'utf8' });
+
+  if (result.status !== 0) {
+    throw new Error(
+      formatDevKitSkillInstallerFailure({
+        platform: process.platform,
+        scriptPath,
+        toolsDir,
+        command,
+        result,
+      })
+    );
+  }
+
+  const stdout = String(result.stdout || '');
+  const stderr = String(result.stderr || '');
+  return {
+    ok: true,
+    status: 'installed',
+    script: scriptPath,
+    stdout,
+    stderr,
+    summary: summarizeSkillInstallerOutput(stdout),
+  };
+}
+
+function listPresentSkillInstallerOutputEntries(targetDir: string): string[] {
+  return SKILL_INSTALLER_OUTPUT_ENTRIES.filter((entry) =>
+    fs.existsSync(path.join(targetDir, entry))
+  );
 }
 
 async function downloadAndExtractDevKit(url: string): Promise<string> {
@@ -293,6 +443,53 @@ function formatSpawnFailure(result: ReturnType<typeof spawnSync>): string {
     String(result.stdout || '').trim() ||
     `exit status ${result.status ?? 'unknown'}`
   );
+}
+
+function formatDevKitSkillInstallerFailure(options: {
+  platform: NodeJS.Platform;
+  scriptPath: string;
+  toolsDir: string;
+  command: string[];
+  result: ReturnType<typeof spawnSync>;
+}): string {
+  return [
+    'Failed to install AI dev kit skills',
+    `platform: ${options.platform}`,
+    `script: ${options.scriptPath}`,
+    `cwd: ${options.toolsDir}`,
+    `command: ${options.command.map(shellQuote).join(' ')}`,
+    `exit_status: ${options.result.status ?? 'unknown'}`,
+    options.result.signal ? `signal: ${options.result.signal}` : '',
+    options.result.error ? `spawn_error: ${options.result.error.message}` : '',
+    'stdout:',
+    formatSpawnOutput(options.result.stdout),
+    'stderr:',
+    formatSpawnOutput(options.result.stderr),
+  ]
+    .filter((line) => line.length > 0)
+    .join('\n');
+}
+
+function formatSpawnOutput(value: unknown): string {
+  const text = String(value || '').trim();
+  return text.length > 0 ? text : '(empty)';
+}
+
+function summarizeSkillInstallerOutput(stdout: string): string {
+  const entries = stdout
+    .split(/\r?\n/)
+    .map((line) => line.match(/\[install-skills\]\s+([^:]+):\s+installed=(\d+)/))
+    .filter((match): match is RegExpMatchArray => Boolean(match))
+    .map((match) => `${match[1]}=${match[2]}`);
+
+  return entries.length > 0 ? entries.join(', ') : 'completed';
+}
+
+function shellQuote(value: string): string {
+  if (/^[A-Za-z0-9_./:=@-]+$/.test(value)) {
+    return value;
+  }
+  return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
 function resolveDevKitRoot(sourceDir: string): string {

--- a/src/maker/cli/devKit.ts
+++ b/src/maker/cli/devKit.ts
@@ -73,12 +73,13 @@ export interface InstallAiDevKitResult {
 
 export interface AiDevKitSkillInstallerResult {
   ok: boolean;
-  status: 'installed' | 'skipped';
+  status: 'installed' | 'skipped' | 'failed';
   script?: string;
   stdout: string;
   stderr: string;
   summary: string;
   reason?: string;
+  error?: string;
 }
 
 export interface AiDevKitSkillInstallerStart {
@@ -158,7 +159,7 @@ export async function installAiDevKit(
     installedEntries.push(entry.name);
   }
 
-  const skillInstaller = installAiDevKitSkills(targetDir, {
+  const skillInstaller = runDevKitSkillInstallerForInstall(targetDir, {
     onStart: options.onSkillInstallerStart,
   });
 
@@ -282,6 +283,11 @@ function copyEntry(
   }
 }
 
+/**
+ * Runs the dev-kit skill installer synchronously for short-lived CLI flows only.
+ * Do not call this from long-lived MCP request handlers; use lightweight status
+ * inspection there to avoid blocking the server event loop.
+ */
 export function installAiDevKitSkills(
   targetDir: string,
   options: { onStart?: (event: AiDevKitSkillInstallerStart) => void } = {}
@@ -323,13 +329,11 @@ export function installAiDevKitSkills(
     command,
   });
 
-  const result = isWindows
-    ? spawnSync(command[0], command.slice(1), { cwd: toolsDir, encoding: 'utf8' })
-    : spawnSync(command[0], command.slice(1), { cwd: toolsDir, encoding: 'utf8' });
+  const result = spawnSync(command[0], command.slice(1), { cwd: toolsDir, encoding: 'utf8' });
 
   if (result.status !== 0) {
-    throw new Error(
-      formatDevKitSkillInstallerFailure({
+    throw new AiDevKitSkillInstallerError(
+      formatFailedSkillInstallerResult({
         platform: process.platform,
         scriptPath,
         toolsDir,
@@ -349,6 +353,29 @@ export function installAiDevKitSkills(
     stderr,
     summary: summarizeSkillInstallerOutput(stdout),
   };
+}
+
+function runDevKitSkillInstallerForInstall(
+  targetDir: string,
+  options: { onStart?: (event: AiDevKitSkillInstallerStart) => void } = {}
+): AiDevKitSkillInstallerResult {
+  try {
+    return installAiDevKitSkills(targetDir, options);
+  } catch (error) {
+    if (error instanceof AiDevKitSkillInstallerError) {
+      return error.result;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      ok: false,
+      status: 'failed',
+      stdout: '',
+      stderr: '',
+      summary: 'failed',
+      reason: 'installer_failed',
+      error: message,
+    };
+  }
 }
 
 function listPresentSkillInstallerOutputEntries(targetDir: string): string[] {
@@ -468,6 +495,45 @@ function formatDevKitSkillInstallerFailure(options: {
   ]
     .filter((line) => line.length > 0)
     .join('\n');
+}
+
+function formatFailedSkillInstallerResult(options: {
+  platform: NodeJS.Platform;
+  scriptPath: string;
+  toolsDir: string;
+  command: string[];
+  result: ReturnType<typeof spawnSync>;
+}): AiDevKitSkillInstallerResult {
+  return {
+    ok: false,
+    status: 'failed',
+    script: options.scriptPath,
+    stdout: String(options.result.stdout || ''),
+    stderr: String(options.result.stderr || ''),
+    summary: summarizeSkillInstallerFailure(options.result),
+    reason: 'installer_failed',
+    error: formatDevKitSkillInstallerFailure(options),
+  };
+}
+
+function summarizeSkillInstallerFailure(result: ReturnType<typeof spawnSync>): string {
+  if (typeof result.status === 'number') {
+    return `failed: exit_status=${result.status}`;
+  }
+  if (result.signal) {
+    return `failed: signal=${result.signal}`;
+  }
+  if (result.error) {
+    return `failed: ${result.error.message}`;
+  }
+  return 'failed';
+}
+
+class AiDevKitSkillInstallerError extends Error {
+  constructor(readonly result: AiDevKitSkillInstallerResult) {
+    super(result.error || result.summary);
+    this.name = 'AiDevKitSkillInstallerError';
+  }
 }
 
 function formatSpawnOutput(value: unknown): string {

--- a/src/maker/cli/projects.ts
+++ b/src/maker/cli/projects.ts
@@ -9,7 +9,7 @@ import type { MakerPat, MakerProjectSummary } from '../types.js';
 import { getProjectConfigPath, loadPat, loadProjectConfig, saveProjectConfig } from '../storage.js';
 import { getUserIdFromMakerJwt, requireMakerJwt } from '../auth/jwt.js';
 import { getManualMakerPat, requestMakerPat, saveManualMakerPat } from '../git/pat.js';
-import { getMakerEndpoints, requireMakerEndpoint } from '../config.js';
+import { getMakerEndpoints, getMakerPatTokensUrl, requireMakerEndpoint } from '../config.js';
 import { ensureGitAvailable, getGitCommand } from '../system/git.js';
 import { finalizeStagedDevKitGitignore } from './devKit.js';
 
@@ -690,7 +690,7 @@ export async function inspectMakerRemoteSyncStatus(cwd: string): Promise<MakerRe
 
 export function getMakerRemoteSyncFailureNextAction(failure: MakerGitFailure): string {
   if (failure.classification === 'auth') {
-    return '暂时无法检查 Maker 远端是否有新提交：Git 鉴权失败。请先运行 `taptap-maker pat set` 并粘贴新的 Maker PAT 后，再重新读取 maker://status。';
+    return `暂时无法检查 Maker 远端是否有新提交：Git 鉴权失败。PAT 页面：${getMakerPatTokensUrl()}。请在该页面创建新的 Maker PAT，然后运行 \`taptap-maker pat set\` 并粘贴 PAT 后，再重新读取 maker://status。`;
   }
 
   return '暂时无法检查 Maker 远端是否有新提交。请把 failure 信息反馈给用户；如果只是 503、5xx、超时或网络中断，可稍后重新读取 maker://status。';
@@ -989,7 +989,7 @@ function nextActionForFailure(classification: MakerGitFailure['classification'])
     case 'git_missing':
       return '本机未检测到可用的 Git。请用户自行安装 Git，并在 `git --version` 可用后重启 MCP 客户端再重试；安装前不要执行 clone、fetch、commit 或 push。';
     case 'auth':
-      return '运行 `taptap-maker pat set` 并粘贴新的 Maker PAT 后，再重试 maker_build_current_directory；如果仍失败，请确认 PAT 是否过期或缺少 Maker git 权限。';
+      return `Maker Git 鉴权失败。PAT 页面：${getMakerPatTokensUrl()}。请在该页面创建新的 Maker PAT，然后运行 \`taptap-maker pat set\` 并粘贴 PAT 后重试。`;
     case 'remote_transient':
       return '远端 Maker git 服务临时不可用。本地 commit 会保留；不要手动执行通用 git push，稍后直接重试 maker_build_current_directory。';
     case 'branch_not_allowed':

--- a/src/maker/cli/skill.ts
+++ b/src/maker/cli/skill.ts
@@ -34,11 +34,13 @@ export function formatMakerSkillStatus(
     path: path.join(resolveMakerSkillSourceDir(skill.name), 'SKILL.md'),
   }));
   return [
-    'TapTap bundled workflow skills',
+    'TapTap Maker workflow guide documents',
     '',
     ...skillDocuments.map((skill) => `- ${skill.name}: ${skill.path}`),
     '',
-    'These skill documents are bundled in the package. Let the current AI client decide whether and how to load them.',
+    'Use these documents as reading references for Maker local workflows.',
+    'Maker initialization next_step: execute `taptap-maker init`.',
+    'Load these documents when the current AI client supports reading local guide files.',
   ].join('\n');
 }
 

--- a/src/maker/server/mcp.ts
+++ b/src/maker/server/mcp.ts
@@ -66,6 +66,7 @@ import { formatMakerSkillStatus } from '../cli/skill.js';
 import {
   DEV_KIT_GITIGNORE_STAGING_FILE,
   inspectAiDevKit,
+  inspectAiDevKitSkillInstallStatus,
   type AiDevKitStatus,
 } from '../cli/devKit.js';
 import {
@@ -105,7 +106,7 @@ export const tools = [
   {
     name: 'maker_status_lite',
     description:
-      'Compatibility fallback for clients that cannot read the maker://status resource. Prefer reading maker://status when resources are available. Shows local Maker status for the user current working directory, including Git, PAT/TapTap auth, project binding, AI dev kit status, and bundled workflow skill document paths.',
+      'Compatibility status surface for clients using tool output instead of the maker://status resource. Prefer reading maker://status when resources are available. Shows local Maker status for the user current working directory, including Git, PAT/TapTap auth, project binding, AI dev kit status, and bundled workflow guide document paths. Maker initialization next_step: taptap-maker init.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -242,7 +243,7 @@ export const resources = [
     uri: 'maker://status',
     name: 'Maker status',
     description:
-      'Local TapTap Maker project status, including Git, PAT/TapTap auth, project binding, AI dev kit status, and bundled workflow skill document paths.',
+      'Local TapTap Maker project status, including Git, PAT/TapTap auth, project binding, AI dev kit status, and bundled workflow guide document paths. Maker initialization next_step: taptap-maker init.',
     mimeType: 'text/plain',
   },
 ];
@@ -446,8 +447,8 @@ async function formatStatus(
   const projectSection = identify.projectId
     ? [
         '目标目录已绑定 Maker 项目。',
-        '请继续在当前绑定项目上执行状态、提交、构建等操作；不要再引导用户 clone，除非用户明确要求切换或重新拉取项目。',
-        '本地 Maker 工作流请优先参考 taptap-maker-local skill；CLI 负责初始化/PAT/app/clone，MCP 只保留状态和同步构建。',
+        '请继续在当前绑定项目上执行状态、提交、构建等操作；用户明确要求切换或重新拉取项目时，再进入项目选择流程。',
+        '本地 Maker 工作流请参考 taptap-maker-local workflow guide document；CLI 负责初始化/PAT/app/clone，MCP 只保留状态和同步构建。',
       ].join('\n')
     : isLikelyAiDialogueDirectory(targetDir)
       ? formatAiDialogueDirectoryHint(targetDir)
@@ -494,7 +495,7 @@ function formatMakerRemoteSyncSkipped(): string {
     'Maker remote sync',
     '',
     '- status: skipped',
-    '- next_action: 已跳过远端同步检查；如需确认是否需要 pull，请重新读取 maker_status_lite 且不要设置 skip_remote_sync。',
+    '- next_action: 已跳过远端同步检查；如需确认是否需要 pull，请重新读取 maker_status_lite 并启用远端同步检查。',
   ].join('\n');
 }
 
@@ -617,6 +618,7 @@ function formatAiDevKitStatusLines(
   status: 'ready' | 'missing',
   devKitStatus: AiDevKitStatus
 ): string[] {
+  const skillStatus = inspectAiDevKitSkillInstallStatus(devKitStatus.targetDir);
   return [
     'AI dev kit',
     '',
@@ -624,6 +626,8 @@ function formatAiDevKitStatusLines(
     `- required_entries: ${devKitStatus.requiredEntries.join(', ')}`,
     `- present_entries: ${devKitStatus.presentEntries.join(', ') || '(none)'}`,
     `- missing_entries: ${devKitStatus.missingEntries.join(', ') || '(none)'}`,
+    `- skill_install_status: ${skillStatus.status}`,
+    `- skill_install_summary: ${skillStatus.summary}`,
   ];
 }
 
@@ -632,7 +636,8 @@ async function formatAutoProjectListFromPat(): Promise<string> {
     const projects = await listMakerProjects();
     return [
       '本地已有 Maker PAT，当前目录尚未绑定 Maker 项目。',
-      '当前目录未绑定时，先展示下面的 Maker Apps 预览和总数，避免长列表刷屏；选择、解释和 clone 顺序请参考 taptap-maker-local skill。',
+      '当前目录未绑定时，先展示下面的 Maker Apps 预览和总数；选择、解释和 clone 顺序请参考 taptap-maker-local workflow guide document。',
+      '用户选择 app 后，next_step: 执行 `taptap-maker init`。',
       '',
       formatStatusProjectList(projects),
     ].join('\n');
@@ -699,7 +704,7 @@ export function formatStatusProjectList(projects: StatusProject[]): string {
       ? `为了保持友好的可读性，默认最多展示 ${visibleProjects.length} 个 app；如需完整列表，可以选择显示全部。`
       : '已显示全部 app；请询问用户选择。',
     hiddenCount > 0 ? '如需完整列表，请运行 taptap-maker apps --json 查看全部 app。' : undefined,
-    'AI 展示建议：如果聊天或客户端宽度足够，可把 app 预览整理成两列紧凑布局；每个 app 保留序号、app_id、名称，以及可用的最近活跃时间或 user_id。窄屏保持单列。不要省略 app_id，也不要在用户确认前自动选择 app。',
+    'AI 展示建议：如果聊天或客户端宽度足够，可把 app 预览整理成两列紧凑布局；每个 app 保留序号、app_id、名称，以及可用的最近活跃时间或 user_id。窄屏保持单列。选择 app 前先获取用户确认。',
     '',
     ...visibleProjects.map(
       (project, index) =>
@@ -712,8 +717,9 @@ export function formatStatusProjectList(projects: StatusProject[]): string {
         }`
     ),
     '',
-    '仅当当前目录未绑定且用户要初始化或 clone 时，才让用户选择 app 并继续 taptap-maker init。',
-    '如果当前目录已绑定 Maker 项目，这个列表仅作账号项目参考；请继续当前项目，除非用户明确要求切换或重新 clone。',
+    '当前目录未绑定且用户要初始化或 clone 时，让用户选择 app 并继续 taptap-maker init。',
+    '用户回复序号或 app_id 后，next_step: 执行 `taptap-maker init`，或让已经启动的 `taptap-maker init` 交互继续读取该选择。',
+    '如果当前目录已绑定 Maker 项目，这个列表仅作账号项目参考；请继续当前项目。用户明确要求切换或重新 clone 时，再进入项目选择流程。',
   ]
     .filter((line) => line !== undefined)
     .join('\n');
@@ -746,7 +752,7 @@ export function formatClonePartialStateLines(targetDir: string): string[] {
     `- safe_to_retry: ${safeToRetry ? 'yes' : 'no'}`,
     safeToRetry
       ? '- next_step: 可以直接重试 taptap-maker init；如果连续失败，建议换一个全新的独立目录重新 clone。'
-      : '- next_step: 当前目录已经有 Maker 绑定信息；先运行 taptap-maker doctor 或读取 maker://status 确认状态，不要重复 clone。',
+      : '- next_step: 当前目录已经有 Maker 绑定信息；先运行 taptap-maker doctor 或读取 maker://status 确认状态。',
   ].filter(Boolean);
 }
 


### PR DESCRIPTION
## 改动内容
- dev-kit 解压/复制后按平台执行 tools/install-skills.* 安装本地 AI skills。
- init 输出 skill 安装开始、结果和失败详情，status 输出 skill_install_status/summary。
- PAT 鉴权失败时输出当前环境 PAT 页面 URL。
- 按 review 反馈拆分 dev-kit copy 成功与 skill installer 失败状态。

## 影响面
- 影响 taptap-maker init、dev-kit update、maker://status 和 maker_status_lite。
- 失败时保留 clone 流程继续执行，并把 installer stdout/stderr 暴露给 AI 和用户。

## 验证
- npm test
- npm run build
- npm run lint
- git diff --check