### PR TITLE
ci(release): simplify manual package publishing

### DIFF
--- a/.github/workflows/publish-maker.yml
+++ b/.github/workflows/publish-maker.yml
@@ -6,17 +6,13 @@ on:
       version_mode:
         description: 'Version mode: run from main or beta; auto increments only the final numeric segment'
         required: true
-        default: manual
+        default: auto-last-number
         type: choice
         options:
-          - manual
           - auto-last-number
+          - manual
       version:
         description: 'Manual @taptap/maker version, for example 0.0.1-beta.1 or 0.0.1'
-        required: false
-        type: string
-      confirm_version:
-        description: 'Required in manual mode: enter the exact same version again'
         required: false
         type: string
       tag:
@@ -58,7 +54,6 @@ jobs:
         env:
           MAKER_VERSION_MODE: ${{ inputs.version_mode }}
           MAKER_MANUAL_VERSION: ${{ inputs.version }}
-          MAKER_CONFIRM_VERSION: ${{ inputs.confirm_version }}
           MAKER_NPM_TAG: ${{ inputs.tag }}
 
       - name: Approval summary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ name: Manual Main Package Release
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Optional target version. Leave empty to auto increment only z from npm latest.'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -66,16 +71,36 @@ jobs:
           echo "The main package \`@taptap/instant-games-open-mcp\` was not released." >> "$GITHUB_STEP_SUMMARY"
           echo "Use the \`Publish Maker Package\` workflow to publish \`@taptap/maker\`." >> "$GITHUB_STEP_SUMMARY"
 
-  # ========== 阶段 1: 分析是否需要发布 + 检测 native 变更 ==========
+  unsupported-branch:
+    name: Unsupported Release Branch
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' &&
+      github.ref_name != 'main'
+
+    steps:
+      - name: Summary
+        run: |
+          echo "## Unsupported release branch" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "The main package latest release workflow can only run from \`main\`." >> "$GITHUB_STEP_SUMMARY"
+          echo "Current branch: \`${{ github.ref_name }}\`" >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+
+  # ========== 阶段 1: 解析版本 + 检测 native 变更 ==========
   analyze:
-    name: Analyze Release
+    name: Resolve Release
     runs-on: ubuntu-latest
     needs: scope
     if: |
-      github.event_name == 'workflow_dispatch'
+      github.event_name == 'workflow_dispatch' &&
+      github.ref_name == 'main'
     outputs:
-      should_release: ${{ steps.analyze.outputs.should_release }}
-      version: ${{ steps.analyze.outputs.version }}
+      should_release: ${{ steps.version.outputs.should_release }}
+      version: ${{ steps.version.outputs.version }}
+      current_version: ${{ steps.version.outputs.current_version }}
+      major_minor_changed: ${{ steps.version.outputs.major_minor_changed }}
+      version_mode: ${{ steps.version.outputs.mode }}
       native_changed: ${{ steps.native_check.outputs.changed }}
       has_native_assets: ${{ steps.release_check.outputs.has_assets }}
 
@@ -94,28 +119,25 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Analyze commits for release
-        id: analyze
+      - name: Resolve main package version
+        id: version
+        run: node scripts/resolve-main-release-version.js
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # 告知 .releaserc.cjs 禁用 npm 发布验证（实际发布由 OIDC 处理）
-          SEMANTIC_RELEASE_DRY_RUN: 'true'
+          MAIN_MANUAL_VERSION: ${{ inputs.version }}
+
+      - name: Approval summary
         run: |
-          # set -o pipefail 确保 semantic-release 失败时（含认证错误）整个管道返回非零退出码
-          # 注意：不能用 grep 检测错误关键词，因为 semantic-release 分析 commit 时会打印 commit body，
-          # 如果 commit message 中包含错误关键词（如 EINVALIDNPMTOKEN）会导致误匹配
-          set -o pipefail
-          npx semantic-release --dry-run --no-ci 2>&1 | tee release-output.txt
-
-          NEW_VERSION=$(grep "\[semantic-release\] .* The next release version is" release-output.txt | sed 's/.*is //' || echo "")
-
-          if [ -z "$NEW_VERSION" ]; then
-            echo "should_release=false" >> $GITHUB_OUTPUT
-            echo "No release needed"
-          else
-            echo "should_release=true" >> $GITHUB_OUTPUT
-            echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
-            echo "Will release version: $NEW_VERSION"
+          echo "## Main package publish preflight" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- package: \`@taptap/instant-games-open-mcp\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- dist-tag: \`latest\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- mode: \`${{ steps.version.outputs.mode }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- current online version: \`${{ steps.version.outputs.current_version }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- target version: \`${{ steps.version.outputs.version }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- major/minor changed: \`${{ steps.version.outputs.major_minor_changed }}\`" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.version.outputs.major_minor_changed }}" = "true" ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "Major/minor changed. Review the current online version and target version above, then approve the protected publish job to continue." >> "$GITHUB_STEP_SUMMARY"
           fi
 
       # 检测 native/ 目录是否有变更
@@ -395,7 +417,7 @@ jobs:
     if: |
       always() &&
       github.event_name == 'workflow_dispatch' &&
-      github.ref_name != 'beta' &&
+      github.ref_name == 'main' &&
       needs.analyze.outputs.should_release == 'true' &&
       (needs.build-native.result == 'success' || needs.download-native.result == 'success')
 
@@ -449,45 +471,9 @@ jobs:
       - name: Resolve release package version
         id: release_version
         run: |
-          CURRENT_VERSION="${{ needs.analyze.outputs.version }}"
-
-          if ! npm view "@taptap/instant-games-open-mcp@${CURRENT_VERSION}" version >/dev/null 2>&1; then
-            echo "version=${CURRENT_VERSION}" >> "$GITHUB_OUTPUT"
-            echo "semantic_version=${CURRENT_VERSION}" >> "$GITHUB_OUTPUT"
-            echo "Using semantic-release version: ${CURRENT_VERSION}"
-            exit 0
-          fi
-
-          if [[ "$CURRENT_VERSION" == *-* ]]; then
-            echo "Expected stable release version, got prerelease: ${CURRENT_VERSION}"
-            exit 1
-          fi
-
-          VERSIONS_JSON="$(npm view "@taptap/instant-games-open-mcp" versions --json)"
-          RESOLVED_VERSION="$(
-            CURRENT_VERSION="$CURRENT_VERSION" VERSIONS_JSON="$VERSIONS_JSON" node -e '
-              const versions = JSON.parse(process.env.VERSIONS_JSON || "[]");
-              const current = process.env.CURRENT_VERSION || "";
-              const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(current);
-              if (!match) {
-                throw new Error(`Invalid stable version: ${current}`);
-              }
-              const [, major, minor, patch] = match;
-              const pattern = new RegExp(`^${major}\\.${minor}\\.(\\d+)$`);
-              let maxPatch = Number(patch);
-              for (const version of versions) {
-                const versionMatch = pattern.exec(version);
-                if (versionMatch) {
-                  maxPatch = Math.max(maxPatch, Number(versionMatch[1]));
-                }
-              }
-              console.log(`${major}.${minor}.${maxPatch + 1}`);
-            '
-          )"
-
-          echo "version=${RESOLVED_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "semantic_version=${CURRENT_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "semantic-release proposed ${CURRENT_VERSION}, already exists; using ${RESOLVED_VERSION}"
+          VERSION="${{ needs.analyze.outputs.version }}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Using manually resolved version: ${VERSION}"
 
       # 创建 Release 分支
       - name: Create release branch
@@ -671,16 +657,12 @@ jobs:
       - name: Release summary
         run: |
           VERSION=${{ steps.release_version.outputs.version }}
-          SEMANTIC_VERSION=${{ steps.release_version.outputs.semantic_version }}
           NATIVE_CHANGED=${{ needs.analyze.outputs.native_changed }}
           HAS_ASSETS=${{ needs.analyze.outputs.has_native_assets }}
 
           echo "## 🎉 Release Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "✅ 版本: ${VERSION}" >> $GITHUB_STEP_SUMMARY
-          if [ "$SEMANTIC_VERSION" != "$VERSION" ]; then
-            echo "ℹ️ semantic-release 原始版本: ${SEMANTIC_VERSION}" >> $GITHUB_STEP_SUMMARY
-          fi
 
           if [ "$NATIVE_CHANGED" == "true" ]; then
             echo "🔨 Native Signer: 重新构建 (native 代码有变更)" >> $GITHUB_STEP_SUMMARY
@@ -705,231 +687,6 @@ jobs:
           echo "查看详情：" >> $GITHUB_STEP_SUMMARY
           echo "- npm: https://www.npmjs.com/package/@taptap/instant-games-open-mcp/v/${VERSION}" >> $GITHUB_STEP_SUMMARY
           echo "- GitHub: https://github.com/${{ github.repository }}/releases/tag/v${VERSION}" >> $GITHUB_STEP_SUMMARY
-
-  # ========== Beta 预览发布 ==========
-  beta-release:
-    name: Beta Release
-    runs-on: ubuntu-latest
-    environment: npm_publish
-    permissions:
-      contents: write
-      id-token: write
-    needs: [analyze, build-native, download-native]
-    # 复用同一个 workflow 文件，避免 npm Trusted Publishing 需要新增 publisher 配置。
-    # beta 不创建 release PR，不写回 package.json / CHANGELOG.md。
-    if: |
-      always() &&
-      github.event_name == 'workflow_dispatch' &&
-      github.ref_name == 'beta' &&
-      needs.analyze.outputs.should_release == 'true' &&
-      (needs.build-native.result == 'success' || needs.download-native.result == 'success')
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 'lts/*'
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Download native binaries
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-
-      - name: Move native binaries to native/
-        run: |
-          mkdir -p native
-          find artifacts -name "*.node" -exec cp {} native/ \;
-
-          echo "=== Native binaries ==="
-          ls -la native/*.node
-
-      - name: Lint code
-        run: npm run lint
-
-      - name: Check code formatting
-        run: npm run format:check
-
-      - name: Resolve beta package version
-        id: beta_version
-        run: |
-          CURRENT_VERSION="${{ needs.analyze.outputs.version }}"
-          BASE_VERSION="${CURRENT_VERSION%%-beta.*}"
-          if [ "$BASE_VERSION" = "$CURRENT_VERSION" ]; then
-            echo "Expected beta prerelease version, got: ${CURRENT_VERSION}"
-            exit 1
-          fi
-
-          LATEST_STABLE="$(npm view "@taptap/instant-games-open-mcp" dist-tags.latest 2>/dev/null || echo "")"
-          RESOLVED_BASE="$(
-            BASE_VERSION="$BASE_VERSION" LATEST_STABLE="$LATEST_STABLE" node -e '
-              const base = process.env.BASE_VERSION;
-              const latest = process.env.LATEST_STABLE;
-              const parse = (value) => {
-                const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(value || "");
-                return match ? match.slice(1).map(Number) : null;
-              };
-              const baseParts = parse(base);
-              const latestParts = parse(latest);
-              if (!baseParts || !latestParts) {
-                console.log(base);
-                process.exit(0);
-              }
-              const cmp =
-                baseParts[0] - latestParts[0] ||
-                baseParts[1] - latestParts[1] ||
-                baseParts[2] - latestParts[2];
-              if (cmp <= 0) {
-                console.log(`${latestParts[0]}.${latestParts[1]}.${latestParts[2] + 1}`);
-              } else {
-                console.log(base);
-              }
-            '
-          )"
-
-          VERSIONS_JSON="$(npm view "@taptap/instant-games-open-mcp" versions --json)"
-          RESOLVED_VERSION="$(
-            BASE_VERSION="$RESOLVED_BASE" VERSIONS_JSON="$VERSIONS_JSON" node -e '
-              const versions = JSON.parse(process.env.VERSIONS_JSON || "[]");
-              const base = process.env.BASE_VERSION;
-              const escapedBase = base.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-              const pattern = new RegExp(`^${escapedBase}-beta\\.(\\d+)$`);
-              let max = 0;
-              for (const version of versions) {
-                const match = pattern.exec(version);
-                if (match) {
-                  max = Math.max(max, Number(match[1]));
-                }
-              }
-              console.log(`${base}-beta.${max + 1}`);
-            '
-          )"
-
-          echo "version=${RESOLVED_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "semantic_version=${CURRENT_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "semantic-release proposed ${CURRENT_VERSION}; latest stable is ${LATEST_STABLE}; using ${RESOLVED_VERSION}"
-
-      - name: Set beta package version
-        run: npm version "${{ steps.beta_version.outputs.version }}" --no-git-tag-version
-
-      - name: Build package
-        run: npm run build
-
-      - name: Verify native binaries in package output
-        run: |
-          test -d dist/native
-          test "$(find dist/native -name "*.node" | wc -l | tr -d ' ')" -gt 0
-          find dist/native -maxdepth 1 -name "*.node" -print
-
-      - name: Run tests
-        run: npm test
-
-      - name: Pack beta tarball
-        id: pack
-        run: |
-          TARBALL_DIR="$(mktemp -d)"
-          npm pack --pack-destination "$TARBALL_DIR"
-          TARBALL="$(find "$TARBALL_DIR" -name "*.tgz" -print -quit)"
-
-          if [ -z "$TARBALL" ]; then
-            echo "Failed to create npm tarball"
-            exit 1
-          fi
-
-          echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
-          echo "Packed beta tarball: $TARBALL"
-
-      - name: Publish beta to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          VERSION="${{ steps.beta_version.outputs.version }}"
-          TARBALL="${{ steps.pack.outputs.tarball }}"
-
-          if npm view "@taptap/instant-games-open-mcp@${VERSION}" version >/dev/null 2>&1; then
-            echo "Resolved beta version ${VERSION} already exists on npm"
-            exit 1
-          fi
-
-          npm publish "$TARBALL" --access public --tag beta --provenance 2>/dev/null \
-            || npm publish "$TARBALL" --access public --tag beta
-
-      - name: Create prerelease tag
-        run: |
-          VERSION="${{ steps.beta_version.outputs.version }}"
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          if git ls-remote --tags origin "v${VERSION}" | grep -q "refs/tags/v${VERSION}$"; then
-            echo "Tag v${VERSION} already exists"
-          else
-            git tag -a "v${VERSION}" -m "Beta release v${VERSION}"
-            git push origin "v${VERSION}"
-          fi
-
-      - name: Create GitHub prerelease
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION="${{ steps.beta_version.outputs.version }}"
-          TARBALL="${{ steps.pack.outputs.tarball }}"
-
-          if gh release view "v${VERSION}" >/dev/null 2>&1; then
-            echo "GitHub release v${VERSION} already exists"
-          else
-            gh release create "v${VERSION}" \
-              --prerelease \
-              --title "v${VERSION}" \
-              --notes "Internal beta release from \`${GITHUB_REF_NAME}\`." \
-              native/*.node \
-              "$TARBALL"
-          fi
-
-      - name: Beta release summary
-        run: |
-          VERSION="${{ steps.beta_version.outputs.version }}"
-          SEMANTIC_VERSION="${{ steps.beta_version.outputs.semantic_version }}"
-          NATIVE_CHANGED="${{ needs.analyze.outputs.native_changed }}"
-          HAS_ASSETS="${{ needs.analyze.outputs.has_native_assets }}"
-
-          echo "## Beta Release Summary" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Version: ${VERSION}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Semantic-release version: ${SEMANTIC_VERSION}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- npm dist-tag: beta" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Native changed: ${NATIVE_CHANGED}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Reused native assets: ${HAS_ASSETS}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Install: \`npm install @taptap/instant-games-open-mcp@beta\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Run: \`npx -y @taptap/instant-games-open-mcp@beta\`" >> "$GITHUB_STEP_SUMMARY"
-
-  beta-native-unavailable:
-    name: Beta Native Signer Unavailable
-    runs-on: ubuntu-latest
-    needs: [analyze, build-native, download-native]
-    if: |
-      always() &&
-      github.ref_name == 'beta' &&
-      needs.analyze.outputs.should_release == 'true' &&
-      needs.build-native.result != 'success' &&
-      needs.download-native.result != 'success'
-
-    steps:
-      - name: Summary
-        run: |
-          echo "## Native Signer Unavailable" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Beta package was not published because native signer binaries could not be prepared." >> "$GITHUB_STEP_SUMMARY"
-          exit 1
 
   # ========== 无需发布 ==========
   no-release:

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -35,7 +35,7 @@
 ```
 人工运行主包发布 workflow
     ↓
-分析 commits（semantic-release dry-run）
+读取 npm latest 并解析目标版本
     ↓
 创建 release 分支（release/vX.X.X）
     ↓
@@ -78,7 +78,7 @@ main          # 稳定版本（1.2.3）- 受保护
 主包自动发布已禁用。PR 合并到 `main`、`beta` 或 `alpha` 不会自动发布 npm。
 
 1. **人工触发 workflow** → 在 GitHub Actions 页面运行主包发布 workflow
-2. **分析 commits** → 确定版本号（semantic-release dry-run）
+2. **解析版本** → 留空时基于 npm `latest` 只递增 patch
 3. **创建 release 分支** → `release/vX.X.X`
 4. **发布到 npm** → 在 release 分支更新版本
 5. **生成 CHANGELOG** → 自动生成版本说明
@@ -127,46 +127,36 @@ git push origin fix/critical-bug
 # 版本变更：1.2.0 → 1.2.1 (patch)
 ```
 
-### 3.3 发布 Beta 版本
+### 3.3 发布 Maker Beta 版本
 
-Beta 用于内部预览测试，走独立的 npm `@beta` dist-tag，不会创建 release PR，
+Maker Beta 用于内部预览测试，走 `@taptap/maker@beta` dist-tag，不会创建 release PR，
 也不会把 `package.json` / `CHANGELOG.md` 的版本变更写回仓库。
 注意：npm 包仍发布到 public registry，`@beta` 不是访问控制；beta 包必须按对外发布标准处理，
 不能包含 RND 凭证、内部账号 Token 或未公开的敏感配置。
 
 ```bash
-# 1. 切换到长期 beta 分支（不存在时从 origin/main 创建）
-git fetch origin
-git switch beta || git switch -c beta origin/main
+# 1. Maker 修复通过 PR 合并到 beta 或 main
+# 2. 人工运行 Publish Maker Package workflow
+#    - Use workflow from: beta
+#    - Version mode: auto-last-number
+#    - tag: beta
+#    - version 留空
 
-# 2. 先同步 main，再合并要测试的功能分支
-git merge origin/main
-git merge feature/feature-a
-git merge feature/feature-b
+# 3. 用户安装 Maker beta 版本
+npm install @taptap/maker@beta
+npx -y @taptap/maker@beta init
 
-# 3. 推送到远程 beta 分支
-git push origin beta
-
-# 4. 需要发布 beta 时，人工运行 release workflow 并选择 beta 分支
-# 版本：1.3.0-beta.1
-
-# 5. 用户安装 beta 版本
-npm install @taptap/instant-games-open-mcp@beta
-npx -y @taptap/instant-games-open-mcp@beta
-
-# 6. 测试稳定后，通过 PR 将对应功能分支合并到 main
-# 7. main 合并后不会自动发布；需要正式发布时人工运行 workflow
-# 版本：1.3.0
+# 4. 测试稳定后，再通过 PR 将对应修复同步到 main
 ```
 
-产品侧 MCP 配置可以直接使用 beta 包：
+产品侧 Maker MCP 配置可以直接使用 beta 包：
 
 ```json
 {
   "mcpServers": {
-    "taptap-minigame-beta": {
+    "taptap-maker-beta": {
       "command": "npx",
-      "args": ["-y", "@taptap/instant-games-open-mcp@beta"],
+      "args": ["-y", "@taptap/maker@beta", "mcp"],
       "env": {
         "TAPTAP_MCP_ENV": "rnd",
         "TAPTAP_MCP_CLIENT_ID": "your_rnd_client_id",
@@ -307,22 +297,24 @@ npx commitlint --from HEAD~1 --to HEAD
 
 **文件**：`.github/workflows/release.yml`
 
-**触发条件**：只能手动运行 `workflow_dispatch`
+**触发条件**：只能从 `main` 手动运行 `workflow_dispatch`
 
-> `beta` 使用同一个 `.github/workflows/release.yml` 中的独立 beta job，
-> 复用 npm Trusted Publishing 配置，但不会创建 release PR 或影响 `main` 正式发版流程。
+**页面参数**：
+
+- `version` 可留空；留空时默认读取 npm `latest`，只递增 `x.y.z` 中的 `z`。
+- 只有需要手动指定版本时才填写 `version`，格式必须是稳定三段版本，例如 `1.24.7`。
+- 如果手动版本修改了 `x` 或 `y`，预检 Summary 会展示当前线上版本和目标版本，发布 job
+  必须经过 `npm_publish` protected environment 人工审批后才能继续。
 
 **执行步骤**：
 
-1. **质量检查** - 运行 lint、build、test
-2. **执行 semantic-release**：
-   - 分析所有 commits
-   - 计算新版本号
-   - 更新 `package.json`
-   - 生成/更新 `CHANGELOG.md`
-   - Git commit 和 tag
-   - **发布到 npm**
-   - 创建 GitHub Release
+1. **解析版本** - 从 npm `latest` 读取当前线上版本，默认只递增 patch。
+2. **预检 Summary** - 展示当前线上版本、目标版本、是否修改 major/minor。
+3. **质量检查** - 运行 lint、format check、build、test。
+4. **生成发布产物** - 更新 `package.json`，生成主包 CHANGELOG / Release notes。
+5. **发布到 npm** - 发布 `@taptap/instant-games-open-mcp@latest`。
+6. **创建 release PR** - 写回 `package.json` / `package-lock.json` / `CHANGELOG.md`。
+7. **创建 GitHub Release** - release PR 合并后创建 tag 和 GitHub Release。
 
 **npm 发布策略**：
 
@@ -330,33 +322,10 @@ npx commitlint --from HEAD~1 --to HEAD
 - ✅ 使用 **Automation Token** 绕过 2FA
 - ✅ 完整的 CI/CD 质量检查
 
-### 5.3 Beta 发布工作流
+### 5.3 主包 Beta 发布
 
-**文件**：`.github/workflows/release.yml` 中的 `beta-release` job
-
-**触发条件**：手动运行 workflow，并选择 `beta` 分支
-
-**执行步骤**：
-
-1. 使用 semantic-release dry-run 计算候选 beta 版本号
-2. 构建或复用 native signer，使 beta 包的 production 体感与正式包一致
-3. 运行 lint、format check、build、test
-4. 如果候选 beta 基础版本不高于 npm `latest`，先提升到 `latest` 的下一个 patch
-   基础版本；再自动递增到该基础版本下一个可用的 `beta.N`
-5. 将工作区版本临时设置为最终 beta 版本
-6. 打包并发布到 npm `@beta` dist-tag
-7. 创建 `vX.Y.Z-beta.N` Git tag 和 GitHub prerelease
-
-**设计约束**：
-
-- 不修改 `main` 的正式 release workflow
-- 不创建 release PR
-- 不提交 `package.json` / `CHANGELOG.md`
-- 复用现有 release workflow 文件名，以匹配 npm Trusted Publishing 配置
-- beta 版本号必须是 npm 上未发布过的新版本，不能只刷新 dist-tag
-- beta 包发布到 public npm，必须视为对外发布产物
-- 内置 production native signer，确保 production 环境开箱即用
-- 不内置 RND 凭证，RND 测试通过 MCP 配置的 `env` 注入
+主包 `@taptap/instant-games-open-mcp` 的旧 beta 发布 job 已关闭。需要 beta 验证时，
+优先使用 Maker 独立包的 `Publish Maker Package` workflow 发布 `@taptap/maker@beta`。
 
 ### 5.4 Maker 独立包发布工作流
 
@@ -389,7 +358,8 @@ npx commitlint --from HEAD~1 --to HEAD
 - Maker-only PR 必须带 `(maker)` scope，且只能修改 Maker-owned paths。
 - 主包 release workflow 不会由 Maker PR 合并自动触发。
 - 旧包 semantic-release 分析、CHANGELOG 和 GitHub Release notes 会过滤 Maker-only commits。
-- 手动版本号必须二次确认。
+- workflow 默认使用 `auto-last-number`，通常只需要选择分支后直接运行。
+- 手动版本号只在需要指定版本时填写。
 - Maker 包只能从长期发布分支 `beta` 或 `main` 发布；`fix/*` 分支只用于提交 PR，
   不作为发版来源。
 - 自动版本号只允许在 `beta` 或 `main` 分支上递增最后一个数字段。
@@ -422,18 +392,13 @@ PR 检查会拒绝以下情况：
 
 PR 路径检测使用 merge-base 语义，只统计 PR 分支实际改动，不把评审期间 main
 新合入的文件算进当前 PR。合并 Maker-only PR 时不要编辑 squash commit 标题去掉
-`(maker)`；即使标题被误改，主包 release workflow 仍会按 Maker-only paths 跳过主包发布，
-但 PR 标题标记是团队审查和追踪 Maker 发布边界的必需信号。
+`(maker)`；PR 标题标记是团队审查和追踪 Maker 发布边界的必需信号。
 
-主包 release workflow 在 push 到 `main`、`beta` 或 `alpha` 时会再次做路径检查。
-Maker-only push 会跳过主包发布；后续主包发布也会过滤这些 Maker-only commits，避免延迟
-触发版本升级或污染主包 CHANGELOG / GitHub Release notes。
-
-Maker 包版本号使用三段式 semver，例如 `0.0.1`。CI 自动递增只能在 `beta` 或 `main`
+Maker 包版本号使用三段式 semver，例如 `0.0.1`。CI 自动递增默认在 `beta` 或 `main`
 分支使用 `auto-last-number`，且只递增最后一个数字段；如果当前 dist-tag 落后于已发布
 稳定版本，CI 会跳过已存在版本并选择同 major/minor 下未发布的下一个 patch。手动发布
-如果要改变 major 或 minor，必须在 workflow 输入中填写目标版本号并再次确认；CI 会在
-预检 job 的 Actions Summary 展示当前线上 dist-tag 版本和目标版本，人工核对后点击
+如果要改变 major 或 minor，CI 会在预检 job 的 Actions Summary 展示当前线上
+dist-tag 版本和目标版本，人工核对后点击
 protected environment 审批按钮继续发布。
 beta 发布建议使用 `0.0.6-beta.1` 这类 prerelease 版本和 `tag=beta`，正式发布使用稳定三段
 版本和 `tag=latest`，两者保持相同的 npm pack、CLI 验证和 publish 流程。
@@ -555,27 +520,20 @@ npx commitlint --from HEAD~1 --to HEAD
 npx commitlint --from HEAD~5 --to HEAD
 ```
 
-### 8.3 本地测试发布流程（dry-run）
+### 8.3 本地测试版本解析
 
 ```bash
-# 不会真正发布，只显示会做什么
-npx semantic-release --dry-run
+# 需要能访问 npm registry，只解析版本，不发布
+GITHUB_REF_NAME=main node scripts/resolve-main-release-version.js
 ```
 
 **输出示例**：
 
 ```
-[semantic-release] › ℹ  Running semantic-release version 19.0.5
-[semantic-release] › ✔  Loaded plugin "commit-analyzer"
-[semantic-release] › ✔  Loaded plugin "release-notes-generator"
-[semantic-release] › ✔  Loaded plugin "npm"
-[semantic-release] › ✔  Loaded plugin "github"
-[semantic-release] › ℹ  This run was triggered in dry-run mode. No release will be published.
-[semantic-release] › ✔  Allowed to push to the Git repository
-[semantic-release] › ℹ  Start step "analyzeCommits" of plugin "commit-analyzer"
-[semantic-release] › ℹ  Analyzing commits...
-[semantic-release] › ✔  Completed step "analyzeCommits" of plugin "commit-analyzer"
-[semantic-release] › ℹ  The next release version is 1.3.0
+Current online @taptap/instant-games-open-mcp@latest version: 1.24.5
+Resolved @taptap/instant-games-open-mcp version: 1.24.6
+Version mode: auto-last-number
+Major/minor changed: false
 ```
 
 ---
@@ -593,33 +551,23 @@ npx semantic-release --dry-run
 ### 9.2 版本号计算
 
 - ✅ 版本号由 workflow 计算，**不需要手动修改** `package.json`
-- ✅ 由 semantic-release 根据 commit 历史自动计算
+- ✅ 默认由 npm `latest` 自动计算下一个 patch
+- ✅ 手动填写版本时，major/minor 变化必须经过 protected environment 审批
 - ❌ 不要手动修改版本号
 
 ### 9.3 预发布版本
 
-**Beta 版本**（测试新特性）：
+**Beta 版本**：
 
-```bash
-git fetch origin
-git switch beta || git switch -c beta origin/main
-git merge origin/main
-git merge feature/feature-a
-git push origin beta
-# 需要发布时人工运行 release workflow 并选择 beta 分支：1.3.0-beta.1
-npm install @taptap/instant-games-open-mcp@beta
-```
-
-Beta 发布只用于内部预览测试。测试通过后，应将对应 feature/fix 分支通过 PR 合并到
-`main`，需要正式发布时人工运行 release workflow 发布 `latest`。
+主包 `@taptap/instant-games-open-mcp` 的 beta 发布 job 已关闭。Maker 验证使用
+`Publish Maker Package` workflow 发布 `@taptap/maker@beta`。
 
 **Alpha 版本**（早期测试）：
 
 ```bash
 git checkout -b alpha
 git push origin alpha
-# 不会自动发布；需要发布时人工运行 release workflow
-npm install @taptap/instant-games-open-mcp@alpha
+# 不会自动发布；当前主包 release workflow 只允许从 main 发布 latest
 ```
 
 **Next 版本**（下一个主版本）：
@@ -627,8 +575,7 @@ npm install @taptap/instant-games-open-mcp@alpha
 ```bash
 git checkout -b next
 git push origin next
-# 不会自动发布；需要发布时人工运行 release workflow
-npm install @taptap/instant-games-open-mcp@next
+# 不会自动发布；当前主包 release workflow 只允许从 main 发布 latest
 ```
 
 ### 9.4 旧版本维护

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -53,11 +53,11 @@ Maker-only paths 跳过这类 push；如需发布 Maker CLI，使用 GitHub Acti
 `Publish Maker Package` workflow。
 
 Maker 包版本号使用三段式 semver，例如 `0.0.1`。Maker 包只能从长期发布分支 `beta` 或
-`main` 发布，`fix/*` 分支只用于提交 PR，不作为发版来源。CI 的 `auto-last-number` 模式
-只递增最后一个数字段；如果当前 dist-tag 落后于已发布稳定版本，CI 会跳过已存在版本并选择
-同 major/minor 下未发布的下一个 patch。手动发布如果修改 major 或 minor，必须在 workflow
-界面确认目标版本号；CI 会先在 Actions Summary 展示当前线上 dist-tag 版本和目标版本，人工
-核对后点击 protected environment 审批按钮继续发布。发布 job 在 `npm publish` 前会再次查询
+`main` 发布，`fix/*` 分支只用于提交 PR，不作为发版来源。workflow 默认使用
+`auto-last-number`，不填版本号时只递增最后一个数字段；如果当前 dist-tag 落后于已发布稳定
+版本，CI 会跳过已存在版本并选择同 major/minor 下未发布的下一个 patch。手动发布如果修改
+major 或 minor，CI 会先在 Actions Summary 展示当前线上 dist-tag 版本和目标版本，人工核对后
+点击 protected environment 审批按钮继续发布。发布 job 在 `npm publish` 前会再次查询
 目标版本是否仍未发布，避免审批等待期间同版本被抢先发布。
 beta 发布建议使用 prerelease 版本和 `tag=beta`，正式发布使用稳定三段版本和 `tag=latest`；
 两者保持同一套 npm pack、CLI 验证和 publish 流程。

--- a/scripts/release-scope.cjs
+++ b/scripts/release-scope.cjs
@@ -39,6 +39,7 @@ const RELEASE_INFRA_EXACT_PATHS = new Set([
   'scripts/check-release-scope.cjs',
   'scripts/generate-main-release-notes.cjs',
   'scripts/release-scope.cjs',
+  'scripts/resolve-main-release-version.js',
   'scripts/resolve-maker-version.js',
   'scripts/semantic-release-main-analyzer.cjs',
   'src/__tests__/mainPackageManifest.test.ts',

--- a/scripts/resolve-main-release-version.js
+++ b/scripts/resolve-main-release-version.js
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+
+/**
+ * Resolve the main package version for the manual publish workflow.
+ *
+ * Empty manual input means auto-last-number: read npm latest, stay on the same
+ * major/minor line, and publish the next available patch.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+
+const PACKAGE_NAME = '@taptap/instant-games-open-mcp';
+const NPM_VIEW_TIMEOUT_MS = 30 * 1000;
+const STABLE_VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
+const RELEASE_BRANCHES = new Set(['main']);
+
+function readEnv(name, fallback = '') {
+  return process.env[name] || fallback;
+}
+
+function npmView(args) {
+  return execFileSync('npm', ['view', PACKAGE_NAME, ...args], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: NPM_VIEW_TIMEOUT_MS,
+  }).trim();
+}
+
+function npmVersionExists(version) {
+  try {
+    execFileSync('npm', ['view', `${PACKAGE_NAME}@${version}`, 'version'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: NPM_VIEW_TIMEOUT_MS,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readPublishedVersions() {
+  const versions = JSON.parse(npmView(['versions', '--json']));
+  if (Array.isArray(versions)) {
+    return versions;
+  }
+  if (typeof versions === 'string' && versions) {
+    return [versions];
+  }
+  return [];
+}
+
+function assertStableVersion(version) {
+  if (!STABLE_VERSION_PATTERN.test(version)) {
+    throw new Error(`Invalid stable version: ${version}. Expected x.y.z, for example 1.24.7.`);
+  }
+}
+
+function parseStableVersion(version) {
+  assertStableVersion(version);
+  const [major, minor, patch] = version.split('.').map(Number);
+  return { major, minor, patch };
+}
+
+function compareStableVersions(a, b) {
+  const left = parseStableVersion(a);
+  const right = parseStableVersion(b);
+  return left.major - right.major || left.minor - right.minor || left.patch - right.patch;
+}
+
+function changesMajorOrMinor(previousVersion, nextVersion) {
+  const previous = parseStableVersion(previousVersion);
+  const next = parseStableVersion(nextVersion);
+  return previous.major !== next.major || previous.minor !== next.minor;
+}
+
+function maxStablePatchForCurrentLine(currentVersion, publishedVersions) {
+  const current = parseStableVersion(currentVersion);
+  const sameLineVersions = publishedVersions
+    .filter((version) => STABLE_VERSION_PATTERN.test(version))
+    .filter((version) => {
+      const parsed = parseStableVersion(version);
+      return parsed.major === current.major && parsed.minor === current.minor;
+    });
+
+  return sameLineVersions.reduce((maxVersion, version) => {
+    return compareStableVersions(version, maxVersion) > 0 ? version : maxVersion;
+  }, currentVersion);
+}
+
+function incrementPatch(version) {
+  const parsed = parseStableVersion(version);
+  return `${parsed.major}.${parsed.minor}.${parsed.patch + 1}`;
+}
+
+function assertReleaseBranch(branch) {
+  if (!RELEASE_BRANCHES.has(branch)) {
+    throw new Error(
+      `${PACKAGE_NAME} latest can only be published from main; current branch: ${
+        branch || '(unknown)'
+      }`
+    );
+  }
+}
+
+function resolveAutoVersion(currentVersion, publishedVersions) {
+  const autoBase = maxStablePatchForCurrentLine(currentVersion, publishedVersions);
+  return incrementPatch(autoBase);
+}
+
+function resolveManualVersion(currentVersion) {
+  const version = readEnv('MAIN_MANUAL_VERSION').trim();
+  assertStableVersion(version);
+
+  if (compareStableVersions(version, currentVersion) <= 0) {
+    throw new Error(
+      `Manual target version ${version} must be greater than current online latest ${currentVersion}.`
+    );
+  }
+
+  return version;
+}
+
+function writeOutput(name, value) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (outputPath) {
+    appendFileSync(outputPath, `${name}=${value}\n`, 'utf8');
+  }
+}
+
+function main() {
+  const branch = readEnv('GITHUB_REF_NAME');
+  assertReleaseBranch(branch);
+
+  const currentVersion = npmView(['dist-tags.latest']);
+  assertStableVersion(currentVersion);
+
+  const publishedVersions = readPublishedVersions();
+  const manualVersion = readEnv('MAIN_MANUAL_VERSION').trim();
+  const version = manualVersion
+    ? resolveManualVersion(currentVersion)
+    : resolveAutoVersion(currentVersion, publishedVersions);
+
+  if (npmVersionExists(version)) {
+    throw new Error(`${PACKAGE_NAME}@${version} already exists on npm.`);
+  }
+
+  const majorMinorChanged = changesMajorOrMinor(currentVersion, version);
+
+  writeOutput('version', version);
+  writeOutput('current_version', currentVersion);
+  writeOutput('major_minor_changed', String(majorMinorChanged));
+  writeOutput('mode', manualVersion ? 'manual' : 'auto-last-number');
+  writeOutput('should_release', 'true');
+
+  console.log(`Current online ${PACKAGE_NAME}@latest version: ${currentVersion}`);
+  console.log(`Resolved ${PACKAGE_NAME} version: ${version}`);
+  console.log(`Version mode: ${manualVersion ? 'manual' : 'auto-last-number'}`);
+  console.log(`Major/minor changed: ${majorMinorChanged}`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/scripts/resolve-maker-version.js
+++ b/scripts/resolve-maker-version.js
@@ -3,8 +3,8 @@
 /**
  * Resolve the @taptap/maker version for the manual publish workflow.
  *
- * Manual mode requires an exact repeated target-version confirmation. Auto mode
- * only increments the final numeric segment on long-lived release branches.
+ * Manual mode is only needed when specifying a target version. Auto mode only
+ * increments the final numeric segment on long-lived release branches.
  */
 
 import { execFileSync } from 'node:child_process';
@@ -90,18 +90,9 @@ function readCurrentDistTagVersion(tag) {
 
 function resolveManualVersion(currentVersion) {
   const version = readEnv('MAKER_MANUAL_VERSION').trim();
-  const confirmation = readEnv('MAKER_CONFIRM_VERSION').trim();
 
   if (!version) {
     throw new Error('Manual mode requires MAKER_MANUAL_VERSION.');
-  }
-  if (!confirmation) {
-    throw new Error('Manual mode requires MAKER_CONFIRM_VERSION.');
-  }
-  if (version !== confirmation) {
-    throw new Error(
-      `Manual version confirmation mismatch: version=${version}, confirm_version=${confirmation}`
-    );
   }
 
   assertValidVersion(version);
@@ -200,7 +191,7 @@ function writeOutput(name, value) {
 }
 
 function main() {
-  const mode = readEnv('MAKER_VERSION_MODE', 'manual');
+  const mode = readEnv('MAKER_VERSION_MODE', 'auto-last-number');
   const tag = readEnv('MAKER_NPM_TAG', 'beta');
 
   if (!['manual', 'auto-last-number'].includes(mode)) {

--- a/src/__tests__/mainReleaseVersionPolicy.test.ts
+++ b/src/__tests__/mainReleaseVersionPolicy.test.ts
@@ -1,0 +1,131 @@
+import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const SCRIPT_PATH = join(process.cwd(), 'scripts', 'resolve-main-release-version.js');
+const PACKAGE_NAME = '@taptap/instant-games-open-mcp';
+
+function createFakeNpm(
+  currentVersion: string,
+  existingVersions: string[] = [currentVersion],
+  versionsJson = JSON.stringify(existingVersions)
+) {
+  const dir = mkdtempSync(join(tmpdir(), 'main-release-version-policy-'));
+  const binDir = join(dir, 'bin');
+  mkdirSync(binDir, { recursive: true });
+  const npmPath = join(binDir, 'npm');
+  writeFileSync(
+    npmPath,
+    `#!/usr/bin/env node
+const args = process.argv.slice(2);
+const current = ${JSON.stringify(currentVersion)};
+const existing = new Set(${JSON.stringify(existingVersions)});
+if (args[0] !== 'view') {
+  console.error('Unsupported npm command: ' + args.join(' '));
+  process.exit(1);
+}
+const query = args[1] || '';
+const field = args[2] || '';
+if (query === ${JSON.stringify(PACKAGE_NAME)} && field === 'versions') {
+  console.log(${JSON.stringify(versionsJson)});
+  process.exit(0);
+}
+if (query === ${JSON.stringify(PACKAGE_NAME)} && field === 'dist-tags.latest') {
+  console.log(current);
+  process.exit(0);
+}
+const versionMatch = /^@taptap\\/instant-games-open-mcp@(.+)$/.exec(query);
+if (versionMatch && field === 'version') {
+  if (existing.has(versionMatch[1])) {
+    console.log(versionMatch[1]);
+    process.exit(0);
+  }
+  process.exit(1);
+}
+console.error('Unsupported npm view: ' + args.join(' '));
+process.exit(1);
+`,
+    'utf8'
+  );
+  chmodSync(npmPath, 0o755);
+  return binDir;
+}
+
+function runResolver(env: Record<string, string | undefined>) {
+  return spawnSync('node', [SCRIPT_PATH], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      ...env,
+      PATH: `${env.PATH}:${process.env.PATH || ''}`,
+    },
+    encoding: 'utf8',
+  });
+}
+
+describe('main package release version policy', () => {
+  it('auto increments only the patch from npm latest', () => {
+    const fakeBin = createFakeNpm('1.24.5');
+    const result = runResolver({
+      PATH: fakeBin,
+      GITHUB_REF_NAME: 'main',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(
+      'Current online @taptap/instant-games-open-mcp@latest version: 1.24.5'
+    );
+    expect(result.stdout).toContain('Resolved @taptap/instant-games-open-mcp version: 1.24.6');
+    expect(result.stdout).toContain('Version mode: auto-last-number');
+    expect(result.stdout).toContain('Major/minor changed: false');
+  });
+
+  it('skips already published patch versions in the same major/minor line', () => {
+    const fakeBin = createFakeNpm('1.24.3', ['1.24.3', '1.24.4', '1.24.5']);
+    const result = runResolver({
+      PATH: fakeBin,
+      GITHUB_REF_NAME: 'main',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Resolved @taptap/instant-games-open-mcp version: 1.24.6');
+  });
+
+  it('allows manual major or minor changes and flags approval requirement', () => {
+    const fakeBin = createFakeNpm('1.24.5');
+    const result = runResolver({
+      PATH: fakeBin,
+      GITHUB_REF_NAME: 'main',
+      MAIN_MANUAL_VERSION: '1.25.0',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Resolved @taptap/instant-games-open-mcp version: 1.25.0');
+    expect(result.stdout).toContain('Version mode: manual');
+    expect(result.stdout).toContain('Major/minor changed: true');
+  });
+
+  it('rejects latest publishing outside main', () => {
+    const fakeBin = createFakeNpm('1.24.5');
+    const result = runResolver({
+      PATH: fakeBin,
+      GITHUB_REF_NAME: 'beta',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('latest can only be published from main');
+  });
+
+  it('rejects prerelease manual versions for latest', () => {
+    const fakeBin = createFakeNpm('1.24.5');
+    const result = runResolver({
+      PATH: fakeBin,
+      GITHUB_REF_NAME: 'main',
+      MAIN_MANUAL_VERSION: '1.25.0-beta.1',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Invalid stable version');
+  });
+});

--- a/src/__tests__/makerVersionPolicy.test.ts
+++ b/src/__tests__/makerVersionPolicy.test.ts
@@ -83,7 +83,6 @@ describe('Maker publish version policy', () => {
       PATH: fakeBin,
       MAKER_VERSION_MODE: 'manual',
       MAKER_MANUAL_VERSION: '0.0.6',
-      MAKER_CONFIRM_VERSION: '0.0.6',
       MAKER_NPM_TAG: 'beta',
       GITHUB_REF_NAME: 'fix/maker-release',
     });
@@ -178,13 +177,12 @@ describe('Maker publish version policy', () => {
     expect(result.stderr).toContain('auto-last-number requires a stable three-segment version');
   });
 
-  it('allows manual major or minor changes after target confirmation', () => {
+  it('allows manual major or minor changes and flags approval requirement', () => {
     const fakeBin = createFakeNpm('0.0.5');
     const result = runResolver({
       PATH: fakeBin,
       MAKER_VERSION_MODE: 'manual',
       MAKER_MANUAL_VERSION: '0.1.0',
-      MAKER_CONFIRM_VERSION: '0.1.0',
       MAKER_NPM_TAG: 'beta',
       GITHUB_REF_NAME: 'main',
     });
@@ -202,7 +200,6 @@ describe('Maker publish version policy', () => {
       PATH: fakeBin,
       MAKER_VERSION_MODE: 'manual',
       MAKER_MANUAL_VERSION: '0.0.6',
-      MAKER_CONFIRM_VERSION: '0.0.6',
       MAKER_NPM_TAG: 'beta',
       GITHUB_REF_NAME: 'main',
     });

--- a/src/__tests__/releaseScope.test.ts
+++ b/src/__tests__/releaseScope.test.ts
@@ -44,6 +44,7 @@ describe('release-scope classifier', () => {
       '.github/workflows/release.yml',
       '.github/workflows/publish-maker.yml',
       'scripts/release-scope.cjs',
+      'scripts/resolve-main-release-version.js',
       'scripts/resolve-maker-version.js',
       'src/__tests__/releaseScope.test.ts',
       'src/__tests__/makerVersionPolicy.test.ts',

--- a/src/__tests__/releaseScopeCli.test.ts
+++ b/src/__tests__/releaseScopeCli.test.ts
@@ -55,6 +55,7 @@ describe('release scope PR guard', () => {
         '.github/workflows/release.yml',
         '.github/workflows/publish-maker.yml',
         'scripts/release-scope.cjs',
+        'scripts/resolve-main-release-version.js',
         'scripts/resolve-maker-version.js',
         'CONTRIBUTING.md',
         'README.md',


### PR DESCRIPTION
## Summary

- Keep the main package release workflow manual, main-only, and latest-only.
- Resolve the main package version from npm latest; empty version input auto-increments only the patch segment.
- Show current online version and target version in the preflight summary; major/minor changes require protected environment approval.
- Default Maker publishing to auto-last-number and remove the duplicate confirm_version input.
- Remove the old main package beta publish job from release.yml.

## Verification

- npm test -- --runInBand
- npm run lint
- npm run build
- npx prettier --check .github/workflows/release.yml .github/workflows/publish-maker.yml docs/CI_CD.md docs/MAKER.md scripts/resolve-main-release-version.js scripts/resolve-maker-version.js src/__tests__/mainReleaseVersionPolicy.test.ts src/__tests__/makerVersionPolicy.test.ts src/__tests__/releaseScope.test.ts src/__tests__/releaseScopeCli.test.ts
- node --check scripts/resolve-main-release-version.js && node --check scripts/resolve-maker-version.js
- release workflow static check: no push trigger, no main package beta publish job, main branch guard present