### PR TITLE
ci(maker): add npm tag cleanup workflow

### DIFF
--- a/.github/workflows/maker-npm-tags.yml
+++ b/.github/workflows/maker-npm-tags.yml
@@ -1,0 +1,68 @@
+name: Maker NPM Tags
+
+on:
+  workflow_dispatch:
+    inputs:
+      package_name:
+        description: 'Package to update. Must be @taptap/maker.'
+        required: true
+        default: '@taptap/maker'
+      confirm_package:
+        description: 'Type @taptap/maker again to confirm.'
+        required: true
+      remove_latest:
+        description: 'Remove the latest dist-tag.'
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  update-tags:
+    name: Update @taptap/maker npm tags
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate package confirmation
+        run: |
+          set -euo pipefail
+
+          if [ "$PACKAGE_NAME" != "@taptap/maker" ]; then
+            echo "::error::package_name must be @taptap/maker."
+            exit 1
+          fi
+
+          if [ "$CONFIRM_PACKAGE" != "$PACKAGE_NAME" ]; then
+            echo "::error::confirm_package must exactly match package_name."
+            exit 1
+          fi
+        env:
+          PACKAGE_NAME: ${{ inputs.package_name }}
+          CONFIRM_PACKAGE: ${{ inputs.confirm_package }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Update npm dist-tags
+        run: |
+          set -euo pipefail
+
+          npm whoami
+          echo "Before:"
+          npm dist-tag ls "$PACKAGE_NAME"
+
+          if [ "$REMOVE_LATEST" = "true" ]; then
+            npm dist-tag rm "$PACKAGE_NAME" latest
+          fi
+
+          echo "After:"
+          npm dist-tag ls "$PACKAGE_NAME"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          PACKAGE_NAME: ${{ inputs.package_name }}
+          REMOVE_LATEST: ${{ inputs.remove_latest }}


### PR DESCRIPTION
## 改动内容
- 新增 Maker 专用手动 workflow，用 NPM_TOKEN 管理 @taptap/maker dist-tags。
- 支持双重确认包名后移除 latest dist-tag。

## 影响面
- 用于修复首次 beta 发布后 latest 被指向 0.0.1-beta.1 的问题。
- workflow_dispatch 手动触发，不修改旧包 release workflow。

## 验证
- 人工检查 workflow 输入校验和 npm dist-tag rm 命令。
- 当前 npm view 显示 beta 和 latest 都指向 0.0.1-beta.1，需要运行该 workflow 清理 latest。