### PR TITLE
fix(maker): stop help invocations from running init

### DIFF
--- a/src/__tests__/makerCliCommands.test.ts
+++ b/src/__tests__/makerCliCommands.test.ts
@@ -1338,6 +1338,22 @@ describe('Maker CLI commands', () => {
     expect(output).toContain('- action: safe_to_kill_orphan_maker_processes');
   });
 
+  test('subcommand --help prints usage instead of running the command', async () => {
+    await runMakerCli(['init', '--help']);
+
+    const output = stdoutSpy.mock.calls.join('');
+    expect(output).toContain('Usage:');
+    expect(listMakerProjects).not.toHaveBeenCalled();
+  });
+
+  test('subcommand -h prints usage instead of running the command', async () => {
+    await runMakerCli(['doctor', '-h']);
+
+    const output = stdoutSpy.mock.calls.join('');
+    expect(output).toContain('Usage:');
+    expect(output).not.toContain('TapTap Maker doctor');
+  });
+
   test('doctor reports check_failed when the process scan cannot run', async () => {
     spawnSyncMock.mockImplementation((command, args) => {
       if (command === 'ps' && Array.isArray(args) && args.includes('-axo')) {

--- a/src/__tests__/makerLifecycle.test.ts
+++ b/src/__tests__/makerLifecycle.test.ts
@@ -45,6 +45,9 @@ describe('Maker process lifecycle guards', () => {
     expect(isDisconnectedStdioError(Object.assign(new Error('read EIO'), { code: 'EIO' }))).toBe(
       true
     );
+    expect(
+      isDisconnectedStdioError(Object.assign(new Error('read ENXIO'), { code: 'ENXIO' }))
+    ).toBe(true);
     expect(isDisconnectedStdioError(Object.assign(new Error('other'), { code: 'ENOENT' }))).toBe(
       false
     );

--- a/src/__tests__/makerLifecycle.test.ts
+++ b/src/__tests__/makerLifecycle.test.ts
@@ -42,6 +42,9 @@ describe('Maker process lifecycle guards', () => {
     expect(
       isDisconnectedStdioError(Object.assign(new Error('reset'), { code: 'ECONNRESET' }))
     ).toBe(true);
+    expect(isDisconnectedStdioError(Object.assign(new Error('read EIO'), { code: 'EIO' }))).toBe(
+      true
+    );
     expect(isDisconnectedStdioError(Object.assign(new Error('other'), { code: 'ENOENT' }))).toBe(
       false
     );

--- a/src/maker/cli/commands.ts
+++ b/src/maker/cli/commands.ts
@@ -123,6 +123,14 @@ export async function runMakerCli(argv: string[]): Promise<void> {
     return;
   }
 
+  // `--help`/`-h` after a subcommand (e.g. `taptap-maker init --help`) must print help
+  // and exit. It must NEVER fall through into the real command: init is interactive and
+  // a help-seeking invocation left running can hang forever on prompts.
+  if (parsed.options.help || parsed.options.h) {
+    printHelp();
+    return;
+  }
+
   if (command === 'init') {
     await runInit(parsed, ctx);
     return;
@@ -1767,13 +1775,24 @@ async function promptRequired(label: string): Promise<string> {
     throw new Error(`${label} is required in non-interactive mode.`);
   }
   const rl = readline.createInterface({ input, output });
+  // stdin EOF (Ctrl+D, detached terminal) closes the interface without settling the
+  // pending question promise; without this guard the prompt awaits forever.
+  let settled = false;
+  const closed = new Promise<never>((_, reject) => {
+    rl.once('close', () => {
+      if (!settled) {
+        reject(new Error(`${label} input closed before a value was provided.`));
+      }
+    });
+  });
   try {
-    const answer = await rl.question(`${label}: `);
+    const answer = await Promise.race([rl.question(`${label}: `), closed]);
     if (!answer.trim()) {
       throw new Error(`${label} cannot be empty.`);
     }
     return answer.trim();
   } finally {
+    settled = true;
     rl.close();
   }
 }

--- a/src/maker/index.ts
+++ b/src/maker/index.ts
@@ -103,6 +103,7 @@ main().catch((error) => {
 function installCrashLogging(): void {
   installStdioErrorHandler(process.stdout, 'stdout-error');
   installStdioErrorHandler(process.stderr, 'stderr-error');
+  installStdinErrorHandler();
 
   let handlingFatalError = false;
   process.on('uncaughtException', (error) => {
@@ -145,6 +146,18 @@ function installStdioErrorHandler(
   stream.on('error', (error) => {
     logCrash(source, error);
     if (isDisconnectedStdioError(error)) {
+      process.exit(0);
+    }
+  });
+}
+
+function installStdinErrorHandler(): void {
+  // Reads on a detached TTY fail with EIO/ENXIO; without a listener the stream error
+  // escalates to uncaughtException and an orphaned interactive CLI can spin forever.
+  process.stdin.on('error', (error) => {
+    logCrash('stdin-error', error);
+    if (isDisconnectedStdioError(error)) {
+      logLifecycleEvent('stdin-error-disconnected', 'Maker stdin became unreadable; exiting.');
       process.exit(0);
     }
   });

--- a/src/maker/lifecycle.ts
+++ b/src/maker/lifecycle.ts
@@ -2,7 +2,16 @@ import type { Readable } from 'node:stream';
 import { appendMakerCrashLog } from './crashLog.js';
 import type { TapTapMCPProxy } from '../mcp-proxy/proxy.js';
 
-const DISCONNECTED_STDIO_CODES = new Set(['EPIPE', 'ERR_STREAM_DESTROYED', 'ECONNRESET']);
+// EIO/ENXIO: reads on a TTY whose controlling terminal went away (closed window,
+// dropped SSH session) fail with these codes; treat them as "client gone" too,
+// otherwise an orphaned interactive CLI can spin on stdin errors at full CPU.
+const DISCONNECTED_STDIO_CODES = new Set([
+  'EPIPE',
+  'ERR_STREAM_DESTROYED',
+  'ECONNRESET',
+  'EIO',
+  'ENXIO',
+]);
 
 export function isDisconnectedStdioError(error: unknown): boolean {
   if (!error || typeof error !== 'object') {


### PR DESCRIPTION
## 改动内容

- 让 `taptap-maker init --help` / 子命令 `-h` 只打印 usage，不再执行真实命令。
- 为交互 prompt 增加 stdin close 兜底，避免 detached 终端下永久等待。
- 将 EIO/ENXIO 识别为断开的 stdio，并在 stdin 不可读时退出。

## 验证

- `npx jest src/__tests__/makerCliCommands.test.ts src/__tests__/makerLifecycle.test.ts --runInBand`
- `npm run build`