### PR TITLE
ci(maker): add npm access repair workflow

### DIFF
--- a/.github/workflows/maker-npm-access.yml
+++ b/.github/workflows/maker-npm-access.yml
@@ -1,0 +1,55 @@
+name: Maker NPM Access
+
+on:
+  workflow_dispatch:
+    inputs:
+      package_name:
+        description: 'Package to make public. Must be @taptap/maker.'
+        required: true
+        default: '@taptap/maker'
+      confirm_package:
+        description: 'Type @taptap/maker again to confirm.'
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  set-public:
+    name: Set @taptap/maker public access
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate package confirmation
+        run: |
+          set -euo pipefail
+
+          if [ "$PACKAGE_NAME" != "@taptap/maker" ]; then
+            echo "::error::package_name must be @taptap/maker."
+            exit 1
+          fi
+
+          if [ "$CONFIRM_PACKAGE" != "$PACKAGE_NAME" ]; then
+            echo "::error::confirm_package must exactly match package_name."
+            exit 1
+          fi
+        env:
+          PACKAGE_NAME: ${{ inputs.package_name }}
+          CONFIRM_PACKAGE: ${{ inputs.confirm_package }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Set package access to public
+        run: |
+          set -euo pipefail
+
+          npm whoami
+          npm access public "$PACKAGE_NAME"
+          npm dist-tag ls "$PACKAGE_NAME"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          PACKAGE_NAME: ${{ inputs.package_name }}


### PR DESCRIPTION
## 改动内容
- 新增 Maker 专用手动 workflow，用 NPM_TOKEN 执行 npm access public @taptap/maker。
- 添加 package_name 和 confirm_package 双重校验，避免误操作其他 npm 包。

## 影响面
- workflow_dispatch 手动触发，不会自动运行。
- 不修改旧包 release workflow，不影响 @taptap/instant-games-open-mcp 发布链路。

## 验证
- 人工检查 workflow 输入校验和 npm access 命令。
- Publish Maker Package 已成功发布 @taptap/maker@0.0.1-beta.1，但公开 registry 查询仍 404，需要此 workflow 修正访问级别。