### PR TITLE
fix(maker): parse space-separated --ide list from PowerShell 5.1

### DIFF
--- a/src/__tests__/makerCliCommands.test.ts
+++ b/src/__tests__/makerCliCommands.test.ts
@@ -256,6 +256,48 @@ describe('Maker CLI commands', () => {
     expect(fs.existsSync(path.join(tempDir, '.cursor', 'mcp.json'))).toBe(true);
   });
 
+  test('mcp install resolves space-joined --ide from PowerShell 5.1 array expansion', async () => {
+    // Windows PowerShell 5.1 turns `--ide codex,cursor,claude` into a single
+    // space-joined argument "codex cursor claude"; it must still resolve to the
+    // three IDEs instead of one unknown IDE.
+    await runMakerCli(['mcp', 'install', '--ide', 'codex cursor claude', '--json']);
+
+    const payloads = JSON.parse(String(stdoutSpy.mock.calls[0][0]));
+    expect(payloads.map((entry: { ide: string }) => entry.ide)).toEqual([
+      'codex',
+      'cursor',
+      'claude',
+    ]);
+    expect(payloads.every((entry: { ok: boolean }) => entry.ok)).toBe(true);
+    expect(
+      payloads.some((entry: { message: string }) => /unknown ide/i.test(entry.message))
+    ).toBe(false);
+  });
+
+  test('mcp install still reports a genuinely unknown IDE token', async () => {
+    // The whitespace split must not swallow real typos: known IDEs still install
+    // while the unknown token is reported.
+    await runMakerCli(['mcp', 'install', '--ide', 'cursor foobar', '--json']);
+
+    const payloads = JSON.parse(String(stdoutSpy.mock.calls[0][0]));
+    expect(payloads).toEqual([
+      expect.objectContaining({ ide: 'cursor', ok: true }),
+      expect.objectContaining({
+        ide: 'foobar',
+        ok: false,
+        message: expect.stringContaining('Skipped unknown IDE: foobar'),
+      }),
+    ]);
+  });
+
+  test('mcp install accepts the --ides alias with whitespace separators', async () => {
+    await runMakerCli(['mcp', 'install', '--ides', 'cursor claude', '--json']);
+
+    const payloads = JSON.parse(String(stdoutSpy.mock.calls[0][0]));
+    expect(payloads.map((entry: { ide: string }) => entry.ide)).toEqual(['cursor', 'claude']);
+    expect(payloads.every((entry: { ok: boolean }) => entry.ok)).toBe(true);
+  });
+
   test('init treats the token after command as positional app id', async () => {
     await runMakerCli([
       'init',

--- a/src/__tests__/makerCliCommands.test.ts
+++ b/src/__tests__/makerCliCommands.test.ts
@@ -269,9 +269,9 @@ describe('Maker CLI commands', () => {
       'claude',
     ]);
     expect(payloads.every((entry: { ok: boolean }) => entry.ok)).toBe(true);
-    expect(
-      payloads.some((entry: { message: string }) => /unknown ide/i.test(entry.message))
-    ).toBe(false);
+    expect(payloads.some((entry: { message: string }) => /unknown ide/i.test(entry.message))).toBe(
+      false
+    );
   });
 
   test('mcp install still reports a genuinely unknown IDE token', async () => {

--- a/src/maker/cli/commands.ts
+++ b/src/maker/cli/commands.ts
@@ -999,7 +999,8 @@ function mcpVerifyModeOption(parsed: ParsedArgs): 'npx' | 'self' {
 }
 
 /**
- * Parse a comma-separated list of IDE keys (e.g. "codex,cursor,claude").
+ * Parse a comma- and/or whitespace-separated list of IDE keys
+ * (e.g. "codex,cursor,claude" or "codex cursor claude").
  *
  * Splits on both commas AND whitespace. Whitespace is intentional: Windows
  * PowerShell 5.1 parses an unquoted `--ide codex,cursor,claude` as an array and

--- a/src/maker/cli/commands.ts
+++ b/src/maker/cli/commands.ts
@@ -998,9 +998,19 @@ function mcpVerifyModeOption(parsed: ParsedArgs): 'npx' | 'self' {
   throw new Error('Invalid mcp verify --mode. Use npx or self.');
 }
 
+/**
+ * Parse a comma-separated list of IDE keys (e.g. "codex,cursor,claude").
+ *
+ * Splits on both commas AND whitespace. Whitespace is intentional: Windows
+ * PowerShell 5.1 parses an unquoted `--ide codex,cursor,claude` as an array and
+ * passes it to the native command as a single space-joined argument
+ * ("codex cursor claude"). Splitting on whitespace too lets that mangled form
+ * still resolve to three valid IDEs instead of one unknown IDE. IDE keys never
+ * contain spaces, so this is safe — do not narrow it back to commas only.
+ */
 function parseIdeList(value: string): string[] {
   return value
-    .split(',')
+    .split(/[\s,]+/)
     .map((item) => item.trim().toLowerCase())
     .filter(Boolean);
 }


### PR DESCRIPTION
## 问题

Windows PowerShell 5.1 下执行:

```powershell
npx -y @taptap/maker install --ide codex,cursor,claude
# Skipped unknown IDE: codex cursor claude
```

PowerShell 5.1 把不加引号的 `codex,cursor,claude` 当作数组,传给原生命令时用**空格**拼成单个参数 `"codex cursor claude"`。而 `parseIdeList` 只按逗号切分,于是整串被当成一个未知 IDE,三个配置全部跳过。

> 注:PowerShell 7.x 会原样保留逗号,因此该问题只在 Windows PowerShell 5.1(Windows 默认 `powershell.exe`)出现。

## 修复

`parseIdeList` 改为按**逗号和空格**切分(`/[\s,]+/`),让 PS5.1 拼出来的空格形态也能解析成三个真实 IDE。IDE key 本身不含空格,所有原本有效的输入行为完全不变。

## 副作用评估

只有原本就会失败的输入(含空格/tab)行为改变——从「报错」变为「正确解析」;未知 token 仍逐个上报 `Skipped unknown IDE`,不会吞掉真实拼写错误。

## 验证

- 新增 3 个 CLI 测试:PS5.1 空格形态、`--ides` 别名、未知 IDE token
- `makerCliCommands.test.ts` 24 项全通过(21 基线 + 3 新增)
- 用真实打包产物 `dist/maker.js` 端到端验证:空格形态、逗号形态、含未知项均符合预期
- 另有 2 个 git/clone 相关 suite 在本环境预存失败(`ENOENT scripts/remote.lua`,沙箱 git 环境问题),与本改动无关——已 stash 改动确认基线同样失败,**零回归**

🤖 Generated with [Claude Code](https://claude.com/claude-code)