### PR TITLE
ci(release): isolate maker package publishing

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -8,9 +8,13 @@ on:
 
 jobs:
   review:
-    # PR 评论触发时，仅响应 @claude 提及
+    # Maker/release automation PRs are covered by dedicated CI guards; manual @claude
+    # comments can still request a review when needed.
     if: |
-      (github.event_name == 'pull_request') ||
+      (github.event_name == 'pull_request' &&
+       !contains(github.event.pull_request.title, '(maker)') &&
+       !startsWith(github.event.pull_request.title, 'ci(maker):') &&
+       !startsWith(github.event.pull_request.title, 'ci(release):')) ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '@claude'))

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -117,11 +117,30 @@ jobs:
       - name: Validate PR commits with commitlint
         run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
 
+  release-scope:
+    name: Release Scope Guard
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate Maker release scope
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          node scripts/check-release-scope.cjs \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}" \
+            --title "$PR_TITLE"
+
   # PR 总结
   summary:
     name: PR Summary
     runs-on: ubuntu-latest
-    needs: [lint, build, test, commitlint]
+    needs: [lint, build, test, commitlint, release-scope]
     if: always()
 
     steps:
@@ -133,11 +152,13 @@ jobs:
           echo "- Build: ${{ needs.build.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- Test: ${{ needs.test.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- Commitlint: ${{ needs.commitlint.result }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Release scope: ${{ needs.release-scope.result }}" >> $GITHUB_STEP_SUMMARY
 
           if [[ "${{ needs.lint.result }}" != "success" ]] || \
              [[ "${{ needs.build.result }}" != "success" ]] || \
              [[ "${{ needs.test.result }}" != "success" ]] || \
-             [[ "${{ needs.commitlint.result }}" != "success" ]]; then
+             [[ "${{ needs.commitlint.result }}" != "success" ]] || \
+             [[ "${{ needs.release-scope.result }}" != "success" ]]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "❌ Some checks failed. Please fix them before merging." >> $GITHUB_STEP_SUMMARY
             exit 1

--- a/.github/workflows/publish-maker.yml
+++ b/.github/workflows/publish-maker.yml
@@ -35,9 +35,49 @@ permissions:
   id-token: write
 
 jobs:
+  resolve-version:
+    name: Resolve @taptap/maker version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      current_version: ${{ steps.version.outputs.current_version }}
+      major_minor_changed: ${{ steps.version.outputs.major_minor_changed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Resolve publish version
+        id: version
+        run: node scripts/resolve-maker-version.js
+        env:
+          MAKER_VERSION_MODE: ${{ inputs.version_mode }}
+          MAKER_MANUAL_VERSION: ${{ inputs.version }}
+          MAKER_CONFIRM_VERSION: ${{ inputs.confirm_version }}
+          MAKER_NPM_TAG: ${{ inputs.tag }}
+
+      - name: Approval summary
+        run: |
+          echo "## @taptap/maker publish preflight" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- dist-tag: \`${{ inputs.tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- current online version: \`${{ steps.version.outputs.current_version || 'none' }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- target version: \`${{ steps.version.outputs.version }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- major/minor changed: \`${{ steps.version.outputs.major_minor_changed }}\`" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.version.outputs.major_minor_changed }}" = "true" ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "Major/minor changed. Review the current online version and target version above, then approve the protected publish job to continue." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   publish:
     name: Publish @taptap/maker
     runs-on: ubuntu-latest
+    needs: resolve-version
     environment: npm_publish
     steps:
       - name: Checkout
@@ -58,24 +98,15 @@ jobs:
       - name: Test
         run: npm test
 
-      - name: Resolve publish version
-        id: version
-        run: node scripts/resolve-maker-version.js
-        env:
-          MAKER_VERSION_MODE: ${{ inputs.version_mode }}
-          MAKER_MANUAL_VERSION: ${{ inputs.version }}
-          MAKER_CONFIRM_VERSION: ${{ inputs.confirm_version }}
-          MAKER_NPM_TAG: ${{ inputs.tag }}
-
       - name: Build Maker bundle
         run: npm run build -- --skip-server --skip-proxy --skip-native
         env:
-          MAKER_PACKAGE_VERSION: ${{ steps.version.outputs.version }}
+          MAKER_PACKAGE_VERSION: ${{ needs.resolve-version.outputs.version }}
 
       - name: Prepare standalone package
         run: node scripts/prepare-maker-package.js --version "$MAKER_PACKAGE_VERSION"
         env:
-          MAKER_PACKAGE_VERSION: ${{ steps.version.outputs.version }}
+          MAKER_PACKAGE_VERSION: ${{ needs.resolve-version.outputs.version }}
 
       - name: Dry-run package contents
         run: cd packages/maker && npm pack --dry-run
@@ -86,7 +117,19 @@ jobs:
       - name: Verify packed CLI
         run: npx -y -p "./packages/maker/taptap-maker-${MAKER_PACKAGE_VERSION}.tgz" taptap-maker help
         env:
-          MAKER_PACKAGE_VERSION: ${{ steps.version.outputs.version }}
+          MAKER_PACKAGE_VERSION: ${{ needs.resolve-version.outputs.version }}
+
+      - name: Verify version is still unpublished before npm publish
+        run: |
+          set -euo pipefail
+          if npm view "@taptap/maker@${MAKER_PACKAGE_VERSION}" version >/tmp/maker-version-check.txt 2>/dev/null; then
+            echo "::error::@taptap/maker@${MAKER_PACKAGE_VERSION} already exists on npm."
+            cat /tmp/maker-version-check.txt
+            exit 1
+          fi
+          echo "@taptap/maker@${MAKER_PACKAGE_VERSION} is still unpublished."
+        env:
+          MAKER_PACKAGE_VERSION: ${{ needs.resolve-version.outputs.version }}
 
       - name: Publish package
         run: |
@@ -96,6 +139,6 @@ jobs:
             || npm publish "$tarball" --access public --tag "$NPM_TAG"
           echo "Published @taptap/maker@$MAKER_PACKAGE_VERSION"
         env:
-          MAKER_PACKAGE_VERSION: ${{ steps.version.outputs.version }}
+          MAKER_PACKAGE_VERSION: ${{ needs.resolve-version.outputs.version }}
           NPM_TAG: ${{ inputs.tag }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,13 +22,64 @@ env:
   MACOSX_DEPLOYMENT_TARGET: '10.13'
 
 jobs:
+  scope:
+    name: Release Scope
+    runs-on: ubuntu-latest
+    outputs:
+      skip_legacy_release: ${{ steps.scope.outputs.skip_legacy_release }}
+      only_maker_changed: ${{ steps.scope.outputs.only_maker_changed }}
+      has_maker_marker: ${{ steps.scope.outputs.has_maker_marker }}
+      non_maker_files: ${{ steps.scope.outputs.non_maker_files }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Evaluate release scope
+        id: scope
+        env:
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "skip_legacy_release=false" >> "$GITHUB_OUTPUT"
+            echo "only_maker_changed=false" >> "$GITHUB_OUTPUT"
+            echo "has_maker_marker=false" >> "$GITHUB_OUTPUT"
+            echo "non_maker_files=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          node scripts/check-release-scope.cjs \
+            --mode push \
+            --base "${{ github.event.before }}" \
+            --head "${{ github.sha }}" \
+            --title "$HEAD_COMMIT_MESSAGE"
+
+  maker-only-release-skipped:
+    name: Legacy Release Skipped For Maker
+    runs-on: ubuntu-latest
+    needs: scope
+    if: needs.scope.outputs.skip_legacy_release == 'true'
+
+    steps:
+      - name: Summary
+        run: |
+          echo "## Legacy Release Skipped" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "This push only changed Maker-owned paths." >> "$GITHUB_STEP_SUMMARY"
+          echo "The main package \`@taptap/instant-games-open-mcp\` was not released." >> "$GITHUB_STEP_SUMMARY"
+          echo "Use the \`Publish Maker Package\` workflow to publish \`@taptap/maker\`." >> "$GITHUB_STEP_SUMMARY"
+
   # ========== 阶段 1: 分析是否需要发布 + 检测 native 变更 ==========
   analyze:
     name: Analyze Release
     runs-on: ubuntu-latest
+    needs: scope
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event.head_commit != null &&
+      (needs.scope.outputs.skip_legacy_release != 'true' &&
+       github.event.head_commit != null &&
        !contains(github.event.head_commit.message, '[skip ci]') &&
        github.event.head_commit.author.name != 'github-actions[bot]')
     outputs:
@@ -460,33 +511,35 @@ jobs:
 
           git checkout -b "$BRANCH"
 
+      - name: Set release package version
+        run: |
+          VERSION=${{ steps.release_version.outputs.version }}
+
+          npm version $VERSION --no-git-tag-version
+
+      # 生成主包 CHANGELOG 和 GitHub Release notes，过滤 Maker-only commits
+      - name: Generate filtered main package release notes
+        run: |
+          node scripts/generate-main-release-notes.cjs
+          test -s release-notes.md
+          cp release-notes.md "$RUNNER_TEMP/main-release-notes.md"
+        env:
+          RELEASE_VERSION: ${{ steps.release_version.outputs.version }}
+
+      - name: Verify package contents before publish
+        run: |
+          test -s "$RUNNER_TEMP/main-release-notes.md"
+          echo "=== Files to be published ==="
+          npm pack --dry-run
+
       # 发布到 npm (包含 native binaries)
       # 优先使用 OIDC provenance；fallback 到 NPM_TOKEN（首次发布新包名时需要）
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          VERSION=${{ steps.release_version.outputs.version }}
-
-          # 更新版本号
-          npm version $VERSION --no-git-tag-version
-
-          # 验证 native 文件会被包含
-          echo "=== Files to be published ==="
-          npm pack --dry-run
-
-          # 尝试 OIDC provenance 发布，失败则 fallback 到 NPM_TOKEN
           npm publish --access public --tag latest --provenance 2>/dev/null \
             || npm publish --access public --tag latest
-
-      # 生成 CHANGELOG
-      - name: Generate CHANGELOG
-        run: |
-          npx conventional-changelog-cli -p conventionalcommits -i CHANGELOG.md -s
-
-          # 过滤掉噪音提交（与 .commitlintrc.cjs 中的忽略规则一致）
-          # - Initial plan, WIP, TODO, FIXME: Copilot/bot 的临时提交
-          sed -i '/^\* \(Initial plan\|WIP\|TODO\|FIXME\)\b/d' CHANGELOG.md
 
       # 提交并推送
       - name: Commit and push release branch
@@ -609,11 +662,7 @@ jobs:
           git fetch origin
           git checkout -B main origin/main
 
-          # 生成 release notes
-          RELEASE_NOTES=$(gh api repos/${{ github.repository }}/releases/generate-notes \
-            -f tag_name="v${VERSION}" \
-            -f target_commitish=main \
-            --jq '.body') || RELEASE_NOTES="Release v${VERSION}"
+          test -s "$RUNNER_TEMP/main-release-notes.md"
 
           # 在 main 最新 commit 上创建 tag（即 squash merge 后的 release commit）
           git tag -a "v${VERSION}" -m "Release v${VERSION}"
@@ -622,7 +671,7 @@ jobs:
           # 创建 GitHub Release，上传 native binaries 作为 assets
           gh release create "v${VERSION}" \
             --title "v${VERSION}" \
-            --notes "$RELEASE_NOTES" \
+            --notes-file "$RUNNER_TEMP/main-release-notes.md" \
             native/*.node
           echo "Created release with native binaries as assets"
 

--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -47,7 +47,7 @@ module.exports = {
   plugins: [
     // 1. 分析 commit 消息，确定版本号变更类型
     [
-      '@semantic-release/commit-analyzer',
+      './scripts/semantic-release-main-analyzer.cjs',
       {
         preset: 'conventionalcommits',
         // 🔒 禁用自动 major 识别

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ git push origin feature/new-feature
 # 4. 在 GitHub 创建 PR
 # 5. 等待 CI 检查通过（lint、build、test、commitlint）
 # 6. 请求 Code Review
-# 7. 合并后自动发布到 npm
+# 7. 合并后由维护者按仓库 CI/CD 策略处理发布
 ```
 
 ### Commit 规范
@@ -41,12 +41,16 @@ test: add tests              # 测试 → 不触发发布
 ```
 
 **Commit Message 要求**：
+
 - Type 必须是规定的类型之一
 - Subject 长度：5-100 字符
 - 使用祈使句："add feature" 而不是 "added feature"
 - 不要以句号结尾
+- 不要使用 `WIP`、`temp`、`test`、`Initial plan` 等空泛消息
+- 重要改动应在 body 中用短 bullet 写清楚改动内容、行为变化、设计取舍、风险和验证结果
 
 **示例**：
+
 ```bash
 ✅ feat(leaderboard): add score submission API
 ✅ fix(auth): resolve token refresh issue
@@ -56,15 +60,30 @@ test: add tests              # 测试 → 不触发发布
 ❌ feat: fix          # 太短（< 5 字符）
 ```
 
+### PR 归属规范
+
+PR 应按改动归属拆分，避免不同发布边界互相影响：
+
+- 主包或共享能力改动：使用普通 Conventional Commit 标题，例如
+  `fix(auth): refresh expired token`。
+- Maker-only 改动：PR 标题必须带 `(maker)`，例如
+  `fix(maker): repair local build`，并且只能修改 Maker-owned paths。
+- 不要在同一个业务 PR 里混改 Maker-owned paths 和主包/共享路径；需要拆成两个 PR。
+- 发布基础设施改动可以同时调整 release workflow、scope 脚本、文档和对应测试；标题使用
+  `ci(release): ...`，并在 PR 描述中说明验证结果。
+- Maker-only PR 合并时不要删除 squash 标题里的 `(maker)`，这是审查和追踪发布边界的必需信号。
+
 ### CI 检查
 
 PR 必须通过所有检查才能合并：
+
 - ✅ **Lint**: ESLint 代码检查
 - ✅ **Build**: TypeScript 编译
 - ✅ **Test**: Jest 单元测试
 - ✅ **Commitlint**: Commit 消息格式验证
 
 **本地验证**：
+
 ```bash
 npm run lint      # 代码检查
 npm run build     # 构建
@@ -116,6 +135,7 @@ src/
 ```
 
 **模块说明**：
+
 - **app**: 基础应用管理（开发者/应用选择、OAuth 授权、环境检查）
 - **leaderboard**: 排行榜功能（依赖 app 模块）
 - **h5Game**: H5 游戏管理
@@ -177,6 +197,7 @@ git commit -m "feat: 添加云存档功能"
 添加新功能时，确保：
 
 ### 代码实现
+
 - [ ] 使用脚手架生成模块结构
 - [ ] 实现所有 TODO 标记的内容
 - [ ] 工具采用统一格式（`ToolRegistration[]`）
@@ -184,22 +205,25 @@ git commit -m "feat: 添加云存档功能"
 - [ ] 在 server.ts 注册模块
 
 ### 质量检查
+
 - [ ] Lint 通过：`npm run lint`
 - [ ] 编译无错：`npm run build`
 - [ ] 测试通过：`npm test`
 - [ ] 本地验证启动：`node dist/server.js`
 
 ### Commit 和文档
+
 - [ ] Commit 消息符合 Conventional Commits 规范
 - [ ] 更新 README.md（如有用户可见的新特性）
 - [ ] 更新相关技术文档（如有架构变更，参考 [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)）
 
 ### PR 流程
+
 - [ ] 创建 PR 并填写详细描述
 - [ ] 等待所有 CI 检查通过
 - [ ] 请求 Code Review
 - [ ] 解决所有 Review 意见
-- [ ] 合并后自动发布到 npm
+- [ ] 合并后由维护者按仓库 CI/CD 策略处理发布
 
 ---
 
@@ -238,6 +262,7 @@ export const myResources: ResourceRegistration[] = [
 ```
 
 **优势**：
+
 - ✅ 定义和处理器永不不匹配
 - ✅ TypeScript 类型安全
 - ✅ 易于维护
@@ -253,6 +278,7 @@ export const myResources: ResourceRegistration[] = [
 ```
 
 **依赖规则**：
+
 - ✅ 业务模块可依赖 `core/` 和 `features/app/`
 - ❌ 业务模块之间不能相互依赖
 - ✅ app 模块只依赖 core
@@ -317,6 +343,7 @@ const overview = generateOverview(documentation);
 **完整参考**：查看 `src/features/leaderboard/` 模块
 
 特别关注：
+
 - `index.ts` - 模块结构
 - `tools.ts` - 统一格式的工具定义
 - `resources.ts` - 统一格式的资源定义
@@ -355,17 +382,18 @@ TapTap API
 
 当前项目统计：
 
-| 模块 | 文件数 | 代码行数 | 说明 |
-|------|-------|---------|------|
-| app | 4 | ~430 行 | 应用管理基础功能 |
-| leaderboard | 7 | ~1350 行 | 排行榜（已分离 app 操作）|
-| h5Game | 5 | ~600 行 | H5 游戏管理 |
-| vibrate | 6 | ~300 行 | 振动 API 文档 |
-| core | 10 | ~1100 行 | 共享核心代码 |
-| server.ts | 1 | ~450 行 | 主服务器 |
-| **总计** | **33** | **~4230 行** | |
+| 模块        | 文件数 | 代码行数     | 说明                      |
+| ----------- | ------ | ------------ | ------------------------- |
+| app         | 4      | ~430 行      | 应用管理基础功能          |
+| leaderboard | 7      | ~1350 行     | 排行榜（已分离 app 操作） |
+| h5Game      | 5      | ~600 行      | H5 游戏管理               |
+| vibrate     | 6      | ~300 行      | 振动 API 文档             |
+| core        | 10     | ~1100 行     | 共享核心代码              |
+| server.ts   | 1      | ~450 行      | 主服务器                  |
+| **总计**    | **33** | **~4230 行** |                           |
 
 **架构优化成果**：
+
 - ✅ 模块化后清理重复代码
 - ✅ app 功能独立，可被其他模块复用
 - ✅ 代码内聚度提升，维护更容易
@@ -375,6 +403,7 @@ TapTap API
 ## 🎊 享受模块化开发！
 
 模块化架构让添加新功能变得简单快捷！有问题请参考：
+
 - **代码示例**：`src/features/leaderboard/` 模块
 - **架构文档**：[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
 - **部署测试**：[docs/DEPLOYMENT.md#4-开发者测试指南](docs/DEPLOYMENT.md#4-开发者测试指南)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ## 🦞 OpenClaw Plugin（实验中）
 
-仓库内提供了一个可独立发布的 OpenClaw plugin 子包：
+仓库内提供了一个可独立使用的 OpenClaw plugin 子包：
 
 - [`packages/openclaw-dc-plugin`](packages/openclaw-dc-plugin)
 
@@ -42,7 +42,6 @@
 详见：
 
 - [OpenClaw Plugin 说明](docs/OPENCLAW_PLUGIN.md)
-- 维护者发布方式：`npm run openclaw:pack` / `npm run openclaw:publish`
 
 ## 🛠️ TapTap Maker 本地开发（CLI-first）
 
@@ -536,35 +535,7 @@ graph LR
 - **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** - 架构文档
 - **[docs/DEPLOYMENT.md](docs/DEPLOYMENT.md)** - 部署指南（本地、Docker、开发者测试）
 - **[docs/PROXY.md](docs/PROXY.md)** - MCP Proxy 开发指南（面向 TapCode 等平台）
-- **[docs/CI_CD.md](docs/CI_CD.md)** - CI/CD 和自动化发布流程
 - **[docs/PATH_RESOLUTION.md](docs/PATH_RESOLUTION.md)** - 路径解析系统
-
-## 🔄 CI/CD
-
-基于 Conventional Commits 的完全自动化发布：
-
-```bash
-# 创建功能分支
-git checkout -b feat/awesome-feature
-
-# 提交代码
-git commit -m "feat: add awesome feature"
-
-# 创建 PR 并合并
-gh pr create && gh pr merge
-
-# 自动发布到 npm（版本：1.4.13 → 1.5.0）
-```
-
-**发布流程**：
-
-1. PR 合并 → 触发 Actions
-2. 分析 commits 确定版本号
-3. 发布到 npm
-4. 自动创建版本 PR 并合并
-5. 创建 GitHub Release
-
-详见: [docs/CI_CD.md](docs/CI_CD.md)
 
 ## 🤝 贡献
 

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -367,9 +367,9 @@ npx commitlint --from HEAD~1 --to HEAD
 
 **认证方式**：
 
-- 使用 npm Trusted Publishing / GitHub OIDC。
+- 优先使用 npm Trusted Publishing / GitHub OIDC。
 - workflow 必须保留 `permissions.id-token: write`。
-- 不使用 `NPM_TOKEN`，也不允许 provenance 失败后降级发布。
+- `npm publish --provenance` 失败时 fallback 到不带 provenance 的 `npm publish`。
 
 **执行步骤**：
 
@@ -379,15 +379,59 @@ npx commitlint --from HEAD~1 --to HEAD
 4. 组装 `packages/maker`
 5. `npm pack --dry-run`
 6. 用 tarball 验证 `taptap-maker help`
-7. 使用 `npm publish --provenance` 发布到指定 dist-tag
+7. `npm publish` 前再次查询目标版本，避免审批等待期间同版本被抢先发布。
+8. 使用 `npm publish --provenance` 发布到指定 dist-tag。
 
 **设计约束**：
 
 - 不走旧包的 semantic-release。
-- 不修改旧包 release workflow。
+- Maker-only PR 必须带 `(maker)` scope，且只能修改 Maker-owned paths。
+- 旧包 release workflow 会按 Maker-only paths 跳过主包发布。
+- 旧包 semantic-release 分析、CHANGELOG 和 GitHub Release notes 会过滤 Maker-only commits。
 - 手动版本号必须二次确认。
-- 自动版本号只允许递增最后一个数字段。
-- 如果 OIDC/provenance 发布失败，workflow 必须失败并停止。
+- 自动版本号只允许在 `fix/*` 分支上递增最后一个数字段。
+- 手动发布如果修改三段版本号里的前两段，CI 会先在 Actions Summary 显示当前
+  线上 dist-tag 版本和目标版本，再由人工点击 protected environment 审批按钮继续。
+- 发布 job 在实际 `npm publish` 前会再次检查目标版本是否仍未发布。
+- 如果带 provenance 和不带 provenance 的发布都失败，workflow 必须失败并停止。
+
+### 5.5 主包与 Maker 包发布隔离
+
+`@taptap/instant-games-open-mcp` 和 `@taptap/maker` 使用隔离的发布边界：
+
+- 主包发布由 `.github/workflows/release.yml` 负责。
+- Maker 包发布由 `.github/workflows/publish-maker.yml` 负责。
+- 主包 npm 只发布主 MCP 和 proxy 入口，不包含 `taptap-maker` CLI、Maker-only bundle
+  或 Maker skills；这些文件由 `@taptap/maker` 独立发布。
+- Maker-only PR 必须使用 Conventional Commit scope 标记，例如
+  `fix(maker): repair local build`。
+- Maker-only PR 只能修改 Maker-owned paths：
+  `src/maker/`、`packages/maker/`、`skills/taptap-maker-*`、
+  `skills/update-taptap-mcp/`、Maker 发布脚本、Maker 文档和 Maker 测试。
+- 如果 Maker 改动需要修改 `package.json`、`README.md`、`.releaserc.cjs`、
+  `.github/workflows/release.yml` 等共享文件，应拆成独立 PR。
+
+PR 检查会拒绝以下情况：
+
+- 只改 Maker-owned paths，但 PR 标题缺少 `(maker)`。
+- 同一个 PR 同时修改 Maker-owned paths 和共享或主包路径。
+- PR 标题包含 `(maker)`，但没有保持为纯 Maker-owned paths。
+
+PR 路径检测使用 merge-base 语义，只统计 PR 分支实际改动，不把评审期间 main
+新合入的文件算进当前 PR。合并 Maker-only PR 时不要编辑 squash commit 标题去掉
+`(maker)`；即使标题被误改，主包 release workflow 仍会按 Maker-only paths 跳过主包发布，
+但 PR 标题标记是团队审查和追踪 Maker 发布边界的必需信号。
+
+主包 release workflow 在 push 到 `main`、`beta` 或 `alpha` 时会再次做路径检查。
+Maker-only push 会跳过主包发布；后续主包发布也会过滤这些 Maker-only commits，避免延迟
+触发版本升级或污染主包 CHANGELOG / GitHub Release notes。
+
+Maker 包版本号使用三段式 semver，例如 `0.0.1`。CI 自动递增只能在 `fix/*` 分支使用
+`auto-last-number`，且只递增最后一个数字段。手动发布如果要改变 major 或 minor，必须在
+workflow 输入中填写目标版本号并再次确认；CI 会在预检 job 的 Actions Summary 展示当前
+线上 dist-tag 版本和目标版本，人工核对后点击 protected environment 审批按钮继续发布。
+beta 发布建议使用 `0.0.6-beta.1` 这类 prerelease 版本和 `tag=beta`，正式发布使用稳定三段
+版本和 `tag=latest`，两者保持相同的 npm pack、CLI 验证和 publish 流程。
 
 ---
 
@@ -406,7 +450,7 @@ module.exports = {
     { name: 'next', prerelease: true },
   ],
   plugins: [
-    '@semantic-release/commit-analyzer',
+    './scripts/semantic-release-main-analyzer.cjs',
     '@semantic-release/release-notes-generator',
     '@semantic-release/changelog',
     '@semantic-release/npm',

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -43,6 +43,38 @@ node dist/maker.js
 npx @modelcontextprotocol/inspector node dist/maker.js
 ```
 
+## Maker NPM 发布边界
+
+Maker CLI 独立发布为 `@taptap/maker`，不走主包
+`@taptap/instant-games-open-mcp` 的 semantic-release。Maker-only PR 标题必须带
+`(maker)` scope，例如 `fix(maker): repair PAT setup`，并且只能修改 Maker-owned paths。
+合并时不要编辑 squash commit 标题去掉 `(maker)`。合并后主包 release workflow 会按
+Maker-only paths 跳过这类 push；如需发布 Maker CLI，使用 GitHub Actions 中的
+`Publish Maker Package` workflow。
+
+Maker 包版本号使用三段式 semver，例如 `0.0.1`。CI 的 `auto-last-number` 模式只允许在
+`fix/*` 分支使用，并且只递增最后一个数字段。手动发布如果修改 major 或 minor，必须在
+workflow 界面确认目标版本号；CI 会先在 Actions Summary 展示当前线上 dist-tag 版本和
+目标版本，人工核对后点击 protected environment 审批按钮继续发布。发布 job 在
+`npm publish` 前会再次查询目标版本是否仍未发布，避免审批等待期间同版本被抢先发布。
+beta 发布建议使用 prerelease 版本和 `tag=beta`，正式发布使用稳定三段版本和 `tag=latest`；
+两者保持同一套 npm pack、CLI 验证和 publish 流程。
+
+### 主包迁移说明
+
+主包 `@taptap/instant-games-open-mcp` 只保留 TapTap Open API MCP server 和 proxy 入口。
+`taptap-maker` CLI、Maker MCP bundle 和 Maker workflow skills 迁移到独立包
+`@taptap/maker`，后续 Maker 功能更新不会再通过主包发布。已通过主包调用 Maker CLI 的用户
+需要改为：
+
+```bash
+npx -y @taptap/maker init
+```
+
+AI 客户端 MCP 配置也应使用 `taptap-maker mcp install` 写入的
+`npx -y -p @taptap/maker taptap-maker` 命令；不要再依赖
+`@taptap/instant-games-open-mcp` 提供 Maker CLI。
+
 ## 崩溃日志保护
 
 Maker MCP 的最后兜底异常日志写入 `~/.taptap-maker/mcp-crash.log`。日志采用固定上限保护：

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
       },
       "bin": {
         "instant-games-open-mcp": "bin/instant-games-open-mcp",
-        "taptap-maker": "bin/taptap-maker",
         "taptap-mcp-proxy": "bin/taptap-mcp-proxy"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,13 +6,11 @@
   "main": "dist/server.js",
   "bin": {
     "instant-games-open-mcp": "bin/instant-games-open-mcp",
-    "taptap-mcp-proxy": "bin/taptap-mcp-proxy",
-    "taptap-maker": "bin/taptap-maker"
+    "taptap-mcp-proxy": "bin/taptap-mcp-proxy"
   },
   "exports": {
     ".": "./dist/server.js",
     "./proxy": "./dist/proxy.js",
-    "./maker": "./dist/maker.js",
     "./package.json": "./package.json"
   },
   "scripts": {
@@ -92,11 +90,11 @@
     "typescript": "^5.0.0"
   },
   "files": [
-    "dist/",
-    "bin/",
-    "skills/taptap-maker-local/",
-    "skills/taptap-maker-dev-kit-guide/",
-    "skills/update-taptap-mcp/"
+    "dist/server.js",
+    "dist/proxy.js",
+    "dist/native/",
+    "bin/instant-games-open-mcp",
+    "bin/taptap-mcp-proxy"
   ],
   "repository": {
     "type": "git",

--- a/scripts/check-release-scope.cjs
+++ b/scripts/check-release-scope.cjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+'use strict';
+
+const { appendFileSync } = require('node:fs');
+const {
+  classifyFiles,
+  hasMakerMarker,
+  readChangedFiles,
+  readTreeFiles,
+  shouldSkipLegacyRelease,
+} = require('./release-scope.cjs');
+
+const ZERO_SHA_PATTERN = /^0{40}$/;
+
+function parseArgs(argv) {
+  const args = { mode: 'pr', base: '', head: 'HEAD', title: '', range: '' };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--mode') args.mode = argv[++index] || '';
+    else if (arg === '--base') args.base = argv[++index] || '';
+    else if (arg === '--head') args.head = argv[++index] || 'HEAD';
+    else if (arg === '--title') args.title = argv[++index] || '';
+    else if (arg === '--range') args.range = argv[++index] || '';
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  if (!args.base) {
+    throw new Error('Missing --base <sha>');
+  }
+  return args;
+}
+
+function isZeroSha(value) {
+  return ZERO_SHA_PATTERN.test(String(value || ''));
+}
+
+function readFilesForMode(args) {
+  if (args.mode === 'push' && isZeroSha(args.base)) {
+    return readTreeFiles(args.head);
+  }
+  const rangeMode = args.range || (args.mode === 'pr' ? 'three-dot' : 'two-dot');
+  return readChangedFiles(args.base, args.head, rangeMode);
+}
+
+function writeGithubOutput(name, value) {
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}\n`, 'utf8');
+  }
+}
+
+function validatePrScope({ files, title }) {
+  const classification = classifyFiles(files);
+  const markerPresent = hasMakerMarker(title);
+
+  if (
+    classification.hasMakerChanges &&
+    classification.hasNonMakerChanges &&
+    !classification.onlyReleaseInfrastructureChanged
+  ) {
+    return {
+      ok: false,
+      reason: 'Maker-owned paths and main package paths must be changed in separate PRs.',
+      classification,
+    };
+  }
+
+  if (
+    classification.onlyMakerChanged &&
+    !classification.onlyReleaseInfrastructureChanged &&
+    !markerPresent
+  ) {
+    return {
+      ok: false,
+      reason: 'Maker-only PRs must include `(maker)` in the PR title.',
+      classification,
+    };
+  }
+
+  if (markerPresent && !classification.onlyMakerChanged) {
+    return {
+      ok: false,
+      reason: '`(maker)` PRs may only modify Maker-owned paths.',
+      classification,
+    };
+  }
+
+  return {
+    ok: true,
+    reason: 'Release scope is valid.',
+    classification,
+  };
+}
+
+function evaluatePushScope({ files, markerText }) {
+  return shouldSkipLegacyRelease({ files, markerText });
+}
+
+function printClassification(classification) {
+  console.log(`Changed files: ${classification.files.length}`);
+  console.log(`Maker files: ${classification.makerFiles.length}`);
+  console.log(`Non-Maker files: ${classification.nonMakerFiles.length}`);
+  if (classification.nonMakerFiles.length > 0) {
+    console.log('Non-Maker files:');
+    for (const file of classification.nonMakerFiles) {
+      console.log(`- ${file}`);
+    }
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const files = readFilesForMode(args);
+
+  if (args.mode === 'push') {
+    const result = evaluatePushScope({ files, markerText: args.title });
+    writeGithubOutput('skip_legacy_release', String(result.skipLegacyRelease));
+    writeGithubOutput('only_maker_changed', String(result.onlyMakerChanged));
+    writeGithubOutput('has_maker_marker', String(result.hasMakerMarker));
+    writeGithubOutput('non_maker_files', result.nonMakerFiles.join(','));
+    console.log(`skip_legacy_release=${result.skipLegacyRelease}`);
+    console.log(`only_maker_changed=${result.onlyMakerChanged}`);
+    console.log(`has_maker_marker=${result.hasMakerMarker}`);
+    printClassification(result);
+    return;
+  }
+
+  const result = validatePrScope({ files, title: args.title });
+  console.log(result.reason);
+  printClassification(result.classification);
+  if (!result.ok) {
+    process.exit(1);
+  }
+}
+
+module.exports = { evaluatePushScope, isZeroSha, readFilesForMode, validatePrScope };
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/generate-main-release-notes.cjs
+++ b/scripts/generate-main-release-notes.cjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+'use strict';
+
+const { execFileSync } = require('node:child_process');
+const { existsSync, readFileSync, writeFileSync } = require('node:fs');
+const { readCommitFiles, shouldSkipLegacyRelease } = require('./release-scope.cjs');
+
+const TYPE_SECTIONS = [
+  ['feat', 'Features'],
+  ['fix', 'Bug Fixes'],
+  ['perf', 'Performance'],
+  ['refactor', 'Refactoring'],
+  ['revert', 'Reverts'],
+  ['docs', 'Documentation'],
+  ['style', 'Styles'],
+  ['build', 'Build'],
+  ['ci', 'CI'],
+  ['test', 'Tests'],
+  ['chore', 'Chores'],
+];
+
+const IGNORED_RELEASE_NOTES_PATTERN = /^(Initial plan|WIP|TODO|FIXME)\b[:\s]?.*/i;
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8' }).trim();
+}
+
+function getLastTag() {
+  try {
+    return git(['describe', '--tags', '--abbrev=0', '--match', 'v[0-9]*']);
+  } catch {
+    return '';
+  }
+}
+
+function parseLog(range) {
+  const args = ['log', '--format=%H%x1f%s%x1f%b%x1e'];
+  if (range) {
+    args.push(range);
+  }
+  const output = git(args);
+  if (!output) {
+    return [];
+  }
+  return output
+    .split('\x1e')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      const [hash, subject, body = ''] = entry.split('\x1f');
+      return { hash, subject, body, message: `${subject}\n\n${body}`.trim() };
+    });
+}
+
+function parseConventionalSubject(subject) {
+  const match = /^([a-z]+)(?:\(([^)]+)\))?!?:\s+(.+)$/.exec(subject);
+  if (!match) {
+    return null;
+  }
+  return { type: match[1], scope: match[2] || '', summary: match[3] };
+}
+
+function filterMainCommits(commits) {
+  return filterReleaseNotesCommits(
+    commits.filter((commit) => {
+      const files = readCommitFiles(commit.hash);
+      return !shouldSkipLegacyRelease({ files, markerText: commit.message }).skipLegacyRelease;
+    })
+  );
+}
+
+function shouldIgnoreReleaseNotesCommit(commit) {
+  return IGNORED_RELEASE_NOTES_PATTERN.test(String(commit.message || commit.subject || '').trim());
+}
+
+function filterReleaseNotesCommits(commits) {
+  return commits.filter((commit) => !shouldIgnoreReleaseNotesCommit(commit));
+}
+
+function formatCommit(commit) {
+  const parsed = parseConventionalSubject(commit.subject);
+  const label = parsed
+    ? `${parsed.scope ? `${parsed.scope}: ` : ''}${parsed.summary}`
+    : commit.subject;
+  return `* ${label} (${commit.hash.slice(0, 7)})`;
+}
+
+function buildReleaseNotes({ version, commits, date = new Date() }) {
+  const dateText = date.toISOString().slice(0, 10);
+  const lines = [`## <small>${version} (${dateText})</small>`, ''];
+  const releaseNotesCommits = filterReleaseNotesCommits(commits);
+  const conventional = releaseNotesCommits
+    .map((commit) => ({ commit, parsed: parseConventionalSubject(commit.subject) }))
+    .filter((item) => item.parsed);
+
+  for (const [type, section] of TYPE_SECTIONS) {
+    const group = conventional.filter((item) => item.parsed.type === type);
+    if (group.length === 0) {
+      continue;
+    }
+    lines.push(`### ${section}`, '');
+    for (const item of group) {
+      lines.push(formatCommit(item.commit));
+    }
+    lines.push('');
+  }
+
+  const uncategorized = releaseNotesCommits.filter(
+    (commit) => !parseConventionalSubject(commit.subject)
+  );
+  if (uncategorized.length > 0) {
+    lines.push('### Other Changes', '');
+    for (const commit of uncategorized) {
+      lines.push(formatCommit(commit));
+    }
+    lines.push('');
+  }
+
+  if (releaseNotesCommits.length === 0) {
+    lines.push('* No main package changes after filtering Maker-only commits.', '');
+  }
+
+  return `${lines.join('\n').trim()}\n\n`;
+}
+
+function prependChangelog(notes, changelogPath = 'CHANGELOG.md') {
+  const existing = existsSync(changelogPath) ? readFileSync(changelogPath, 'utf8') : '';
+  writeFileSync(changelogPath, `${notes}${existing.replace(/^\s+/, '')}`, 'utf8');
+}
+
+function main() {
+  const version = process.env.RELEASE_VERSION;
+  if (!version) {
+    throw new Error('Missing RELEASE_VERSION.');
+  }
+
+  const lastTag = process.env.LAST_RELEASE_TAG || getLastTag();
+  const range = lastTag ? `${lastTag}..HEAD` : '';
+  const commits = filterMainCommits(parseLog(range));
+  const notes = buildReleaseNotes({ version, commits });
+
+  writeFileSync('release-notes.md', notes, 'utf8');
+  prependChangelog(notes);
+  console.log(`Generated filtered main package release notes for ${version}.`);
+  console.log(`Included commits: ${commits.length}`);
+}
+
+module.exports = {
+  buildReleaseNotes,
+  filterReleaseNotesCommits,
+  filterMainCommits,
+  parseConventionalSubject,
+  shouldIgnoreReleaseNotesCommit,
+};
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/release-scope.cjs
+++ b/scripts/release-scope.cjs
@@ -1,0 +1,145 @@
+'use strict';
+
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+
+const EMPTY_TREE_SHA = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
+const MAKER_MARKER_PATTERN = /\(maker\)/i;
+
+const MAKER_PATH_PREFIXES = [
+  'packages/maker/',
+  'src/maker/',
+  'skills/taptap-maker-local/',
+  'skills/taptap-maker-dev-kit-guide/',
+  'skills/update-taptap-mcp/',
+];
+
+const MAKER_EXACT_PATHS = new Set([
+  '.github/workflows/publish-maker.yml',
+  'bin/taptap-maker',
+  'docs/MAKER.md',
+  'docs/MAKER_CLI_MCP_SKILL_REWORK_OVERVIEW.md',
+  'scripts/bundle-maker.js',
+  'scripts/prepare-maker-package.js',
+  'scripts/resolve-maker-version.js',
+]);
+
+const RELEASE_INFRA_EXACT_PATHS = new Set([
+  '.github/workflows/claude-review.yml',
+  '.github/workflows/pr.yml',
+  '.github/workflows/release.yml',
+  '.github/workflows/publish-maker.yml',
+  '.releaserc.cjs',
+  'CONTRIBUTING.md',
+  'README.md',
+  'docs/CI_CD.md',
+  'docs/MAKER.md',
+  'package-lock.json',
+  'package.json',
+  'scripts/check-release-scope.cjs',
+  'scripts/generate-main-release-notes.cjs',
+  'scripts/release-scope.cjs',
+  'scripts/resolve-maker-version.js',
+  'scripts/semantic-release-main-analyzer.cjs',
+  'src/__tests__/mainPackageManifest.test.ts',
+  'src/__tests__/mainReleaseNotes.test.ts',
+  'src/__tests__/makerVersionPolicy.test.ts',
+  'src/__tests__/releaseScope.test.ts',
+  'src/__tests__/releaseScopeCli.test.ts',
+  'src/__tests__/semanticReleaseMainAnalyzer.test.ts',
+]);
+
+function normalizeGitPath(filePath) {
+  return String(filePath || '')
+    .replaceAll(path.sep, '/')
+    .replace(/^\.\/+/, '');
+}
+
+function hasMakerMarker(text) {
+  return MAKER_MARKER_PATTERN.test(String(text || ''));
+}
+
+function isMakerOwnedPath(filePath) {
+  const normalized = normalizeGitPath(filePath);
+  if (!normalized) {
+    return false;
+  }
+  if (MAKER_EXACT_PATHS.has(normalized)) {
+    return true;
+  }
+  if (normalized.startsWith('src/__tests__/maker') && normalized.endsWith('.ts')) {
+    return true;
+  }
+  return MAKER_PATH_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+}
+
+function isReleaseInfrastructurePath(filePath) {
+  return RELEASE_INFRA_EXACT_PATHS.has(normalizeGitPath(filePath));
+}
+
+function classifyFiles(files) {
+  const normalizedFiles = files.map(normalizeGitPath).filter(Boolean);
+  const makerFiles = normalizedFiles.filter(isMakerOwnedPath);
+  const nonMakerFiles = normalizedFiles.filter((file) => !isMakerOwnedPath(file));
+  const releaseInfrastructureFiles = normalizedFiles.filter(isReleaseInfrastructurePath);
+
+  return {
+    files: normalizedFiles,
+    makerFiles,
+    nonMakerFiles,
+    releaseInfrastructureFiles,
+    hasChanges: normalizedFiles.length > 0,
+    onlyMakerChanged: normalizedFiles.length > 0 && nonMakerFiles.length === 0,
+    hasMakerChanges: makerFiles.length > 0,
+    hasNonMakerChanges: nonMakerFiles.length > 0,
+    onlyReleaseInfrastructureChanged:
+      normalizedFiles.length > 0 && releaseInfrastructureFiles.length === normalizedFiles.length,
+  };
+}
+
+function readChangedFiles(baseRef, headRef = 'HEAD', rangeMode = 'two-dot') {
+  const separator = rangeMode === 'three-dot' ? '...' : '..';
+  const output = execFileSync('git', ['diff', '--name-only', `${baseRef}${separator}${headRef}`], {
+    encoding: 'utf8',
+  });
+  return output.split('\n').filter(Boolean);
+}
+
+function readTreeFiles(headRef = 'HEAD') {
+  const output = execFileSync('git', ['diff', '--name-only', EMPTY_TREE_SHA, headRef], {
+    encoding: 'utf8',
+  });
+  return output.split('\n').filter(Boolean);
+}
+
+function readCommitFiles(commitSha) {
+  const output = execFileSync(
+    'git',
+    ['diff-tree', '--no-commit-id', '--name-only', '-r', '--root', commitSha],
+    { encoding: 'utf8' }
+  );
+  return output.split('\n').filter(Boolean);
+}
+
+function shouldSkipLegacyRelease({ files, markerText }) {
+  const fileClassification = classifyFiles(files);
+  return {
+    ...fileClassification,
+    hasMakerMarker: hasMakerMarker(markerText),
+    skipLegacyRelease: fileClassification.onlyMakerChanged,
+  };
+}
+
+module.exports = {
+  EMPTY_TREE_SHA,
+  MAKER_MARKER_PATTERN,
+  classifyFiles,
+  hasMakerMarker,
+  isMakerOwnedPath,
+  isReleaseInfrastructurePath,
+  normalizeGitPath,
+  readChangedFiles,
+  readCommitFiles,
+  readTreeFiles,
+  shouldSkipLegacyRelease,
+};

--- a/scripts/resolve-maker-version.js
+++ b/scripts/resolve-maker-version.js
@@ -3,8 +3,9 @@
 /**
  * Resolve the @taptap/maker version for the manual publish workflow.
  *
- * Manual mode requires an exact repeated confirmation. Auto mode only increments
- * the final numeric segment from the current npm dist-tag version.
+ * Manual mode requires an exact repeated target-version confirmation. Auto mode
+ * only increments the final numeric segment from the current npm dist-tag
+ * version.
  */
 
 import { execFileSync } from 'node:child_process';
@@ -14,6 +15,7 @@ const PACKAGE_NAME = '@taptap/maker';
 const FIRST_BETA_VERSION = '0.0.1-beta.1';
 const NPM_VIEW_TIMEOUT_MS = 30 * 1000;
 const VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const FIX_BRANCH_PATTERN = /^fix\//;
 
 function readEnv(name, fallback = '') {
   return process.env[name] || fallback;
@@ -23,6 +25,24 @@ function assertValidVersion(version) {
   if (!VERSION_PATTERN.test(version)) {
     throw new Error(`Invalid version: ${version}. Expected semver like 0.0.1 or 0.0.1-beta.1.`);
   }
+}
+
+function parseVersionCore(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version);
+  if (!match) {
+    throw new Error(`Invalid version core: ${version}`);
+  }
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+function changesMajorOrMinor(previousVersion, nextVersion) {
+  const previous = parseVersionCore(previousVersion);
+  const next = parseVersionCore(nextVersion);
+  return previous.major !== next.major || previous.minor !== next.minor;
 }
 
 function npmView(args) {
@@ -55,7 +75,15 @@ function packageHasPublishedVersions() {
   }
 }
 
-function resolveManualVersion() {
+function readCurrentDistTagVersion(tag) {
+  try {
+    return npmView([`dist-tags.${tag}`]);
+  } catch {
+    return '';
+  }
+}
+
+function resolveManualVersion(currentVersion) {
   const version = readEnv('MAKER_MANUAL_VERSION').trim();
   const confirmation = readEnv('MAKER_CONFIRM_VERSION').trim();
 
@@ -72,19 +100,33 @@ function resolveManualVersion() {
   }
 
   assertValidVersion(version);
+
+  if (currentVersion) {
+    assertValidVersion(currentVersion);
+  }
+
   return version;
 }
 
 function incrementFinalNumber(version) {
-  const match = /^(.*?)(\d+)$/.exec(version);
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
   if (!match) {
-    throw new Error(`Cannot auto-increment version without a final numeric segment: ${version}`);
+    throw new Error(
+      `auto-last-number requires a stable three-segment version like 0.0.1; got ${version}`
+    );
   }
-  const [, prefix, lastNumber] = match;
-  return `${prefix}${Number(lastNumber) + 1}`;
+  const [, major, minor, patch] = match;
+  return `${major}.${minor}.${Number(patch) + 1}`;
 }
 
 function resolveAutoVersion(tag, hasPublishedVersions) {
+  const branch = readEnv('GITHUB_REF_NAME');
+  if (!FIX_BRANCH_PATTERN.test(branch)) {
+    throw new Error(
+      `auto-last-number mode is only allowed from fix/* branches; current branch: ${branch || '(unknown)'}`
+    );
+  }
+
   if (!hasPublishedVersions) {
     throw new Error(
       `${PACKAGE_NAME} has no published versions. First publish must use manual ${FIRST_BETA_VERSION}.`
@@ -126,8 +168,14 @@ function main() {
   }
 
   const hasPublishedVersions = packageHasPublishedVersions();
+  const currentVersion = hasPublishedVersions ? readCurrentDistTagVersion(tag) : '';
   const version =
-    mode === 'manual' ? resolveManualVersion() : resolveAutoVersion(tag, hasPublishedVersions);
+    mode === 'manual'
+      ? resolveManualVersion(currentVersion)
+      : resolveAutoVersion(tag, hasPublishedVersions);
+  const majorMinorChanged = Boolean(
+    mode === 'manual' && currentVersion && changesMajorOrMinor(currentVersion, version)
+  );
 
   if (!hasPublishedVersions && (tag !== 'beta' || version !== FIRST_BETA_VERSION)) {
     throw new Error(
@@ -140,7 +188,13 @@ function main() {
   }
 
   writeOutput('version', version);
+  writeOutput('current_version', currentVersion);
+  writeOutput('major_minor_changed', String(majorMinorChanged));
   console.log(`Resolved ${PACKAGE_NAME} version: ${version}`);
+  if (currentVersion) {
+    console.log(`Current online ${PACKAGE_NAME}@${tag} version: ${currentVersion}`);
+  }
+  console.log(`Major/minor changed: ${majorMinorChanged}`);
 }
 
 try {

--- a/scripts/semantic-release-main-analyzer.cjs
+++ b/scripts/semantic-release-main-analyzer.cjs
@@ -1,0 +1,51 @@
+'use strict';
+
+const commitAnalyzer = require('@semantic-release/commit-analyzer');
+const { readCommitFiles, shouldSkipLegacyRelease } = require('./release-scope.cjs');
+
+function isMakerOnlyReleaseCommit(commit, logger) {
+  const markerText = commit.message || commit.subject || '';
+  if (!commit.hash) {
+    logger.log('Keeping commit without hash during release analysis: %s', markerText.split('\n')[0]);
+    return false;
+  }
+
+  const files = readCommitFiles(commit.hash);
+  return shouldSkipLegacyRelease({ files, markerText }).skipLegacyRelease;
+}
+
+function filterMainPackageCommits(commits, logger) {
+  const kept = [];
+  const skipped = [];
+
+  for (const commit of commits) {
+    if (isMakerOnlyReleaseCommit(commit, logger)) {
+      skipped.push(commit);
+    } else {
+      kept.push(commit);
+    }
+  }
+
+  if (skipped.length > 0) {
+    logger.log('Ignoring %d Maker-only commit(s) for main package release analysis.', skipped.length);
+    for (const commit of skipped) {
+      logger.log('- %s', (commit.subject || commit.message || '').split('\n')[0]);
+    }
+  }
+
+  return kept;
+}
+
+async function analyzeCommits(pluginConfig, context) {
+  const commits = filterMainPackageCommits(context.commits || [], context.logger);
+  return commitAnalyzer.analyzeCommits(pluginConfig, {
+    ...context,
+    commits,
+  });
+}
+
+module.exports = {
+  analyzeCommits,
+  filterMainPackageCommits,
+  isMakerOnlyReleaseCommit,
+};

--- a/src/__tests__/mainPackageManifest.test.ts
+++ b/src/__tests__/mainPackageManifest.test.ts
@@ -1,0 +1,19 @@
+import { createRequire } from 'node:module';
+
+const nodeRequire = createRequire(__filename);
+const packageJson = nodeRequire('../../package.json');
+const packageLock = nodeRequire('../../package-lock.json');
+
+describe('main package manifest', () => {
+  it('does not publish Maker CLI artifacts from the main npm package', () => {
+    expect(packageJson.bin).not.toHaveProperty('taptap-maker');
+    expect(packageJson.exports).not.toHaveProperty('./maker');
+    expect(packageJson.files).not.toContain('dist/');
+    expect(packageJson.files).not.toContain('bin/');
+    expect(packageJson.files).not.toContain('skills/taptap-maker-local/');
+    expect(packageJson.files).not.toContain('skills/taptap-maker-dev-kit-guide/');
+    expect(packageJson.files).not.toContain('skills/update-taptap-mcp/');
+
+    expect(packageLock.packages[''].bin).not.toHaveProperty('taptap-maker');
+  });
+});

--- a/src/__tests__/mainReleaseNotes.test.ts
+++ b/src/__tests__/mainReleaseNotes.test.ts
@@ -1,0 +1,46 @@
+import { createRequire } from 'node:module';
+
+const nodeRequire = createRequire(__filename);
+const releaseNotes = nodeRequire('../../scripts/generate-main-release-notes.cjs');
+
+describe('main package release notes', () => {
+  it('formats conventional commits into filtered release sections', () => {
+    const output = releaseNotes.buildReleaseNotes({
+      version: '1.24.0',
+      date: new Date('2026-06-01T00:00:00.000Z'),
+      commits: [
+        { hash: '1234567890', subject: 'feat(app): add selection guard' },
+        { hash: 'abcdef1234', subject: 'fix(proxy): repair token passthrough' },
+        { hash: 'fedcba9876', subject: 'style(ui): format toolbar' },
+      ],
+    });
+
+    expect(output).toContain('## <small>1.24.0 (2026-06-01)</small>');
+    expect(output).toContain('### Features');
+    expect(output).toContain('* app: add selection guard (1234567)');
+    expect(output).toContain('### Bug Fixes');
+    expect(output).toContain('* proxy: repair token passthrough (abcdef1)');
+    expect(output).toContain('### Styles');
+    expect(output).toContain('* ui: format toolbar (fedcba9)');
+  });
+
+  it('filters temporary non-conventional planning commits from release notes', () => {
+    const output = releaseNotes.buildReleaseNotes({
+      version: '1.24.0',
+      date: new Date('2026-06-01T00:00:00.000Z'),
+      commits: [
+        { hash: '1111111111', subject: 'Initial plan for release isolation' },
+        { hash: '2222222222', subject: 'WIP: update release workflow' },
+        { hash: '3333333333', subject: 'TODO add release notes' },
+        { hash: '4444444444', subject: 'FIXME release guard' },
+        { hash: '5555555555', subject: 'manual maintenance note' },
+      ],
+    });
+
+    expect(output).not.toContain('Initial plan');
+    expect(output).not.toContain('WIP');
+    expect(output).not.toContain('TODO');
+    expect(output).not.toContain('FIXME');
+    expect(output).toContain('* manual maintenance note (5555555)');
+  });
+});

--- a/src/__tests__/makerVersionPolicy.test.ts
+++ b/src/__tests__/makerVersionPolicy.test.ts
@@ -1,0 +1,133 @@
+import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const SCRIPT_PATH = join(process.cwd(), 'scripts', 'resolve-maker-version.js');
+
+function createFakeNpm(currentVersion: string, existingVersions: string[] = [currentVersion]) {
+  const dir = mkdtempSync(join(tmpdir(), 'maker-version-policy-'));
+  const binDir = join(dir, 'bin');
+  mkdirSync(binDir, { recursive: true });
+  const npmPath = join(binDir, 'npm');
+  writeFileSync(
+    npmPath,
+    `#!/usr/bin/env node
+const args = process.argv.slice(2);
+const current = ${JSON.stringify(currentVersion)};
+const existing = new Set(${JSON.stringify(existingVersions)});
+if (args[0] !== 'view') {
+  console.error('Unsupported npm command: ' + args.join(' '));
+  process.exit(1);
+}
+const query = args[1] || '';
+const field = args[2] || '';
+if (query === '@taptap/maker' && field === 'versions') {
+  console.log(JSON.stringify(Array.from(existing)));
+  process.exit(0);
+}
+if (query === '@taptap/maker' && field.startsWith('dist-tags.')) {
+  console.log(current);
+  process.exit(0);
+}
+const versionMatch = /^@taptap\\/maker@(.+)$/.exec(query);
+if (versionMatch && field === 'version') {
+  if (existing.has(versionMatch[1])) {
+    console.log(versionMatch[1]);
+    process.exit(0);
+  }
+  process.exit(1);
+}
+console.error('Unsupported npm view: ' + args.join(' '));
+process.exit(1);
+`,
+    'utf8'
+  );
+  chmodSync(npmPath, 0o755);
+  return binDir;
+}
+
+function runResolver(env: Record<string, string | undefined>) {
+  return spawnSync('node', [SCRIPT_PATH], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      ...env,
+      PATH: `${env.PATH}:${process.env.PATH || ''}`,
+    },
+    encoding: 'utf8',
+  });
+}
+
+describe('Maker publish version policy', () => {
+  it('rejects auto-last-number outside fix branches', () => {
+    const fakeBin = createFakeNpm('0.0.5');
+    const result = runResolver({
+      PATH: fakeBin,
+      MAKER_VERSION_MODE: 'auto-last-number',
+      MAKER_NPM_TAG: 'beta',
+      GITHUB_REF_NAME: 'feature/maker-release',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('auto-last-number mode is only allowed from fix/');
+  });
+
+  it('allows auto-last-number from fix branches', () => {
+    const fakeBin = createFakeNpm('0.0.5');
+    const result = runResolver({
+      PATH: fakeBin,
+      MAKER_VERSION_MODE: 'auto-last-number',
+      MAKER_NPM_TAG: 'beta',
+      GITHUB_REF_NAME: 'fix/maker-release',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Resolved @taptap/maker version: 0.0.6');
+  });
+
+  it('rejects auto-last-number when the current dist-tag is a prerelease', () => {
+    const fakeBin = createFakeNpm('0.0.5-beta.1');
+    const result = runResolver({
+      PATH: fakeBin,
+      MAKER_VERSION_MODE: 'auto-last-number',
+      MAKER_NPM_TAG: 'beta',
+      GITHUB_REF_NAME: 'fix/maker-release',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('auto-last-number requires a stable three-segment version');
+  });
+
+  it('allows manual major or minor changes after target confirmation', () => {
+    const fakeBin = createFakeNpm('0.0.5');
+    const result = runResolver({
+      PATH: fakeBin,
+      MAKER_VERSION_MODE: 'manual',
+      MAKER_MANUAL_VERSION: '0.1.0',
+      MAKER_CONFIRM_VERSION: '0.1.0',
+      MAKER_NPM_TAG: 'beta',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Current online @taptap/maker@beta version: 0.0.5');
+    expect(result.stdout.match(/Current online @taptap\/maker@beta version/g)).toHaveLength(1);
+    expect(result.stdout).toContain('Resolved @taptap/maker version: 0.1.0');
+    expect(result.stdout).toContain('Major/minor changed: true');
+  });
+
+  it('does not require previous online confirmation for manual patch changes', () => {
+    const fakeBin = createFakeNpm('0.0.5');
+    const result = runResolver({
+      PATH: fakeBin,
+      MAKER_VERSION_MODE: 'manual',
+      MAKER_MANUAL_VERSION: '0.0.6',
+      MAKER_CONFIRM_VERSION: '0.0.6',
+      MAKER_NPM_TAG: 'beta',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Resolved @taptap/maker version: 0.0.6');
+    expect(result.stdout).toContain('Major/minor changed: false');
+  });
+});

--- a/src/__tests__/releaseScope.test.ts
+++ b/src/__tests__/releaseScope.test.ts
@@ -1,0 +1,103 @@
+import { createRequire } from 'node:module';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const nodeRequire = createRequire(__filename);
+const releaseScope = nodeRequire('../../scripts/release-scope.cjs');
+
+describe('release-scope classifier', () => {
+  it('classifies Maker-owned files without classifying shared release files', () => {
+    expect(releaseScope.isMakerOwnedPath('src/maker/server/mcp.ts')).toBe(true);
+    expect(releaseScope.isMakerOwnedPath('packages/maker/package.json')).toBe(true);
+    expect(releaseScope.isMakerOwnedPath('src/__tests__/makerRuntimeLogs.test.ts')).toBe(true);
+    expect(releaseScope.isMakerOwnedPath('.github/workflows/release.yml')).toBe(false);
+    expect(releaseScope.isMakerOwnedPath('package.json')).toBe(false);
+  });
+
+  it('skips legacy release for Maker-only paths even if squash message lost the marker', () => {
+    const result = releaseScope.shouldSkipLegacyRelease({
+      files: ['src/maker/index.ts', 'skills/taptap-maker-local/SKILL.md'],
+      markerText: 'fix: repair local build',
+    });
+
+    expect(result.onlyMakerChanged).toBe(true);
+    expect(result.hasMakerMarker).toBe(false);
+    expect(result.skipLegacyRelease).toBe(true);
+  });
+
+  it('does not skip legacy release for mixed path changes even with marker', () => {
+    const result = releaseScope.shouldSkipLegacyRelease({
+      files: ['src/maker/index.ts', 'src/server.ts'],
+      markerText: 'fix(maker): update root entry',
+    });
+
+    expect(result.onlyMakerChanged).toBe(false);
+    expect(result.nonMakerFiles).toEqual(['src/server.ts']);
+    expect(result.skipLegacyRelease).toBe(false);
+  });
+
+  it('recognizes release infrastructure paths that intentionally span release ownership', () => {
+    const classification = releaseScope.classifyFiles([
+      '.github/workflows/claude-review.yml',
+      '.github/workflows/release.yml',
+      '.github/workflows/publish-maker.yml',
+      'scripts/release-scope.cjs',
+      'scripts/resolve-maker-version.js',
+      'src/__tests__/releaseScope.test.ts',
+      'src/__tests__/makerVersionPolicy.test.ts',
+      'CONTRIBUTING.md',
+      'README.md',
+      'docs/CI_CD.md',
+      'docs/MAKER.md',
+      'package.json',
+      'package-lock.json',
+      'src/__tests__/mainPackageManifest.test.ts',
+    ]);
+
+    expect(classification.hasMakerChanges).toBe(true);
+    expect(classification.hasNonMakerChanges).toBe(true);
+    expect(classification.onlyReleaseInfrastructureChanged).toBe(true);
+  });
+
+  it('uses three-dot diff to avoid base-only changes in PR scope detection', () => {
+    const repo = mkdtempSync(join(tmpdir(), 'release-scope-diff-'));
+    const git = (args: string[]) => execFileSync('git', args, { cwd: repo, encoding: 'utf8' });
+    const write = (file: string, content: string) =>
+      writeFileSync(join(repo, file), content, 'utf8');
+
+    git(['init', '-q', '-b', 'main']);
+    git(['config', 'user.email', 'test@example.com']);
+    git(['config', 'user.name', 'Test User']);
+    write('README.md', 'base\n');
+    git(['add', 'README.md']);
+    git(['commit', '-qm', 'chore: initial']);
+    const rootCommit = git(['rev-parse', 'HEAD']).trim();
+    git(['checkout', '-qb', 'maker']);
+    mkdirSync(join(repo, 'src/maker'), { recursive: true });
+    write('src/maker/index.ts', 'export {};\n');
+    git(['add', 'src/maker/index.ts']);
+    git(['commit', '-qm', 'fix(maker): maker change']);
+    git(['checkout', '-q', 'main']);
+    write('README.md', 'base\nmain only\n');
+    git(['commit', '-am', 'docs: main only']);
+    const base = git(['rev-parse', 'HEAD']).trim();
+    const head = git(['rev-parse', 'maker']).trim();
+    const originalCwd = process.cwd();
+
+    try {
+      process.chdir(repo);
+      expect(releaseScope.readCommitFiles(rootCommit)).toEqual(['README.md']);
+      expect(releaseScope.readChangedFiles(base, head, 'two-dot')).toEqual([
+        'README.md',
+        'src/maker/index.ts',
+      ]);
+      expect(releaseScope.readChangedFiles(base, head, 'three-dot')).toEqual([
+        'src/maker/index.ts',
+      ]);
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+});

--- a/src/__tests__/releaseScopeCli.test.ts
+++ b/src/__tests__/releaseScopeCli.test.ts
@@ -1,0 +1,125 @@
+import { createRequire } from 'node:module';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const nodeRequire = createRequire(__filename);
+const { evaluatePushScope, isZeroSha, readFilesForMode, validatePrScope } = nodeRequire(
+  '../../scripts/check-release-scope.cjs'
+);
+
+describe('release scope PR guard', () => {
+  it('accepts Maker-only PRs with the maker marker', () => {
+    const result = validatePrScope({
+      files: ['src/maker/index.ts'],
+      title: 'fix(maker): harden local init',
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects Maker-only PRs without the maker marker', () => {
+    const result = validatePrScope({
+      files: ['src/maker/index.ts'],
+      title: 'fix: harden local init',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('must include `(maker)`');
+  });
+
+  it('rejects maker-marked PRs with shared files', () => {
+    const result = validatePrScope({
+      files: ['src/maker/index.ts', 'package.json'],
+      title: 'fix(maker): update package metadata',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('separate PRs');
+  });
+
+  it('rejects mixed Maker and main package paths even without maker marker', () => {
+    const result = validatePrScope({
+      files: ['src/maker/index.ts', 'src/server.ts'],
+      title: 'fix(server): change shared startup',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('separate PRs');
+  });
+
+  it('allows release infrastructure PRs to update both release ownership surfaces', () => {
+    const result = validatePrScope({
+      files: [
+        '.github/workflows/release.yml',
+        '.github/workflows/publish-maker.yml',
+        'scripts/release-scope.cjs',
+        'scripts/resolve-maker-version.js',
+        'CONTRIBUTING.md',
+        'README.md',
+        'docs/CI_CD.md',
+        'docs/MAKER.md',
+      ],
+      title: 'ci(release): isolate maker package publishing',
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('allows release infrastructure PRs that only touch Maker release workflow files', () => {
+    const result = validatePrScope({
+      files: ['.github/workflows/publish-maker.yml'],
+      title: 'ci(release): tune maker publish workflow',
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('skips legacy release for Maker-only push changes without relying on marker text', () => {
+    const result = evaluatePushScope({
+      files: ['src/maker/index.ts', 'skills/taptap-maker-local/SKILL.md'],
+      markerText: 'fix: harden local init',
+    });
+
+    expect(result.skipLegacyRelease).toBe(true);
+  });
+
+  it('detects all-zero push before sha values', () => {
+    expect(isZeroSha('0000000000000000000000000000000000000000')).toBe(true);
+    expect(isZeroSha('1000000000000000000000000000000000000000')).toBe(false);
+  });
+
+  it('reads the full head tree for all-zero push before sha values', () => {
+    const repo = mkdtempSync(join(tmpdir(), 'release-scope-zero-push-'));
+    const git = (args: string[]) => execFileSync('git', args, { cwd: repo, encoding: 'utf8' });
+    const write = (file: string, content: string) =>
+      writeFileSync(join(repo, file), content, 'utf8');
+
+    git(['init', '-q', '-b', 'main']);
+    git(['config', 'user.email', 'test@example.com']);
+    git(['config', 'user.name', 'Test User']);
+    mkdirSync(join(repo, 'src/maker'), { recursive: true });
+    write('src/maker/index.ts', 'export {};\n');
+    git(['add', 'src/maker/index.ts']);
+    git(['commit', '-qm', 'fix(maker): add maker file']);
+    write('src/server.ts', 'export {};\n');
+    git(['add', 'src/server.ts']);
+    git(['commit', '-qm', 'fix(server): add server file']);
+    const head = git(['rev-parse', 'HEAD']).trim();
+    const originalCwd = process.cwd();
+
+    try {
+      process.chdir(repo);
+      expect(
+        readFilesForMode({
+          mode: 'push',
+          base: '0000000000000000000000000000000000000000',
+          head,
+        }).sort()
+      ).toEqual(['src/maker/index.ts', 'src/server.ts']);
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+});

--- a/src/__tests__/semanticReleaseMainAnalyzer.test.ts
+++ b/src/__tests__/semanticReleaseMainAnalyzer.test.ts
@@ -1,0 +1,63 @@
+import { createRequire } from 'node:module';
+
+const nodeRequire = createRequire(__filename);
+
+jest.mock('@semantic-release/commit-analyzer', () => ({
+  analyzeCommits: jest.fn(),
+}));
+
+jest.mock('node:child_process', () => ({
+  execFileSync: jest.fn((command, args) => {
+    const commit = args[args.length - 1];
+    if (commit === 'maker-sha') {
+      return 'src/maker/index.ts\nskills/taptap-maker-local/SKILL.md\n';
+    }
+    if (commit === 'mixed-sha') {
+      return 'src/maker/index.ts\nsrc/server.ts\n';
+    }
+    return 'src/features/app/tools.ts\n';
+  }),
+}));
+
+const analyzer = nodeRequire('../../scripts/semantic-release-main-analyzer.cjs');
+
+describe('semantic-release main analyzer wrapper', () => {
+  const logger = { log: jest.fn() };
+
+  beforeEach(() => {
+    logger.log.mockClear();
+  });
+
+  it('filters Maker-only commits without relying on the squash message marker', () => {
+    const commits = [
+      {
+        hash: 'maker-sha',
+        subject: 'feat: add init shortcut',
+        message: 'feat: add init shortcut',
+      },
+      {
+        hash: 'main-sha',
+        subject: 'fix(app): improve app selection',
+        message: 'fix(app): improve app selection',
+      },
+    ];
+
+    const filtered = analyzer.filterMainPackageCommits(commits, logger);
+
+    expect(filtered).toEqual([commits[1]]);
+  });
+
+  it('keeps maker-marked commits that touch shared files', () => {
+    const commits = [
+      {
+        hash: 'mixed-sha',
+        subject: 'feat(maker): update root exports',
+        message: 'feat(maker): update root exports',
+      },
+    ];
+
+    const filtered = analyzer.filterMainPackageCommits(commits, logger);
+
+    expect(filtered).toEqual(commits);
+  });
+});


### PR DESCRIPTION
## 改动内容
- 隔离主包 release 和 Maker package 发布流程
- Maker-only PR 需要标题带 `(maker)`，并且不能混改主包/共享路径
- 主包 release 按 Maker-only paths 跳过主包发布，并过滤 Maker-only commits
- Maker 包发布改为独立 workflow，manual 版本确认不再手填线上版本，改为 Summary 展示线上 dist-tag 后人工审批
- Maker auto-last-number 仅允许 fix/* 分支递增末位版本号

## 验证
- npm run lint
- npm run format:check
- npm run build
- npm test -- --runInBand
- semantic-release dry-run
- workflow YAML parse