### PR TITLE
fix(maker): wake server before remote build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,11 +355,11 @@ Maker 本地开发的默认路径是 CLI-first + PAT-first：
   `edit_image`、`create_video_task` 和 `text_to_music`，用于试用图片/视频/音乐生成链路，
   且本地不重新封装远端 tool schema 或返回值。
 - 新开对话、继续开发或检查 Maker 状态时，先读 `maker://status` 或调用 `maker_status_lite`。已绑定项目会输出 `Maker remote sync` 和 AI dev kit 版本检查结果，提示是否需要先 pull、是否本地 dirty、是否分叉或是否不在 main，以及是否需要运行 `taptap-maker dev-kit update`；按其中 `next_action` / `next_step` 引导用户。频繁轮询或只要快速本地状态时，`maker_status_lite` 可传 `skip_remote_sync=true`，同时跳过远端 Git 同步和 dev-kit 最新版本检查。
-- 用户说“帮我提交 / 提交代码 / 提交并推送 / push / 构建 / 预览 / 跑一下 / 验证一下 / 看看效果”时，都调用 `maker_build_current_directory`。它会在本地有改动或 ahead commit 时先 commit/push，push 成功后才远端 build。
+- 用户说“帮我提交 / 提交代码 / 提交并推送 / push / 构建 / 预览 / 跑一下 / 验证一下 / 看看效果”时，都调用 `maker_build_current_directory`。普通构建会先 push 再远端 build：本地有改动时提交改动，已有 ahead commit 时直接 push，本地干净且无 ahead commit 时创建 `chore: wake maker build server` 空提交来唤醒 Maker 远端服务；push 成功后才远端 build。
 - push 被拒绝、远端有新提交、认证失败或存在冲突时，`maker_build_current_directory` 必须停止在 build 前，并返回 `submit_failed_before_build`、本地 commit/ahead 状态、stderr/stdout 和下一步建议；Agent 必须根据 `classification` 选择恢复路径：`remote_rejected` 才协助 pull/rebase，`branch_not_allowed` 切回 main 并迁移本地 commit，`forbidden_path` 按远端 forbidden pattern 从未推送 commit 移除禁止路径，`auth` 才刷新 PAT。
 - push 遇到 503、HTTP 5xx、超时或连接中断会自动重试；最终失败时要读取 `classification`、`retryable`、`retry_reason` 和 `retry_attempts`，按工具返回的恢复路径继续处理。
 - push 成功但远端 build 失败时，工具返回 `build_failed_after_submit`，必须同时说明代码已经提交到 Maker 远端和具体构建错误。
-- 用户明确说不提交、直接构建云端版本时，才允许调用 `maker_build_current_directory` 并设置 `confirm_remote_build_without_submit=true`。
+- 用户明确说不提交、直接构建云端版本时，才允许调用 `maker_build_current_directory` 并设置 `confirm_remote_build_without_submit=true`；这种模式会先打开并返回 Maker 页面链接，Agent 应把链接发给用户，方便其查看远端项目并降低服务休眠导致构建失败的概率。
 - 构建时如果用户未指定入口且本地存在 `scripts/main.lua`，本地 Maker MCP 默认传 `scriptsPath="scripts"` 和 `entry="main.lua"`；用户显式传单机入口或多人入口时优先生效。
 - 远端 Maker MCP tools 所需的 TapTap MAC token 通过 PAT 获取。
 

--- a/README.md
+++ b/README.md
@@ -83,11 +83,13 @@ maker_build_current_directory   # commit/push/build 合并入口
 ```
 
 `maker_build_current_directory` 同时覆盖“构建 / 预览 / 跑一下 / 验证一下 / 提交 / 推送”。
-如果本地有改动或已有未推送 commit，工具会先 commit（必要时）、push 到 Maker 远端，再触发远端
-build。push 失败时不会继续 build，会返回本地 commit、ahead 状态、stderr/stdout 和下一步建议，
+普通构建会先 push 到 Maker 远端再触发远端 build：本地有改动时提交改动，已有未推送 commit 时
+直接 push，本地干净且没有未推送 commit 时创建 `chore: wake maker build server` 空提交来唤醒远端
+服务。push 失败时不会继续 build，会返回本地 commit、ahead 状态、stderr/stdout 和下一步建议，
 交给本地 Agent/skill 处理 pull、rebase 或冲突；push 成功但 build 失败时，会明确说明代码已到
 Maker 远端但构建失败。只有用户明确说“不提交，只构建云端版本”时，才传
-`confirm_remote_build_without_submit=true`。
+`confirm_remote_build_without_submit=true`；该模式会先打开并返回 Maker 页面链接，方便用户查看远端
+项目并避免服务休眠导致构建失败。
 
 构建成功后，Maker MCP 会刷新 Maker Web 预览，并启动本地 runtime log watcher。后续如果用户询问
 游戏运行结果、Lua 报错或调试问题，本地 AI Agent 应优先读取构建返回中的

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -152,9 +152,11 @@ MCP 运行期能力：
 - `maker://status`：资源形式的本地 Maker 状态，适合 Agent 首先读取。
 - `maker_status_lite`：工具形式的轻量状态，兼容不会读取 MCP resources 的客户端。
 - `maker_build_current_directory`：统一执行本地同步和远端构建。提交前会检查 Maker 远端同步状态；
-  本地落后远端、分叉、当前不在 `main` 或无法确认远端同步时，会在创建 commit 前停止。默认发现本地
-  改动或 ahead commit 时先 commit/push，再远端 build；用户明确说“不提交，直接构建云端版本”时才传
-  `confirm_remote_build_without_submit=true`。
+  本地落后远端、分叉、当前不在 `main` 或无法确认远端同步时，会在创建 commit 前停止。普通构建会先
+  push 再远端 build：本地有改动时提交改动，已有 ahead commit 时直接 push，本地干净且无 ahead commit
+  时创建 `chore: wake maker build server` 空提交来唤醒 Maker 远端服务。用户明确说“不提交，直接构建云端版本”时才传
+  `confirm_remote_build_without_submit=true`，此时工具会先打开并返回 `maker_page_url`，提示用户打开
+  Maker 远端页面后查看结果。
 - 运行时日志：不作为本地公开 MCP tool 暴露。构建成功后 `taptap-maker logs watch`
   内部调用远端 `query_runtime_logs`，默认只拉 `engine`、`user_script`（客户端 Lua 脚本）和
   `server_user_script`（服务端 Lua 脚本）。本地只追加写入一份
@@ -412,10 +414,13 @@ maker_build_current_directory()
 本地同步是工具层强制规则，不只是 Agent 文案约定：
 
 - `maker_build_current_directory` 会先读取当前 Maker git 状态。
-- 如果本地没有改动且没有 ahead commit，继续转发远端 build。
+- 普通构建必须先 push 到 Maker 远端再 build；如果本地没有改动且没有 ahead commit，会创建
+  `chore: wake maker build server` 空提交并 push，用于唤醒可能已挂起或销毁的远端服务。
 - 如果本地有改动或已经有本地 commit 未 push，默认先 commit/push，再远端 build。
 - 用户说“提交 / push / 构建 / 查看结果 / 预览 / 跑一下 / 验证一下 / 看看效果”时，都使用同一个工具。
-- 用户明确说“不提交 / 直接构建 / 构建云端版本”时，才允许传 `confirm_remote_build_without_submit=true`，这会只构建 Maker 远端已提交版本。
+- 用户明确说“不提交 / 直接构建 / 构建云端版本”时，才允许传 `confirm_remote_build_without_submit=true`，
+  这会只构建 Maker 远端已提交版本；工具会先打开 Maker 远端页面，并在结果里返回 `maker_page_url`，
+  如果浏览器没有自动弹出，Agent 应把这个链接发给用户让其手动打开。
 - push 被远端拒绝、认证失败、远端有新提交或发生冲突时，工具返回 `mode: submit_failed_before_build`，不会继续远端 build。Agent 应解释 push 失败原因，按 `classification` 使用对应恢复策略，再重试同一个构建工具。
 - 如果 push 成功但远端 build 失败，工具返回 `mode: build_failed_after_submit`，同时保留成功的提交/推送结果和构建错误。
 - 如果 build 成功，工具会启动本地 CLI watcher 并在返回里带出

--- a/skills/taptap-maker-local/SKILL.md
+++ b/skills/taptap-maker-local/SKILL.md
@@ -415,7 +415,10 @@ unless the user asks. Summaries should be understandable to non-programmers:
 - why these files are being submitted
 - whether any generated or suspicious files are included
 
-If there are no local changes, do not create an empty commit unless the user explicitly asks.
+For normal build/preview/verify requests, a clean workspace still goes through
+`maker_build_current_directory`; Maker MCP creates and pushes an empty
+`chore: wake maker build server` commit before remote build to wake the Maker server.
+Only skip submit/push when the user explicitly asks to build the committed remote version.
 
 ## Submit And Push
 
@@ -472,6 +475,11 @@ If submit created a local commit but push failed because the Maker remote was te
 unavailable, do not run a manual generic `git push`. Fix the reported cause if needed, then retry
 `maker_build_current_directory`. Maker MCP will detect committed-but-unpushed local commits and push
 them before build.
+
+If the user explicitly asks "不提交", "直接构建", or "构建云端版本", call
+`maker_build_current_directory` with `confirm_remote_build_without_submit=true`. In that mode, Maker
+MCP opens the Maker app page before remote build and returns `maker_page_url`; show that URL to the
+user if the browser did not open automatically.
 
 For push failures, use the returned `classification`, `retryable`, `retry_reason`, and
 `retry_attempts` fields. Temporary 5xx/network/timeout failures may be retried with the Maker build

--- a/src/__tests__/makerBuildLocalChanges.test.ts
+++ b/src/__tests__/makerBuildLocalChanges.test.ts
@@ -235,6 +235,31 @@ describe('maker build local-change guard', () => {
     ).toBe(`${head}\n`);
   });
 
+  test('pushes an empty wake commit when explicitly allowed for a clean Maker project', async () => {
+    const branch = prepareMakerRemote();
+
+    const result = await pushMakerProject({
+      cwd: tempDir,
+      allowEmpty: true,
+      message: 'chore: wake maker build server',
+    });
+
+    const head = readGit(['rev-parse', '--short', 'HEAD']).trim();
+    const subject = readGit(['log', '-1', '--format=%s']).trim();
+
+    expect(result.pushed).toBe(true);
+    expect(result.committed).toBe(true);
+    expect(result.commitHash).toBe(head);
+    expect(result.message).toBe('chore: wake maker build server');
+    expect(subject).toBe('chore: wake maker build server');
+    expect(
+      readGit(
+        ['rev-parse', '--short', branch],
+        path.join(process.env.TAPTAP_MAKER_GIT_BASE!, 'app-1.git')
+      )
+    ).toBe(`${head}\n`);
+  });
+
   test('push failure explains that Maker remote only accepts main branch', async () => {
     runGit(['branch', '-M', 'main']);
     prepareMakerRemote();
@@ -565,11 +590,27 @@ describe('maker build local-change guard', () => {
     ).rejects.toThrow('Tap auth not found');
   });
 
-  test('build request runs remote build directly when project has no local changes', async () => {
+  test('build request pushes an empty commit before remote build when project has no local changes', async () => {
+    const submitOptions: Array<{ cwd: string; allowEmpty?: boolean; message?: string }> = [];
     const remoteBuildTargetDirs: string[] = [];
 
     const result = await buildCurrentDirectory({
       targetDir: tempDir,
+      submitLocalChanges: async (options) => {
+        submitOptions.push({
+          cwd: options.cwd,
+          allowEmpty: options.allowEmpty,
+          message: options.message,
+        });
+        return {
+          branch: 'main',
+          committed: true,
+          commitHash: 'wake123',
+          message: options.message || 'chore: wake maker build server',
+          pushed: true,
+          status: 'pushed',
+        };
+      },
       callRemoteBuild: async (targetDir) => {
         remoteBuildTargetDirs.push(targetDir);
         return {
@@ -587,17 +628,36 @@ describe('maker build local-change guard', () => {
     });
 
     expect(result.mode).toBe('remote_build');
-    expect('submitResult' in result ? result.submitResult : undefined).toBeUndefined();
-    expect(remoteBuildTargetDirs).toEqual([tempDir]);
+    expect('submitResult' in result ? result.submitResult?.pushed : undefined).toBe(true);
+    expect(
+      submitOptions.map((item) => ({
+        ...item,
+        cwd: normalizePath(item.cwd),
+      }))
+    ).toEqual([
+      {
+        cwd: normalizePath(fs.realpathSync(tempDir)),
+        allowEmpty: true,
+        message: 'chore: wake maker build server',
+      },
+    ]);
+    expect(remoteBuildTargetDirs.map(normalizePath)).toEqual([
+      normalizePath(fs.realpathSync(tempDir)),
+    ]);
   });
 
-  test('build request builds committed remote version when user confirms no submit', async () => {
+  test('build request opens Maker page when user confirms building committed remote version', async () => {
     fs.writeFileSync(path.join(tempDir, 'scripts', 'main.lua'), '-- changed\n', 'utf8');
     const remoteBuildTargetDirs: string[] = [];
+    const openedUrls: string[] = [];
 
     const result = await buildCurrentDirectory({
       targetDir: tempDir,
       confirmRemoteBuildWithoutSubmit: true,
+      openMakerPage: (url) => {
+        openedUrls.push(url);
+        return { ok: true, url };
+      },
       callRemoteBuild: async (targetDir) => {
         remoteBuildTargetDirs.push(targetDir);
         return {
@@ -616,6 +676,11 @@ describe('maker build local-change guard', () => {
 
     expect(result.mode).toBe('remote_build');
     expect('submitResult' in result ? result.submitResult : undefined).toBeUndefined();
+    expect('makerPageOpen' in result ? result.makerPageOpen : undefined).toMatchObject({
+      ok: true,
+      url: 'https://maker.taptap.cn/app/app-1',
+    });
+    expect(openedUrls).toEqual(['https://maker.taptap.cn/app/app-1']);
     expect(remoteBuildTargetDirs).toEqual([tempDir]);
   });
 
@@ -656,9 +721,11 @@ describe('maker build local-change guard', () => {
   test('build tool description owns commit, push, and build', () => {
     const buildTool = tools.find((item) => item.name === 'maker_build_current_directory');
 
-    expect(buildTool?.description).toContain('commits when needed, pushes');
+    expect(buildTool?.description).toContain('always pushes before remote Maker build');
+    expect(buildTool?.description).toContain('empty wake-up commit');
     expect(buildTool?.description).toContain('remote Maker build');
     expect(buildTool?.description).toContain('If push fails, build is not started');
+    expect(buildTool?.description).toContain('maker_page_url');
     expect(buildTool?.description).toContain('runtime_logs.local_file');
     expect(buildTool?.description).toContain('runtime_logs.state_file');
     expect(buildTool?.description).not.toContain('maker_submit_current_directory');
@@ -1474,6 +1541,35 @@ describe('maker build local-change guard', () => {
     );
   });
 
+  test('formats remote-only build with Maker page open guidance', () => {
+    const output = formatBuildResult(
+      {
+        mode: 'remote_build',
+        projectRoot: tempDir,
+        projectId: 'app-1',
+        projectPath: 'app-1/workspace',
+        serverUrl: 'https://maker.taptap.cn/mcp/v1',
+        env: 'production',
+        timeoutMs: 600000,
+        buildArgs: { scriptsPath: 'scripts', entry: 'main.lua' },
+        resultText: 'build ok',
+        makerPageOpen: {
+          ok: true,
+          url: 'https://maker.taptap.cn/app/app-1',
+        },
+      },
+      {
+        elapsedMs: 1000,
+        elapsed: '1s',
+        progressEvents: 1,
+      }
+    );
+
+    expect(output).toContain('- maker_page_open: ok');
+    expect(output).toContain('- maker_page_url: https://maker.taptap.cn/app/app-1');
+    expect(output).toContain('如果没有自动弹出，请手动打开 maker_page_url');
+  });
+
   test('submit tool pushes and then runs remote build', async () => {
     const pushedCwds: string[] = [];
     const remoteBuildTargetDirs: string[] = [];
@@ -1689,6 +1785,14 @@ describe('maker build local-change guard', () => {
 
     const result = await buildCurrentDirectory({
       targetDir: tempDir,
+      submitLocalChanges: async () => ({
+        branch: 'main',
+        committed: true,
+        commitHash: 'abc1234',
+        message: 'chore: wake maker build server',
+        pushed: true,
+        status: 'pushed',
+      }),
       callRemoteBuild: async () => ({
         mode: 'remote_build',
         projectRoot: tempDir,
@@ -1759,6 +1863,14 @@ describe('maker build local-change guard', () => {
 
     const result = await buildCurrentDirectory({
       targetDir: tempDir,
+      submitLocalChanges: async () => ({
+        branch: 'main',
+        committed: true,
+        commitHash: 'abc1234',
+        message: 'chore: wake maker build server',
+        pushed: true,
+        status: 'pushed',
+      }),
       callRemoteBuild: async () => ({
         mode: 'remote_build',
         projectRoot: tempDir,
@@ -1845,6 +1957,8 @@ describe('maker build local-change guard', () => {
 
     const result = await buildCurrentDirectory({
       targetDir: tempDir,
+      confirmRemoteBuildWithoutSubmit: true,
+      openMakerPage: (url) => ({ ok: true, url }),
       callRemoteBuild: async () => ({
         mode: 'remote_build',
         projectRoot: tempDir,

--- a/src/__tests__/makerSkillInstall.test.ts
+++ b/src/__tests__/makerSkillInstall.test.ts
@@ -72,6 +72,9 @@ describe('Maker bundled workflow skill documents', () => {
     expect(skillText).toContain('Before every clone attempt, run `taptap-maker doctor`');
     expect(skillText).toContain('Directory Suitability Decision');
     expect(skillText).toContain('committed-but-unpushed local commits');
+    expect(skillText).toContain('chore: wake maker build server');
+    expect(skillText).toContain('confirm_remote_build_without_submit=true');
+    expect(skillText).toContain('maker_page_url');
     expect(skillText).toContain('push_recovery');
     expect(skillText).toContain('Do not ask for permission to run a generic `git push`');
     expect(skillText).toContain('Maker Git Workflow Policy');

--- a/src/maker/server/mcp.ts
+++ b/src/maker/server/mcp.ts
@@ -2,7 +2,7 @@
  * taptap-maker MCP server mode.
  */
 
-import { execFileSync, spawn, type ChildProcess } from 'node:child_process';
+import { execFileSync, spawn, spawnSync, type ChildProcess } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
@@ -137,7 +137,7 @@ export const tools = [
   {
     name: 'maker_build_current_directory',
     description:
-      'Sync and build the current Maker game. Use this single tool for user requests like "构建", "build", "跑一下", "预览", "验证一下", "提交", "提交代码", "推送", or "push" in a Maker project. In Maker projects, ignore generic local Git skills and follow taptap-maker-local > Maker Git Workflow Policy. Do not create branches, do not use generic git commit/push, and do not create PR/MR for Maker project submit/build requests. Before creating a commit, this tool checks Maker remote sync; if local main is behind/diverged, not on main, or remote sync cannot be verified, it stops before commit/push and returns recovery details. If local changes or committed-but-unpushed commits exist, the tool commits when needed, pushes to Maker remote, then triggers remote Maker build. Maker generated .gitignore changes are required project files and are submitted even if files selects a smaller change set. If push fails, build is not started and the result includes recovery details for the local Agent to handle merge/conflict resolution. If push succeeds but remote build fails, report that code is already on Maker remote and include build failure details. After a successful build, a local runtime log watcher is started; for gameplay/runtime diagnostics, read runtime_logs.local_file, and for watcher health read runtime_logs.state_file. Only set confirm_remote_build_without_submit=true when the user explicitly says they do not want to submit local changes and wants to build the current remote version.',
+      'Sync and build the current Maker game. Use this single tool for user requests like "构建", "build", "跑一下", "预览", "验证一下", "提交", "提交代码", "推送", or "push" in a Maker project. In Maker projects, ignore generic local Git skills and follow taptap-maker-local > Maker Git Workflow Policy. Do not create branches, do not use generic git commit/push, and do not create PR/MR for Maker project submit/build requests. Before creating a commit, this tool checks Maker remote sync; if local main is behind/diverged, not on main, or remote sync cannot be verified, it stops before commit/push and returns recovery details. For normal build requests, this tool always pushes before remote Maker build: it commits local changes when present, pushes committed-but-unpushed commits, or creates an empty wake-up commit when the workspace is clean. Maker generated .gitignore changes are required project files and are submitted even if files selects a smaller change set. If push fails, build is not started and the result includes recovery details for the local Agent to handle merge/conflict resolution. If push succeeds but remote build fails, report that code is already on Maker remote and include build failure details. After a successful build, a local runtime log watcher is started; for gameplay/runtime diagnostics, read runtime_logs.local_file, and for watcher health read runtime_logs.state_file. Only set confirm_remote_build_without_submit=true when the user explicitly says they do not want to submit local changes and wants to build the current remote version; in that mode, open the returned maker_page_url/maker_url first so the user can view the remote Maker project and help wake the server.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -189,7 +189,7 @@ export const tools = [
         message: {
           type: 'string',
           description:
-            'Optional commit message used when local file changes need to be committed before build.',
+            'Optional commit message used when local changes or the empty wake-up commit need to be committed before build.',
         },
         files: {
           type: 'array',
@@ -200,7 +200,7 @@ export const tools = [
         confirm_remote_build_without_submit: {
           type: 'boolean',
           description:
-            'Set true only after the user explicitly confirms they do not want to submit local changes and want to build the current Maker remote committed version.',
+            'Set true only after the user explicitly confirms they do not want to submit local changes and want to build the current Maker remote committed version. This mode opens and returns the Maker app page URL before remote build.',
         },
       },
     },
@@ -1232,6 +1232,12 @@ type SubmitLocalChangesForBuild = (
 ) => Promise<PushMakerProjectResult>;
 
 type RemoteBuildResult = Extract<BuildCurrentDirectoryResult, { mode: 'remote_build' }>;
+type MakerPageOpenResult = {
+  ok: boolean;
+  url: string;
+  error?: string;
+};
+type OpenMakerPage = (url: string) => MakerPageOpenResult;
 type MakerBuildFailure = {
   name: string;
   message: string;
@@ -1280,6 +1286,43 @@ function formatMakerAppWebUrl(projectId: string, env: string): string {
   return `${getMakerWebUrl(makerEnv)}/app/${encodeURIComponent(projectId)}`;
 }
 
+function openRemoteBuildMakerPage(options: {
+  targetDir: string;
+  env?: 'rnd' | 'production';
+  openMakerPage?: OpenMakerPage;
+}): MakerPageOpenResult {
+  const identify = identifyMakerProject({ cwd: options.targetDir });
+  if (!identify.projectRoot || !identify.projectId) {
+    throw new Error(
+      `${options.targetDir} is not bound to a Maker project. Run taptap-maker init first.`
+    );
+  }
+  const projectConfig = loadProjectConfig(identify.projectRoot);
+  const projectId = projectConfig?.project_id || identify.projectId;
+  const env = getMakerEnvironment(options.env, identify.projectRoot);
+  const url = formatMakerAppWebUrl(projectId, env);
+  return (options.openMakerPage || openMakerPageInBrowser)(url);
+}
+
+function openMakerPageInBrowser(url: string): MakerPageOpenResult {
+  const command =
+    process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'cmd' : 'xdg-open';
+  const args = process.platform === 'win32' ? ['/c', 'start', '', url] : [url];
+  const result = spawnSync(command, args, {
+    stdio: 'ignore',
+    windowsHide: true,
+  });
+  if (result.error || result.status !== 0) {
+    return {
+      ok: false,
+      url,
+      error:
+        result.error?.message || `open command exited with status ${result.status ?? 'unknown'}`,
+    };
+  }
+  return { ok: true, url };
+}
+
 type BuildCurrentDirectoryResult =
   | {
       mode: 'remote_build';
@@ -1295,6 +1338,7 @@ type BuildCurrentDirectoryResult =
       previewRefresh?: PreviewRefreshResult;
       runtimeLogWatch?: RuntimeLogWatchStartResult;
       submitResult?: PushMakerProjectResult;
+      makerPageOpen?: MakerPageOpenResult;
     }
   | {
       mode: 'remote_build_failed';
@@ -1302,6 +1346,7 @@ type BuildCurrentDirectoryResult =
       projectId: string;
       buildResult: RemoteBuildResult;
       buildFailure: MakerBuildFailure;
+      makerPageOpen?: MakerPageOpenResult;
     }
   | {
       mode: 'submit_failed_before_build';
@@ -1342,23 +1387,29 @@ export async function buildCurrentDirectory(options: {
   confirmRemoteBuildWithoutSubmit?: boolean;
   submitLocalChanges?: SubmitLocalChangesForBuild;
   callRemoteBuild?: (targetDir: string) => Promise<RemoteBuildResult>;
+  openMakerPage?: OpenMakerPage;
   refreshPreview?: RefreshMakerPreview;
   startRuntimeLogWatch?: StartRuntimeLogWatch;
   onProgress?: MakerProjectProgressHandler;
 }): Promise<BuildCurrentDirectoryResult> {
   const localChanges = await readMakerProjectLocalChanges(options.targetDir);
-  if (localChanges.hasChanges && !options.confirmRemoteBuildWithoutSubmit) {
+  if (!options.confirmRemoteBuildWithoutSubmit) {
     const config = loadProjectConfig(localChanges.projectRoot);
     options.onProgress?.({
       progress: 0,
       total: 100,
       phase: 'sync',
-      message: 'Syncing local Maker changes before remote build',
+      message: localChanges.hasChanges
+        ? 'Syncing local Maker changes before remote build'
+        : 'Waking Maker build server before remote build',
     });
     const submitResult = await (options.submitLocalChanges || pushMakerProject)({
       cwd: localChanges.projectRoot,
-      message: options.message,
+      message:
+        options.message ||
+        (!localChanges.hasChanges ? 'chore: wake maker build server' : undefined),
       files: options.files,
+      allowEmpty: !localChanges.hasChanges,
       onProgress: options.onProgress,
     });
     if (submitResult.failure || (!submitResult.pushed && submitResult.status !== 'clean')) {
@@ -1387,8 +1438,12 @@ export async function buildCurrentDirectory(options: {
     };
   }
 
+  const makerPageOpen = openRemoteBuildMakerPage(options);
   try {
-    return await runRemoteBuildCurrentDirectory(options, options.targetDir);
+    return {
+      ...(await runRemoteBuildCurrentDirectory(options, options.targetDir)),
+      makerPageOpen,
+    };
   } catch (error) {
     if (error instanceof RemoteBuildFailedError) {
       return {
@@ -1397,6 +1452,7 @@ export async function buildCurrentDirectory(options: {
         projectId: error.buildResult.projectId,
         buildResult: error.buildResult,
         buildFailure: toMakerBuildFailure(error),
+        makerPageOpen,
       };
     }
     throw error;
@@ -2172,6 +2228,7 @@ export function formatBuildResult(
       '',
       `- project_root: ${result.projectRoot}`,
       `- project_id: ${result.projectId}`,
+      ...formatMakerPageOpenLines(result.makerPageOpen),
       `- maker_url: ${
         result.buildResult.makerUrl ||
         formatMakerAppWebUrl(result.buildResult.projectId, result.buildResult.env)
@@ -2276,6 +2333,7 @@ export function formatBuildResult(
     `- project_root: ${result.projectRoot}`,
     `- project_id: ${result.projectId}`,
     `- maker_url: ${result.makerUrl || formatMakerAppWebUrl(result.projectId, result.env)}`,
+    ...formatMakerPageOpenLines(result.makerPageOpen),
     `- project_path: ${result.projectPath}`,
     `- server_url: ${result.serverUrl}`,
     `- env: ${result.env}`,
@@ -2393,6 +2451,19 @@ function formatPreviewRefreshLines(result?: PreviewRefreshResult): string[] {
     `- preview_refresh_status: ${result.status}`,
     result.url ? `- preview_refresh_url: ${result.url}` : '',
     result.error ? `- preview_refresh_error: ${result.error}` : '',
+  ].filter(Boolean);
+}
+
+function formatMakerPageOpenLines(result?: MakerPageOpenResult): string[] {
+  if (!result) {
+    return [];
+  }
+
+  return [
+    `- maker_page_open: ${result.ok ? 'ok' : 'failed'}`,
+    `- maker_page_url: ${result.url}`,
+    result.error ? `- maker_page_error: ${result.error}` : '',
+    '- next_action: 已按“不提交，只构建云端版本”打开 Maker 远端页面；如果没有自动弹出，请手动打开 maker_page_url 后再查看构建结果。',
   ].filter(Boolean);
 }
 

--- a/src/maker/server/mcp.ts
+++ b/src/maker/server/mcp.ts
@@ -1311,6 +1311,7 @@ function openMakerPageInBrowser(url: string): MakerPageOpenResult {
   const result = spawnSync(command, args, {
     stdio: 'ignore',
     windowsHide: true,
+    timeout: 5000,
   });
   if (result.error || result.status !== 0) {
     return {


### PR DESCRIPTION
## 改动内容
- 普通 Maker 构建前始终先提交并推送，干净工作区会创建空提交唤醒远端服务。
- 保留明确只构建云端版本的例外路径，并在该路径打开 Maker 页面链接。
- 更新 Maker workflow 文档、README 和 Agent 指引，避免旧流程误导本地 AI。
- 补充空提交 push、remote-only 打开页面和 bundled skill 文档测试。

## 影响面
- 影响 taptap-maker 的本地提交/推送/远端构建路径。
- 影响 Maker workflow guide 和面向 Agent 的构建说明。
- 不改变主 MCP server 的 Open API 工具行为。

## 验证
- npm run format:check
- npm run lint
- npm run build
- npm test -- --runInBand