### PR TITLE
fix(maker): publish beta packages as prereleases

### DIFF
--- a/.github/workflows/publish-maker.yml
+++ b/.github/workflows/publish-maker.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version_mode:
-        description: 'Version mode: run from main or beta; auto increments only the final numeric segment'
+        description: 'Version mode: latest auto increments stable patch; beta/alpha/next auto publish prerelease'
         required: true
         default: auto-last-number
         type: choice

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -142,6 +142,7 @@ Maker Beta 用于内部预览测试，走 `@taptap/maker@beta` dist-tag，不会
 #    - Version mode: auto-last-number
 #    - tag: beta
 #    - version 留空
+#    - 例如最高稳定版本为 0.0.16 时，自动发布 0.0.17-beta.1
 
 # 3. 用户安装 Maker beta 版本
 npm install @taptap/maker@beta
@@ -361,11 +362,14 @@ npx commitlint --from HEAD~1 --to HEAD
 - 主包和 Maker 包都必须手动发版；PR 检查不再按 Maker/main 路径做发布范围拦截。
 - 主包 release workflow 不会由 Maker PR 合并自动触发。
 - 旧包 semantic-release 分析、CHANGELOG 和 GitHub Release notes 会过滤 Maker-only commits。
-- workflow 默认使用 `auto-last-number`，通常只需要选择分支后直接运行。
+- workflow 默认使用 `auto-last-number`，通常只需要选择分支和 dist-tag 后直接运行。
 - 手动版本号只在需要指定版本时填写。
 - Maker 包只能从长期发布分支 `beta` 或 `main` 发布；`fix/*` 分支只用于提交 PR，
   不作为发版来源。
-- 自动版本号只允许在 `beta` 或 `main` 分支上递增最后一个数字段。
+- 自动版本号只允许在 `beta` 或 `main` 分支上运行。
+- `tag=latest` 自动递增稳定 patch，例如 `0.0.16` → `0.0.17`。
+- `tag=beta`、`tag=alpha` 和 `tag=next` 自动发布 prerelease，例如最高稳定版本为
+  `0.0.16` 时发布 `0.0.17-beta.1`，后续同一条线发布 `0.0.17-beta.2`。
 - 手动发布如果修改三段版本号里的前两段，CI 会先在 Actions Summary 显示当前
   线上 dist-tag 版本和目标版本，再由人工点击 protected environment 审批按钮继续。
 - 发布 job 在实际 `npm publish` 前会再次检查目标版本是否仍未发布。
@@ -388,14 +392,13 @@ npx commitlint --from HEAD~1 --to HEAD
 - `package.json`、`.releaserc.cjs` 和 release workflow 等共享发布配置仍建议单独 PR，
   但该限制作为团队流程要求，不再由 PR Check 自动拦截。
 
-Maker 包版本号使用三段式 semver，例如 `0.0.1`。CI 自动递增默认在 `beta` 或 `main`
-分支使用 `auto-last-number`，且只递增最后一个数字段；如果当前 dist-tag 落后于已发布
-稳定版本，CI 会跳过已存在版本并选择同 major/minor 下未发布的下一个 patch。手动发布
-如果要改变 major 或 minor，CI 会在预检 job 的 Actions Summary 展示当前线上
-dist-tag 版本和目标版本，人工核对后点击
-protected environment 审批按钮继续发布。
-beta 发布建议使用 `0.0.6-beta.1` 这类 prerelease 版本和 `tag=beta`，正式发布使用稳定三段
-版本和 `tag=latest`，两者保持相同的 npm pack、CLI 验证和 publish 流程。
+Maker 包版本号使用 semver。CI 自动递增默认在 `beta` 或 `main` 分支使用
+`auto-last-number`：`tag=latest` 发布稳定三段版本；`tag=beta`、`tag=alpha` 和
+`tag=next` 发布 prerelease 版本。如果最高稳定版本为 `0.0.16`，下一次 beta 自动发布
+`0.0.17-beta.1`，后续同一条线递增为 `0.0.17-beta.2`；正式发布再使用稳定三段版本
+`0.0.17` 和 `tag=latest`。手动发布如果要改变 major 或 minor，CI 会在预检 job 的
+Actions Summary 展示当前线上 dist-tag 版本和目标版本，人工核对后点击 protected
+environment 审批按钮继续发布。
 
 ---
 

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -57,13 +57,13 @@ Maker-only paths 跳过这类 push；如需发布 Maker CLI，使用 GitHub Acti
 
 Maker 包版本号使用三段式 semver，例如 `0.0.1`。Maker 包只能从长期发布分支 `beta` 或
 `main` 发布，`fix/*` 分支只用于提交 PR，不作为发版来源。workflow 默认使用
-`auto-last-number`，不填版本号时只递增最后一个数字段；如果当前 dist-tag 落后于已发布稳定
-版本，CI 会跳过已存在版本并选择同 major/minor 下未发布的下一个 patch。手动发布如果修改
-major 或 minor，CI 会先在 Actions Summary 展示当前线上 dist-tag 版本和目标版本，人工核对后
-点击 protected environment 审批按钮继续发布。发布 job 在 `npm publish` 前会再次查询
-目标版本是否仍未发布，避免审批等待期间同版本被抢先发布。
-beta 发布建议使用 prerelease 版本和 `tag=beta`，正式发布使用稳定三段版本和 `tag=latest`；
-两者保持同一套 npm pack、CLI 验证和 publish 流程。
+`auto-last-number`。`tag=latest` 会递增稳定 patch；`tag=beta`、`tag=alpha` 和 `tag=next`
+会基于当前 major/minor 下最高稳定版本生成 prerelease，例如已发布最高稳定版本为 `0.0.16`
+时，下一次 beta 自动发布 `0.0.17-beta.1`，后续同一条线递增为 `0.0.17-beta.2`。
+正式发布再使用稳定三段版本和 `tag=latest`，例如 `0.0.17`，避免 beta 测试包消耗正式版本号。
+手动发布如果修改 major 或 minor，CI 会先在 Actions Summary 展示当前线上 dist-tag 版本和
+目标版本，人工核对后点击 protected environment 审批按钮继续发布。发布 job 在
+`npm publish` 前会再次查询目标版本是否仍未发布，避免审批等待期间同版本被抢先发布。
 
 ### 主包迁移说明
 

--- a/scripts/resolve-maker-version.js
+++ b/scripts/resolve-maker-version.js
@@ -16,6 +16,7 @@ const FIRST_BETA_VERSION = '0.0.1-beta.1';
 const NPM_VIEW_TIMEOUT_MS = 30 * 1000;
 const VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 const RELEASE_BRANCHES = new Set(['main', 'beta']);
+// Keep this set in sync with the prerelease tag choices in publish-maker.yml.
 const PRERELEASE_TAGS = new Set(['alpha', 'beta', 'next']);
 
 function readEnv(name, fallback = '') {
@@ -215,7 +216,7 @@ function maxPrereleaseNumberForBase(baseVersion, tag, publishedVersions) {
   }, 0);
 }
 
-function resolveStableAutoVersion(tag, hasPublishedVersions, publishedVersions) {
+function resolveStableAutoVersion(tag, hasPublishedVersions, publishedVersions, currentVersion) {
   const branch = readEnv('GITHUB_REF_NAME');
   assertAutoReleaseBranch(branch);
 
@@ -225,28 +226,29 @@ function resolveStableAutoVersion(tag, hasPublishedVersions, publishedVersions) 
     );
   }
 
-  let current;
-  try {
-    current = npmView([`dist-tags.${tag}`]);
-  } catch (error) {
+  if (!currentVersion) {
     throw new Error(
       [
         `Cannot resolve current ${PACKAGE_NAME}@${tag} dist-tag for auto mode.`,
         'Use manual mode for the first publish or when changing version shape.',
-        error instanceof Error ? error.message : String(error),
       ].join('\n')
     );
   }
 
-  assertValidVersion(current);
-  assertStableThreeSegmentVersion(current);
-  const autoBase = maxStablePatchForCurrentLine(current, publishedVersions);
+  assertValidVersion(currentVersion);
+  assertStableThreeSegmentVersion(currentVersion);
+  const autoBase = maxStablePatchForCurrentLine(currentVersion, publishedVersions);
   const next = incrementFinalNumber(autoBase);
   assertValidVersion(next);
   return next;
 }
 
-function resolvePrereleaseAutoVersion(tag, hasPublishedVersions, publishedVersions) {
+function resolvePrereleaseAutoVersion(
+  tag,
+  hasPublishedVersions,
+  publishedVersions,
+  currentVersion
+) {
   const branch = readEnv('GITHUB_REF_NAME');
   assertAutoReleaseBranch(branch);
 
@@ -256,22 +258,18 @@ function resolvePrereleaseAutoVersion(tag, hasPublishedVersions, publishedVersio
     );
   }
 
-  let current;
-  try {
-    current = npmView([`dist-tags.${tag}`]);
-  } catch (error) {
+  if (!currentVersion) {
     throw new Error(
       [
         `Cannot resolve current ${PACKAGE_NAME}@${tag} dist-tag for auto mode.`,
         'Use manual mode for the first publish or when changing version shape.',
-        error instanceof Error ? error.message : String(error),
       ].join('\n')
     );
   }
 
-  assertValidVersion(current);
+  assertValidVersion(currentVersion);
 
-  const currentCore = parseVersionCore(current);
+  const currentCore = parseVersionCore(currentVersion);
   const highestStableCore = maxStableCore(publishedVersions);
   const nextBaseCore =
     highestStableCore && compareVersionCore(highestStableCore, currentCore) >= 0
@@ -284,11 +282,16 @@ function resolvePrereleaseAutoVersion(tag, hasPublishedVersions, publishedVersio
   return next;
 }
 
-function resolveAutoVersion(tag, hasPublishedVersions, publishedVersions) {
+function resolveAutoVersion(tag, hasPublishedVersions, publishedVersions, currentVersion) {
   if (PRERELEASE_TAGS.has(tag)) {
-    return resolvePrereleaseAutoVersion(tag, hasPublishedVersions, publishedVersions);
+    return resolvePrereleaseAutoVersion(
+      tag,
+      hasPublishedVersions,
+      publishedVersions,
+      currentVersion
+    );
   }
-  return resolveStableAutoVersion(tag, hasPublishedVersions, publishedVersions);
+  return resolveStableAutoVersion(tag, hasPublishedVersions, publishedVersions, currentVersion);
 }
 
 function writeOutput(name, value) {
@@ -316,7 +319,7 @@ function main() {
   const version =
     mode === 'manual'
       ? resolveManualVersion(currentVersion)
-      : resolveAutoVersion(tag, hasPublishedVersions, publishedVersions);
+      : resolveAutoVersion(tag, hasPublishedVersions, publishedVersions, currentVersion);
   const majorMinorChanged = Boolean(
     mode === 'manual' && currentVersion && changesMajorOrMinor(currentVersion, version)
   );

--- a/scripts/resolve-maker-version.js
+++ b/scripts/resolve-maker-version.js
@@ -3,8 +3,9 @@
 /**
  * Resolve the @taptap/maker version for the manual publish workflow.
  *
- * Manual mode is only needed when specifying a target version. Auto mode only
- * increments the final numeric segment on long-lived release branches.
+ * Manual mode is only needed when specifying a target version. Auto mode keeps
+ * latest on stable patch versions and prerelease tags on tag-scoped
+ * prerelease versions, such as 0.0.17-beta.1.
  */
 
 import { execFileSync } from 'node:child_process';
@@ -15,6 +16,7 @@ const FIRST_BETA_VERSION = '0.0.1-beta.1';
 const NPM_VIEW_TIMEOUT_MS = 30 * 1000;
 const VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 const RELEASE_BRANCHES = new Set(['main', 'beta']);
+const PRERELEASE_TAGS = new Set(['alpha', 'beta', 'next']);
 
 function readEnv(name, fallback = '') {
   return process.env[name] || fallback;
@@ -36,6 +38,24 @@ function parseVersionCore(version) {
     minor: Number(match[2]),
     patch: Number(match[3]),
   };
+}
+
+function formatVersionCore(core) {
+  return `${core.major}.${core.minor}.${core.patch}`;
+}
+
+function compareVersionCore(left, right) {
+  if (left.major !== right.major) {
+    return left.major - right.major;
+  }
+  if (left.minor !== right.minor) {
+    return left.minor - right.minor;
+  }
+  return left.patch - right.patch;
+}
+
+function isStableThreeSegmentVersion(version) {
+  return /^\d+\.\d+\.\d+$/.test(version);
 }
 
 function changesMajorOrMinor(previousVersion, nextVersion) {
@@ -116,7 +136,7 @@ function incrementFinalNumber(version) {
 }
 
 function assertStableThreeSegmentVersion(version) {
-  if (!/^\d+\.\d+\.\d+$/.test(version)) {
+  if (!isStableThreeSegmentVersion(version)) {
     throw new Error(
       `auto-last-number requires a stable three-segment version like 0.0.1; got ${version}`
     );
@@ -139,20 +159,63 @@ function assertAutoReleaseBranch(branch) {
   }
 }
 
-function maxStablePatchForCurrentLine(currentVersion, publishedVersions) {
+function maxStableCore(publishedVersions) {
+  const stableVersions = publishedVersions
+    .filter(isStableThreeSegmentVersion)
+    .map((version) => parseVersionCore(version));
+
+  return stableVersions.reduce((maxCore, core) => {
+    if (!maxCore) {
+      return core;
+    }
+    return compareVersionCore(core, maxCore) > 0 ? core : maxCore;
+  }, null);
+}
+
+function maxStableCoreForCurrentLine(currentVersion, publishedVersions) {
   const current = parseVersionCore(currentVersion);
   const stableVersions = publishedVersions
-    .filter((version) => /^\d+\.\d+\.\d+$/.test(version))
+    .filter(isStableThreeSegmentVersion)
     .map((version) => ({ version, core: parseVersionCore(version) }))
     .filter(({ core }) => core.major === current.major && core.minor === current.minor);
 
-  return stableVersions.reduce((maxVersion, { version, core }) => {
-    const max = parseVersionCore(maxVersion);
-    return core.patch > max.patch ? version : maxVersion;
-  }, currentVersion);
+  return stableVersions.reduce((maxCore, { core }) => {
+    if (!maxCore) {
+      return core;
+    }
+    return compareVersionCore(core, maxCore) > 0 ? core : maxCore;
+  }, null);
 }
 
-function resolveAutoVersion(tag, hasPublishedVersions, publishedVersions) {
+function maxStablePatchForCurrentLine(currentVersion, publishedVersions) {
+  const maxCore = maxStableCoreForCurrentLine(currentVersion, publishedVersions);
+  if (!maxCore) {
+    return currentVersion;
+  }
+  return formatVersionCore(maxCore);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function readPrereleaseNumber(version, tag, baseVersion) {
+  const pattern = new RegExp(`^${escapeRegExp(baseVersion)}-${escapeRegExp(tag)}\\.(\\d+)$`);
+  const match = pattern.exec(version);
+  return match ? Number(match[1]) : null;
+}
+
+function maxPrereleaseNumberForBase(baseVersion, tag, publishedVersions) {
+  return publishedVersions.reduce((maxNumber, version) => {
+    const prereleaseNumber = readPrereleaseNumber(version, tag, baseVersion);
+    if (prereleaseNumber === null) {
+      return maxNumber;
+    }
+    return Math.max(maxNumber, prereleaseNumber);
+  }, 0);
+}
+
+function resolveStableAutoVersion(tag, hasPublishedVersions, publishedVersions) {
   const branch = readEnv('GITHUB_REF_NAME');
   assertAutoReleaseBranch(branch);
 
@@ -181,6 +244,51 @@ function resolveAutoVersion(tag, hasPublishedVersions, publishedVersions) {
   const next = incrementFinalNumber(autoBase);
   assertValidVersion(next);
   return next;
+}
+
+function resolvePrereleaseAutoVersion(tag, hasPublishedVersions, publishedVersions) {
+  const branch = readEnv('GITHUB_REF_NAME');
+  assertAutoReleaseBranch(branch);
+
+  if (!hasPublishedVersions) {
+    throw new Error(
+      `${PACKAGE_NAME} has no published versions. First publish must use manual ${FIRST_BETA_VERSION}.`
+    );
+  }
+
+  let current;
+  try {
+    current = npmView([`dist-tags.${tag}`]);
+  } catch (error) {
+    throw new Error(
+      [
+        `Cannot resolve current ${PACKAGE_NAME}@${tag} dist-tag for auto mode.`,
+        'Use manual mode for the first publish or when changing version shape.',
+        error instanceof Error ? error.message : String(error),
+      ].join('\n')
+    );
+  }
+
+  assertValidVersion(current);
+
+  const currentCore = parseVersionCore(current);
+  const highestStableCore = maxStableCore(publishedVersions);
+  const nextBaseCore =
+    highestStableCore && compareVersionCore(highestStableCore, currentCore) >= 0
+      ? parseVersionCore(incrementFinalNumber(formatVersionCore(highestStableCore)))
+      : currentCore;
+  const baseVersion = formatVersionCore(nextBaseCore);
+  const prereleaseNumber = maxPrereleaseNumberForBase(baseVersion, tag, publishedVersions) + 1;
+  const next = `${baseVersion}-${tag}.${prereleaseNumber}`;
+  assertValidVersion(next);
+  return next;
+}
+
+function resolveAutoVersion(tag, hasPublishedVersions, publishedVersions) {
+  if (PRERELEASE_TAGS.has(tag)) {
+    return resolvePrereleaseAutoVersion(tag, hasPublishedVersions, publishedVersions);
+  }
+  return resolveStableAutoVersion(tag, hasPublishedVersions, publishedVersions);
 }
 
 function writeOutput(name, value) {

--- a/src/__tests__/makerVersionPolicy.test.ts
+++ b/src/__tests__/makerVersionPolicy.test.ts
@@ -8,18 +8,23 @@ const SCRIPT_PATH = join(process.cwd(), 'scripts', 'resolve-maker-version.js');
 function createFakeNpm(
   currentVersion: string,
   existingVersions: string[] = [currentVersion],
-  versionsJson = JSON.stringify(existingVersions)
+  versionsJson = JSON.stringify(existingVersions),
+  maxDistTagQueries?: number
 ) {
   const dir = mkdtempSync(join(tmpdir(), 'maker-version-policy-'));
   const binDir = join(dir, 'bin');
   mkdirSync(binDir, { recursive: true });
   const npmPath = join(binDir, 'npm');
+  const distTagQueryCountPath = join(dir, 'dist-tag-query-count');
   writeFileSync(
     npmPath,
     `#!/usr/bin/env node
+const fs = require('fs');
 const args = process.argv.slice(2);
 const current = ${JSON.stringify(currentVersion)};
 const existing = new Set(${JSON.stringify(existingVersions)});
+const maxDistTagQueries = ${maxDistTagQueries ?? 'null'};
+const distTagQueryCountPath = ${JSON.stringify(distTagQueryCountPath)};
 if (args[0] !== 'view') {
   console.error('Unsupported npm command: ' + args.join(' '));
   process.exit(1);
@@ -31,6 +36,18 @@ if (query === '@taptap/maker' && field === 'versions') {
   process.exit(0);
 }
 if (query === '@taptap/maker' && field.startsWith('dist-tags.')) {
+  if (maxDistTagQueries !== null) {
+    let queryCount = 0;
+    try {
+      queryCount = Number(fs.readFileSync(distTagQueryCountPath, 'utf8')) || 0;
+    } catch {}
+    queryCount += 1;
+    fs.writeFileSync(distTagQueryCountPath, String(queryCount));
+    if (queryCount > maxDistTagQueries) {
+      console.error('dist-tag queried too many times: ' + queryCount);
+      process.exit(1);
+    }
+  }
   console.log(current);
   process.exit(0);
 }
@@ -219,6 +236,41 @@ describe('Maker publish version policy', () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('Resolved @taptap/maker version: 0.1.1-beta.1');
+  });
+
+  it('uses prerelease semantics for alpha and next tags', () => {
+    const alphaBin = createFakeNpm('0.0.16', ['0.0.16']);
+    const alphaResult = runResolver({
+      PATH: alphaBin,
+      MAKER_VERSION_MODE: 'auto-last-number',
+      MAKER_NPM_TAG: 'alpha',
+      GITHUB_REF_NAME: 'beta',
+    });
+    const nextBin = createFakeNpm('0.0.16', ['0.0.16']);
+    const nextResult = runResolver({
+      PATH: nextBin,
+      MAKER_VERSION_MODE: 'auto-last-number',
+      MAKER_NPM_TAG: 'next',
+      GITHUB_REF_NAME: 'beta',
+    });
+
+    expect(alphaResult.status).toBe(0);
+    expect(alphaResult.stdout).toContain('Resolved @taptap/maker version: 0.0.17-alpha.1');
+    expect(nextResult.status).toBe(0);
+    expect(nextResult.stdout).toContain('Resolved @taptap/maker version: 0.0.17-next.1');
+  });
+
+  it('queries the current dist-tag only once in auto mode', () => {
+    const fakeBin = createFakeNpm('0.0.16', ['0.0.16'], JSON.stringify(['0.0.16']), 1);
+    const result = runResolver({
+      PATH: fakeBin,
+      MAKER_VERSION_MODE: 'auto-last-number',
+      MAKER_NPM_TAG: 'beta',
+      GITHUB_REF_NAME: 'beta',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Resolved @taptap/maker version: 0.0.17-beta.1');
   });
 
   it('allows manual major or minor changes and flags approval requirement', () => {

--- a/src/__tests__/makerVersionPolicy.test.ts
+++ b/src/__tests__/makerVersionPolicy.test.ts
@@ -91,8 +91,8 @@ describe('Maker publish version policy', () => {
     expect(result.stderr).toContain('@taptap/maker can only be published from main or beta');
   });
 
-  it('allows auto-last-number from the beta release branch', () => {
-    const fakeBin = createFakeNpm('0.0.5');
+  it('resolves beta auto-last-number to the next prerelease after the highest stable version', () => {
+    const fakeBin = createFakeNpm('0.0.16', ['0.0.13', '0.0.14', '0.0.15', '0.0.16']);
     const result = runResolver({
       PATH: fakeBin,
       MAKER_VERSION_MODE: 'auto-last-number',
@@ -101,7 +101,20 @@ describe('Maker publish version policy', () => {
     });
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain('Resolved @taptap/maker version: 0.0.6');
+    expect(result.stdout).toContain('Resolved @taptap/maker version: 0.0.17-beta.1');
+  });
+
+  it('increments beta prerelease numbers within the next stable version line', () => {
+    const fakeBin = createFakeNpm('0.0.17-beta.1', ['0.0.13', '0.0.16', '0.0.17-beta.1']);
+    const result = runResolver({
+      PATH: fakeBin,
+      MAKER_VERSION_MODE: 'auto-last-number',
+      MAKER_NPM_TAG: 'beta',
+      GITHUB_REF_NAME: 'beta',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Resolved @taptap/maker version: 0.0.17-beta.2');
   });
 
   it('allows auto-last-number from the main release branch', () => {
@@ -117,7 +130,20 @@ describe('Maker publish version policy', () => {
     expect(result.stdout).toContain('Resolved @taptap/maker version: 0.0.6');
   });
 
-  it('increments past already published stable versions when a dist-tag lags behind', () => {
+  it('publishes the stable version after beta prereleases without skipping the patch', () => {
+    const fakeBin = createFakeNpm('0.0.16', ['0.0.16', '0.0.17-beta.1', '0.0.17-beta.2']);
+    const result = runResolver({
+      PATH: fakeBin,
+      MAKER_VERSION_MODE: 'auto-last-number',
+      MAKER_NPM_TAG: 'latest',
+      GITHUB_REF_NAME: 'main',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Resolved @taptap/maker version: 0.0.17');
+  });
+
+  it('uses the next prerelease base when a beta dist-tag lags behind stable versions', () => {
     const fakeBin = createFakeNpm('0.0.3', [
       '0.0.1-beta.1',
       '0.0.1-beta.2',
@@ -135,7 +161,7 @@ describe('Maker publish version policy', () => {
     });
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain('Resolved @taptap/maker version: 0.0.6');
+    expect(result.stdout).toContain('Resolved @taptap/maker version: 0.0.6-beta.1');
   });
 
   it('accepts npm versions output as a single JSON string', () => {
@@ -148,10 +174,10 @@ describe('Maker publish version policy', () => {
     });
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain('Resolved @taptap/maker version: 0.0.6');
+    expect(result.stdout).toContain('Resolved @taptap/maker version: 0.0.6-beta.1');
   });
 
-  it('rejects auto-last-number when the current dist-tag is a prerelease', () => {
+  it('continues beta prerelease numbering when the current dist-tag is a prerelease', () => {
     const fakeBin = createFakeNpm('0.0.5-beta.1');
     const result = runResolver({
       PATH: fakeBin,
@@ -160,11 +186,11 @@ describe('Maker publish version policy', () => {
       GITHUB_REF_NAME: 'beta',
     });
 
-    expect(result.status).toBe(1);
-    expect(result.stderr).toContain('auto-last-number requires a stable three-segment version');
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Resolved @taptap/maker version: 0.0.5-beta.2');
   });
 
-  it('rejects auto-last-number when a prerelease dist-tag has higher stable versions nearby', () => {
+  it('rolls beta prerelease to the next stable line when a higher stable version exists', () => {
     const fakeBin = createFakeNpm('0.0.5-beta.1', ['0.0.5-beta.1', '0.0.6']);
     const result = runResolver({
       PATH: fakeBin,
@@ -173,8 +199,26 @@ describe('Maker publish version policy', () => {
       GITHUB_REF_NAME: 'beta',
     });
 
-    expect(result.status).toBe(1);
-    expect(result.stderr).toContain('auto-last-number requires a stable three-segment version');
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Resolved @taptap/maker version: 0.0.7-beta.1');
+  });
+
+  it('uses the highest stable version across major and minor lines for beta prereleases', () => {
+    const fakeBin = createFakeNpm('0.0.17-beta.2', [
+      '0.0.16',
+      '0.0.17-beta.1',
+      '0.0.17-beta.2',
+      '0.1.0',
+    ]);
+    const result = runResolver({
+      PATH: fakeBin,
+      MAKER_VERSION_MODE: 'auto-last-number',
+      MAKER_NPM_TAG: 'beta',
+      GITHUB_REF_NAME: 'beta',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Resolved @taptap/maker version: 0.1.1-beta.1');
   });
 
   it('allows manual major or minor changes and flags approval requirement', () => {


### PR DESCRIPTION
## Summary
- Change Maker auto versioning so beta, alpha, and next tags publish prerelease versions.
- Base prerelease versions on the highest published stable version, then increment the tag number.
- Keep latest releases on stable patch versions so beta testing no longer consumes release numbers.
- Update Maker release workflow docs and add coverage for prerelease and stable promotion paths.

## Test Plan
- npm test -- makerVersionPolicy.test.ts
- npm test
- npm run lint
- npm run format:check
- npx prettier --check scripts/resolve-maker-version.js .github/workflows/publish-maker.yml docs/MAKER.md docs/CI_CD.md src/__tests__/makerVersionPolicy.test.ts