### PR TITLE
ci(release): allow main release version policy tests

### DIFF
--- a/scripts/release-scope.cjs
+++ b/scripts/release-scope.cjs
@@ -43,6 +43,7 @@ const RELEASE_INFRA_EXACT_PATHS = new Set([
   'scripts/resolve-maker-version.js',
   'scripts/semantic-release-main-analyzer.cjs',
   'src/__tests__/mainPackageManifest.test.ts',
+  'src/__tests__/mainReleaseVersionPolicy.test.ts',
   'src/__tests__/mainReleaseNotes.test.ts',
   'src/__tests__/makerVersionPolicy.test.ts',
   'src/__tests__/releaseScope.test.ts',

--- a/src/__tests__/releaseScope.test.ts
+++ b/src/__tests__/releaseScope.test.ts
@@ -55,6 +55,7 @@ describe('release-scope classifier', () => {
       'package.json',
       'package-lock.json',
       'src/__tests__/mainPackageManifest.test.ts',
+      'src/__tests__/mainReleaseVersionPolicy.test.ts',
     ]);
 
     expect(classification.hasMakerChanges).toBe(true);

--- a/src/__tests__/releaseScopeCli.test.ts
+++ b/src/__tests__/releaseScopeCli.test.ts
@@ -61,6 +61,7 @@ describe('release scope PR guard', () => {
         'README.md',
         'docs/CI_CD.md',
         'docs/MAKER.md',
+        'src/__tests__/mainReleaseVersionPolicy.test.ts',
       ],
       title: 'ci(release): isolate maker package publishing',
     });


### PR DESCRIPTION
## Summary

- Classify the new main release version policy test as release infrastructure.
- Keep release scope guard valid for release workflow policy PRs.

## Verification

- npx jest src/__tests__/releaseScope.test.ts src/__tests__/releaseScopeCli.test.ts --runInBand
- npx prettier --check scripts/release-scope.cjs src/__tests__/releaseScope.test.ts src/__tests__/releaseScopeCli.test.ts
- git diff --check