### PR TITLE
ci(maker): set npm publish environment

### DIFF
--- a/.github/workflows/publish-maker.yml
+++ b/.github/workflows/publish-maker.yml
@@ -38,6 +38,7 @@ jobs:
   publish:
     name: Publish @taptap/maker
     runs-on: ubuntu-latest
+    environment: npm_publish
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## 改动内容
- 为 Publish Maker Package workflow 的 publish job 添加 environment: npm_publish。
- 让 GitHub Actions job 与 npm Trusted Publishing 后台配置的 environment 匹配。

## 影响面
- 仅影响 @taptap/maker 手动发布 workflow。
- 不改变版本解析、tag 输入或打包内容。
- 下一次重跑仍使用 version=0.0.2、confirm_version=0.0.2、tag=latest。

## 验证
- npx prettier --check .github/workflows/publish-maker.yml