### PR TITLE
ci(maker): fix npm access command

### DIFF
--- a/.github/workflows/maker-npm-access.yml
+++ b/.github/workflows/maker-npm-access.yml
@@ -48,7 +48,7 @@ jobs:
           set -euo pipefail
 
           npm whoami
-          npm access public "$PACKAGE_NAME"
+          npm access set status=public "$PACKAGE_NAME"
           npm dist-tag ls "$PACKAGE_NAME"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## 改动内容
- 修正 Maker NPM Access workflow 的 npm access 命令语法。
- 将 npm access public 改为 npm access set status=public，适配 runner 上的 npm 10.9.8。

## 影响面
- 只影响手动修复 @taptap/maker 公开访问级别的 workflow。
- 不修改旧包 release workflow，不影响 @taptap/instant-games-open-mcp 发布链路。

## 验证
- 根据失败 run 26578955194 的 npm access usage 输出校正命令。