### PR TITLE
ci(release): disable automatic main package publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,9 @@
-name: Auto Release (via PR)
+name: Manual Main Package Release
 
-# 通过自动 PR 实现完全自动化的发布流程
+# 主包 npm 发布必须手动触发，不能由 main/beta/alpha push 或 PR merge 自动触发。
 # Native signer 按需编译：只有 native/ 目录有变更时才重新构建
 
 on:
-  push:
-    branches:
-      - main
-      - beta
-      - alpha
   workflow_dispatch:
 
 permissions:
@@ -77,11 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: scope
     if: |
-      github.event_name == 'workflow_dispatch' ||
-      (needs.scope.outputs.skip_legacy_release != 'true' &&
-       github.event.head_commit != null &&
-       !contains(github.event.head_commit.message, '[skip ci]') &&
-       github.event.head_commit.author.name != 'github-actions[bot]')
+      github.event_name == 'workflow_dispatch'
     outputs:
       should_release: ${{ steps.analyze.outputs.should_release }}
       version: ${{ steps.analyze.outputs.version }}
@@ -403,6 +394,7 @@ jobs:
     # 只要 analyze 说要发布，且 build-native 或 download-native 其中一个成功
     if: |
       always() &&
+      github.event_name == 'workflow_dispatch' &&
       github.ref_name != 'beta' &&
       needs.analyze.outputs.should_release == 'true' &&
       (needs.build-native.result == 'success' || needs.download-native.result == 'success')
@@ -586,7 +578,7 @@ jobs:
             --title "chore(release): ${VERSION} [skip ci]" \
             --body "## 📦 Release ${VERSION}
 
-          此 PR 由自动发布流程创建。
+          此 PR 由手动主包发布流程创建。
 
           ### 变更内容
           - ✅ 版本号: ${VERSION}
@@ -727,6 +719,7 @@ jobs:
     # beta 不创建 release PR，不写回 package.json / CHANGELOG.md。
     if: |
       always() &&
+      github.event_name == 'workflow_dispatch' &&
       github.ref_name == 'beta' &&
       needs.analyze.outputs.should_release == 'true' &&
       (needs.build-native.result == 'success' || needs.download-native.result == 'success')

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,13 +102,14 @@ Closes #123
 
 - ❌ **不要直接 commit 到 main 分支**（已配置分支保护）
 - ✅ **创建 feature/fix 分支** → 提交代码 → 创建 PR
-- ✅ **PR 合并后自动触发发布**（由 semantic-release 处理）
+- ❌ **PR 合并后不会自动发布 npm**
+- ✅ **主包 npm 发布只能手动运行 GitHub Actions workflow**
 
 **工作流程：**
 
 ```
 feature 分支开发 → git commit (规范格式) → git push → 创建 PR
-→ CI 检查 → Code Review → Merge PR → 自动发布 → 更新文档
+→ CI 检查 → Code Review → Merge PR → 需要发布时人工触发 workflow → 更新文档
 ```
 
 ### Git 工作区保护规则 ⚠️
@@ -549,7 +550,7 @@ const allModules = [..., yourFeatureModule];
 
 - **完整架构**：[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) - 模块化架构、设计模式、认证机制
 - **部署指南**：[docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) - 三种传输协议、环境变量、MCP 集成配置
-- **CI/CD 流程**：[docs/CI_CD.md](docs/CI_CD.md) - GitHub Flow、Semantic Release、自动发布
+- **CI/CD 流程**：[docs/CI_CD.md](docs/CI_CD.md) - GitHub Flow、Semantic Release、手动发布
 - **路径解析**：[docs/PATH_RESOLUTION.md](docs/PATH_RESOLUTION.md) - 路径处理问题、最佳实践
 
 ### Proxy 相关文档

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -1,6 +1,7 @@
-# CI/CD 和自动化发布
+# CI/CD 和发布
 
-本文档说明 TapTap MCP Server 的 CI/CD 流程和自动化发布机制。
+本文档说明 TapTap MCP Server 的 CI/CD 流程和发布机制。主包 npm 发布不允许由 PR
+合并或分支 push 自动触发，必须由人工在 GitHub Actions 页面手动运行 workflow。
 
 ## 目录
 
@@ -18,22 +19,21 @@
 
 ## 1. 概述
 
-项目采用 **GitHub Flow + Semantic Release** 实现完全自动化的版本管理和发布流程。
+项目采用 **GitHub Flow + Semantic Release** 管理版本分析和发布产物，但主包 npm
+发布入口必须手动触发。
 
 ### 核心特性
 
 - ✅ 基于 Conventional Commits 自动计算版本号
 - ✅ 自动生成 CHANGELOG.md
-- ✅ 自动发布到 npm
+- ✅ 人工触发后发布到 npm
 - ✅ 自动创建 GitHub Release
 - ✅ 完整的 PR 检查（lint、build、test、commitlint）
 
 ### 发布流程图
 
 ```
-Feature PR 合并到 main
-    ↓
-触发 GitHub Actions
+人工运行主包发布 workflow
     ↓
 分析 commits（semantic-release dry-run）
     ↓
@@ -47,7 +47,7 @@ Feature PR 合并到 main
     ↓
 自动创建 PR（release → main）
     ↓
-自动合并 PR（符合 trunk-guard 规则）
+创建 release PR
     ↓
 创建 GitHub Release
 ```
@@ -73,16 +73,17 @@ main          # 稳定版本（1.2.3）- 受保护
 - PR 必须通过所有 CI 检查
 - Commit 消息必须符合 Conventional Commits 规范
 
-### 自动发布机制
+### 主包发布机制
 
-1. **Feature PR 合并** → 触发 GitHub Actions
+主包自动发布已禁用。PR 合并到 `main`、`beta` 或 `alpha` 不会自动发布 npm。
+
+1. **人工触发 workflow** → 在 GitHub Actions 页面运行主包发布 workflow
 2. **分析 commits** → 确定版本号（semantic-release dry-run）
 3. **创建 release 分支** → `release/vX.X.X`
 4. **发布到 npm** → 在 release 分支更新版本
 5. **生成 CHANGELOG** → 自动生成版本说明
 6. **自动创建 PR** → release 分支 → main
-7. **自动合并 PR** → 符合 trunk-guard 要求
-8. **创建 GitHub Release** → 添加 tag 和 release notes
+7. **创建 GitHub Release** → 添加 tag 和 release notes
 
 ---
 
@@ -106,7 +107,7 @@ git push origin feature/awesome-feature
 # 4. 在 GitHub 创建 PR
 # 5. 等待 CI 检查通过
 # 6. 请求 Code Review
-# 7. 合并后自动触发发布
+# 7. 合并后不会自动发布 npm；需要发布时人工运行 GitHub Actions workflow
 # 版本变更：1.2.0 → 1.3.0 (minor)
 ```
 
@@ -122,7 +123,7 @@ git commit -m "fix: resolve critical security issue"
 # 3. Push 并创建 PR
 git push origin fix/critical-bug
 
-# 4. 合并后自动发布
+# 4. 合并后不会自动发布 npm；需要发布时人工运行 GitHub Actions workflow
 # 版本变更：1.2.0 → 1.2.1 (patch)
 ```
 
@@ -143,10 +144,10 @@ git merge origin/main
 git merge feature/feature-a
 git merge feature/feature-b
 
-# 3. 推送到远程，触发 Beta Release
+# 3. 推送到远程 beta 分支
 git push origin beta
 
-# 4. 自动发布 beta 版本到 npm @beta
+# 4. 需要发布 beta 时，人工运行 release workflow 并选择 beta 分支
 # 版本：1.3.0-beta.1
 
 # 5. 用户安装 beta 版本
@@ -154,7 +155,7 @@ npm install @taptap/instant-games-open-mcp@beta
 npx -y @taptap/instant-games-open-mcp@beta
 
 # 6. 测试稳定后，通过 PR 将对应功能分支合并到 main
-# 7. main 合并后走正式发布流程
+# 7. main 合并后不会自动发布；需要正式发布时人工运行 workflow
 # 版本：1.3.0
 ```
 
@@ -302,11 +303,11 @@ npm test          # 测试
 npx commitlint --from HEAD~1 --to HEAD
 ```
 
-### 5.2 自动发布工作流
+### 5.2 主包手动发布工作流
 
 **文件**：`.github/workflows/release.yml`
 
-**触发条件**：PR 合并到 `main` / `alpha` 分支后自动运行
+**触发条件**：只能手动运行 `workflow_dispatch`
 
 > `beta` 使用同一个 `.github/workflows/release.yml` 中的独立 beta job，
 > 复用 npm Trusted Publishing 配置，但不会创建 release PR 或影响 `main` 正式发版流程。
@@ -333,7 +334,7 @@ npx commitlint --from HEAD~1 --to HEAD
 
 **文件**：`.github/workflows/release.yml` 中的 `beta-release` job
 
-**触发条件**：推送到 `beta` 分支，或手动运行 workflow
+**触发条件**：手动运行 workflow，并选择 `beta` 分支
 
 **执行步骤**：
 
@@ -386,7 +387,7 @@ npx commitlint --from HEAD~1 --to HEAD
 
 - 不走旧包的 semantic-release。
 - Maker-only PR 必须带 `(maker)` scope，且只能修改 Maker-owned paths。
-- 旧包 release workflow 会按 Maker-only paths 跳过主包发布。
+- 主包 release workflow 不会由 Maker PR 合并自动触发。
 - 旧包 semantic-release 分析、CHANGELOG 和 GitHub Release notes 会过滤 Maker-only commits。
 - 手动版本号必须二次确认。
 - Maker 包只能从长期发布分支 `beta` 或 `main` 发布；`fix/*` 分支只用于提交 PR，
@@ -486,7 +487,7 @@ module.exports = {
 ### 6.3 GitHub Actions 工作流
 
 **PR 检查**：`.github/workflows/pr.yml`
-**自动发布**：`.github/workflows/release.yml`
+**主包手动发布**：`.github/workflows/release.yml`
 
 ---
 
@@ -589,9 +590,9 @@ npx semantic-release --dry-run
 - **Minor 版本（1.X.0）**：向后兼容的功能性新增
 - **Patch 版本（1.0.X）**：向后兼容的问题修正
 
-### 9.2 版本号自动化
+### 9.2 版本号计算
 
-- ✅ 版本号完全自动化，**不需要手动修改** `package.json`
+- ✅ 版本号由 workflow 计算，**不需要手动修改** `package.json`
 - ✅ 由 semantic-release 根据 commit 历史自动计算
 - ❌ 不要手动修改版本号
 
@@ -605,19 +606,19 @@ git switch beta || git switch -c beta origin/main
 git merge origin/main
 git merge feature/feature-a
 git push origin beta
-# 自动发布：1.3.0-beta.1
+# 需要发布时人工运行 release workflow 并选择 beta 分支：1.3.0-beta.1
 npm install @taptap/instant-games-open-mcp@beta
 ```
 
 Beta 发布只用于内部预览测试。测试通过后，应将对应 feature/fix 分支通过 PR 合并到
-`main`，由正式 release workflow 发布 `latest`。
+`main`，需要正式发布时人工运行 release workflow 发布 `latest`。
 
 **Alpha 版本**（早期测试）：
 
 ```bash
 git checkout -b alpha
 git push origin alpha
-# 自动发布：1.3.0-alpha.1
+# 不会自动发布；需要发布时人工运行 release workflow
 npm install @taptap/instant-games-open-mcp@alpha
 ```
 
@@ -626,7 +627,7 @@ npm install @taptap/instant-games-open-mcp@alpha
 ```bash
 git checkout -b next
 git push origin next
-# 自动发布：2.0.0-next.1
+# 不会自动发布；需要发布时人工运行 release workflow
 npm install @taptap/instant-games-open-mcp@next
 ```
 
@@ -643,7 +644,7 @@ git push origin 1.x
 git checkout 1.x
 git commit -m "fix: security patch"
 git push origin 1.x
-# 自动发布：1.5.1
+# 不会自动发布；需要发布时人工运行 release workflow
 ```
 
 ---

--- a/docs/OPENCLAW_PLUGIN.md
+++ b/docs/OPENCLAW_PLUGIN.md
@@ -54,12 +54,12 @@ packages/openclaw-dc-plugin/
 
 ## 当前发布现状
 
-当前仓库的 GitHub release workflow 只会自动发布主包：
+当前仓库的 GitHub release workflow 只支持手动发布主包：
 
 - 根包 `package.json`
 - 根目录 `npm publish`
 
-`packages/openclaw-dc-plugin` 目前还没有接入独立自动发布流水线，所以：
+`packages/openclaw-dc-plugin` 目前还没有接入独立发布流水线，所以：
 
 - 提 PR / merge PR 不会自动把 plugin 发布到 npm
 - 当前阶段建议先手工发布一次，验证 OpenClaw 安装链路


### PR DESCRIPTION
## Summary

- Disable push-triggered main package release workflow.
- Require workflow_dispatch on release publish jobs as defense in depth.
- Update repository guidance to state PR merges do not publish npm.

## Verification

- git diff --check
- npx prettier --check .github/workflows/release.yml AGENTS.md docs/CI_CD.md docs/OPENCLAW_PLUGIN.md
- node check confirmed release.yml has no push trigger and publish jobs require workflow_dispatch

## Release safety

This PR is intended to stop PR merges and branch pushes from automatically publishing @taptap/instant-games-open-mcp to npm.