### PR TITLE
feat(maker): 将 .installer 加入 gitignore 托管候选列表

### DIFF
--- a/src/maker/cli/devKit.ts
+++ b/src/maker/cli/devKit.ts
@@ -40,6 +40,7 @@ export const DEV_KIT_MANAGED_ENTRY_CANDIDATES = [
   '.cursor',
   '.emmylua',
   '.gemini',
+  '.installer',
   'AGENTS.md',
   'CLAUDE.md',
   'engine-docs',


### PR DESCRIPTION
## 变更概述
- `DEV_KIT_MANAGED_ENTRY_CANDIDATES` 新增 `.installer`，确保 install-skills 脚本创建的 `.installer/skills/` 目录被 gitignore 托管块覆盖

## 背景
install-skills 脚本（taptap/urhox#1806）现在将 `skills/` 移入 `.installer/skills/` 并从中创建 junction/symlink。如果 `.installer` 不在托管候选列表中，该目录不会被 gitignore，用户可能意外提交。

## 测试计划
- [ ] `listPresentDevKitManagedEntries` 能正确检测 `.installer/` 目录
- [ ] `writeDevKitStagedGitignore` 生成的 gitignore 块包含 `.installer/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)