### PR TITLE
ci(maker): add npm token publish fallback

### DIFF
--- a/.github/workflows/publish-maker.yml
+++ b/.github/workflows/publish-maker.yml
@@ -92,8 +92,10 @@ jobs:
         run: |
           set -euo pipefail
           tarball="./packages/maker/taptap-maker-${MAKER_PACKAGE_VERSION}.tgz"
-          npm publish "$tarball" --access public --tag "$NPM_TAG" --provenance
-          echo "Published @taptap/maker@$MAKER_PACKAGE_VERSION with provenance"
+          npm publish "$tarball" --access public --tag "$NPM_TAG" --provenance \
+            || npm publish "$tarball" --access public --tag "$NPM_TAG"
+          echo "Published @taptap/maker@$MAKER_PACKAGE_VERSION"
         env:
           MAKER_PACKAGE_VERSION: ${{ steps.version.outputs.version }}
           NPM_TAG: ${{ inputs.tag }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## 改动内容
- Maker 包发布继续优先使用 OIDC provenance。
- 当 Trusted Publishing/OIDC 发布失败时，使用现有 NPM_TOKEN 执行一次 npm publish 兜底。
- 不修改 Maker 版本解析、npm tag、Node 版本或包内容。

## 验证
- npm run lint -- --quiet
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish-maker.yml"); puts "yaml ok"'
- git diff --check

## 发布注意
- 合并后重跑 Publish Maker Package。
- 仍使用 manual version 0.0.2 / confirm_version 0.0.2 / tag latest。