### PR TITLE
fix(proxy): exit standalone proxy on stdio disconnect

### DIFF
--- a/docs/PROXY.md
+++ b/docs/PROXY.md
@@ -1147,6 +1147,20 @@ HTTP 403 - Authorization failed
 - ✅ 直接运行：`node proxy.js`
 - ✅ 跨平台（Node.js 18.14.1+）
 
+### 6.1.1 进程生命周期
+
+Standalone Proxy 只在宿主连接明确断开时被动退出，不会因为空闲时间或固定 TTL 主动
+自杀。退出触发条件包括：
+
+- stdin `end` / `close`
+- stdin / stdout / stderr 出现断连类错误（如 `EPIPE`、`EIO`、`ENXIO`）
+- 父进程死亡（Linux/macOS 下 PPID 变为 1，或探测父 PID 返回 `ESRCH`）
+- `SIGINT` / `SIGTERM`
+
+触发退出时，Proxy 会先执行本地 cleanup，停止健康检查和重连定时器，再以 exit 0
+结束进程。宿主进程（例如 TapCode 后端）应保持 Proxy 的 stdin 管道打开；如果宿主异常
+退出或关闭 stdin，Proxy 会自动退出，避免孤儿进程继续访问远端 MCP 服务。
+
 ### 6.2 获取文件
 
 #### 方式 1：从 npm 包中提取

--- a/src/__tests__/mcpProxyLifecycle.test.ts
+++ b/src/__tests__/mcpProxyLifecycle.test.ts
@@ -1,5 +1,29 @@
 import { PassThrough } from 'node:stream';
 import { installStandaloneProxyLifecycleHandlers } from '../mcp-proxy/lifecycle';
+import { TapTapMCPProxy } from '../mcp-proxy/proxy';
+import type { ProxyConfig } from '../mcp-proxy/types';
+
+function createProxyConfig(): ProxyConfig {
+  return {
+    server: {
+      url: 'http://127.0.0.1:1/mcp',
+    },
+    tenant: {
+      project_path: '/tmp/project',
+    },
+    auth: {
+      kid: 'kid-1',
+      mac_key: 'mac-key-1',
+      token_type: 'mac',
+      mac_algorithm: 'hmac-sha-1',
+    },
+    options: {
+      log: {
+        enabled: false,
+      },
+    },
+  };
+}
 
 describe('standalone MCP proxy lifecycle guards', () => {
   test('cleans up and exits when stdin closes', () => {
@@ -104,5 +128,23 @@ describe('standalone MCP proxy lifecycle guards', () => {
       'standalone-proxy-stdio-error',
       'Standalone proxy stdio error ignored: ordinary stream failure'
     );
+  });
+
+  test('lifecycle logging does not throw when stderr is already disconnected', () => {
+    const proxy = new TapTapMCPProxy(createProxyConfig());
+    const writeSync = jest.fn(() => {
+      throw Object.assign(new Error('broken pipe'), { code: 'EPIPE' });
+    });
+    const proxyInternals = proxy as unknown as {
+      logWriter: {
+        writeSync: (level: string, message: string) => void;
+      };
+    };
+    proxyInternals.logWriter = { writeSync };
+
+    expect(() => {
+      proxy.logLifecycleEvent('standalone-proxy-stdio-disconnected', 'exiting');
+    }).not.toThrow();
+    expect(writeSync).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/__tests__/mcpProxyLifecycle.test.ts
+++ b/src/__tests__/mcpProxyLifecycle.test.ts
@@ -1,0 +1,108 @@
+import { PassThrough } from 'node:stream';
+import { installStandaloneProxyLifecycleHandlers } from '../mcp-proxy/lifecycle';
+
+describe('standalone MCP proxy lifecycle guards', () => {
+  test('cleans up and exits when stdin closes', () => {
+    const stdin = new PassThrough();
+    const cleanup = jest.fn();
+    const exit = jest.fn();
+    const log = jest.fn();
+
+    installStandaloneProxyLifecycleHandlers({
+      proxy: { cleanup },
+      stdin,
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      exit,
+      log,
+      installSignals: false,
+      installParentWatchdog: false,
+    });
+
+    stdin.emit('end');
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(0);
+    expect(log).toHaveBeenCalledWith(
+      'standalone-proxy-stdin-closed',
+      'Standalone proxy stdin closed; exiting.'
+    );
+  });
+
+  test('cleans up and exits on disconnected stdio errors', () => {
+    const stdin = new PassThrough();
+    const cleanup = jest.fn();
+    const exit = jest.fn();
+    const log = jest.fn();
+
+    installStandaloneProxyLifecycleHandlers({
+      proxy: { cleanup },
+      stdin,
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      exit,
+      log,
+      installSignals: false,
+      installParentWatchdog: false,
+    });
+
+    stdin.emit('error', Object.assign(new Error('read ENXIO'), { code: 'ENXIO' }));
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(0);
+    expect(log).toHaveBeenCalledWith(
+      'standalone-proxy-stdio-disconnected',
+      'Standalone proxy stdio disconnected; exiting.'
+    );
+  });
+
+  test('runs cleanup once when multiple lifecycle exits fire', () => {
+    const stdin = new PassThrough();
+    const cleanup = jest.fn();
+    const exit = jest.fn();
+
+    installStandaloneProxyLifecycleHandlers({
+      proxy: { cleanup },
+      stdin,
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      exit,
+      log: jest.fn(),
+      installSignals: false,
+      installParentWatchdog: false,
+    });
+
+    stdin.emit('end');
+    stdin.emit('error', Object.assign(new Error('broken pipe'), { code: 'EPIPE' }));
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledTimes(1);
+  });
+
+  test('swallows non-disconnected stdio errors without exiting', () => {
+    const cleanup = jest.fn();
+    const exit = jest.fn();
+    const log = jest.fn();
+    const stderr = new PassThrough();
+
+    installStandaloneProxyLifecycleHandlers({
+      proxy: { cleanup },
+      stdin: new PassThrough(),
+      stdout: new PassThrough(),
+      stderr,
+      exit,
+      log,
+      installSignals: false,
+      installParentWatchdog: false,
+    });
+
+    stderr.emit('error', Object.assign(new Error('ordinary stream failure'), { code: 'EINVAL' }));
+
+    expect(cleanup).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(
+      'standalone-proxy-stdio-error',
+      'Standalone proxy stdio error ignored: ordinary stream failure'
+    );
+  });
+});

--- a/src/__tests__/processLifecycle.test.ts
+++ b/src/__tests__/processLifecycle.test.ts
@@ -1,0 +1,118 @@
+import { PassThrough } from 'node:stream';
+import {
+  installParentDeathWatchdog,
+  installStdinExitHandler,
+  isDisconnectedStdioError,
+  shouldExitForParentDeath,
+} from '../core/utils/processLifecycle';
+
+describe('shared process lifecycle guards', () => {
+  test('treats disconnected stdio stream errors as client shutdown', () => {
+    expect(
+      isDisconnectedStdioError(Object.assign(new Error('broken pipe'), { code: 'EPIPE' }))
+    ).toBe(true);
+    expect(
+      isDisconnectedStdioError(
+        Object.assign(new Error('stream destroyed'), { code: 'ERR_STREAM_DESTROYED' })
+      )
+    ).toBe(true);
+    expect(
+      isDisconnectedStdioError(Object.assign(new Error('reset'), { code: 'ECONNRESET' }))
+    ).toBe(true);
+    expect(isDisconnectedStdioError(Object.assign(new Error('read EIO'), { code: 'EIO' }))).toBe(
+      true
+    );
+    expect(
+      isDisconnectedStdioError(Object.assign(new Error('read ENXIO'), { code: 'ENXIO' }))
+    ).toBe(true);
+    expect(isDisconnectedStdioError(Object.assign(new Error('other'), { code: 'ENOENT' }))).toBe(
+      false
+    );
+  });
+
+  test('runs cleanup once before exiting on stdin end and close', () => {
+    const stdin = new PassThrough();
+    const cleanup = jest.fn();
+    const exit = jest.fn();
+    const log = jest.fn();
+
+    installStdinExitHandler({
+      stdin,
+      cleanup,
+      exit,
+      log,
+      source: 'test-stdin-closed',
+      message: 'stdin closed',
+    });
+
+    stdin.emit('end');
+    stdin.emit('close');
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(0);
+    expect(log).toHaveBeenCalledWith('test-stdin-closed', 'stdin closed');
+  });
+
+  test('detects parent death from orphan ppid or ESRCH probe', () => {
+    expect(
+      shouldExitForParentDeath({
+        initialPpid: 123,
+        currentPpid: 1,
+        platform: 'darwin',
+        probeParent: () => true,
+      })
+    ).toBe(true);
+
+    expect(
+      shouldExitForParentDeath({
+        initialPpid: 123,
+        currentPpid: 456,
+        platform: 'win32',
+        probeParent: () => {
+          throw Object.assign(new Error('missing'), { code: 'ESRCH' });
+        },
+      })
+    ).toBe(true);
+
+    expect(
+      shouldExitForParentDeath({
+        initialPpid: 123,
+        currentPpid: 456,
+        platform: 'linux',
+        probeParent: () => true,
+      })
+    ).toBe(false);
+  });
+
+  test('parent death watchdog cleans up and exits when parent disappears', () => {
+    jest.useFakeTimers();
+    try {
+      const cleanup = jest.fn();
+      const exit = jest.fn();
+      const log = jest.fn();
+
+      const timer = installParentDeathWatchdog({
+        cleanup,
+        exit,
+        log,
+        source: 'test-parent-dead',
+        message: 'parent dead',
+        intervalMs: 1000,
+        initialPpid: 123,
+        getCurrentPpid: () => 1,
+        platform: 'darwin',
+        probeParent: () => true,
+      });
+
+      jest.advanceTimersByTime(1000);
+      jest.advanceTimersByTime(1000);
+
+      expect(cleanup).toHaveBeenCalledTimes(1);
+      expect(exit).toHaveBeenCalledWith(0);
+      expect(log).toHaveBeenCalledWith('test-parent-dead', 'parent dead');
+      clearInterval(timer);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/src/__tests__/processLifecycle.test.ts
+++ b/src/__tests__/processLifecycle.test.ts
@@ -2,6 +2,7 @@ import { PassThrough } from 'node:stream';
 import {
   installParentDeathWatchdog,
   installStdinExitHandler,
+  installStdioErrorHandlers,
   isDisconnectedStdioError,
   shouldExitForParentDeath,
 } from '../core/utils/processLifecycle';
@@ -51,6 +52,28 @@ describe('shared process lifecycle guards', () => {
     expect(cleanup).toHaveBeenCalledTimes(1);
     expect(exit).toHaveBeenCalledWith(0);
     expect(log).toHaveBeenCalledWith('test-stdin-closed', 'stdin closed');
+  });
+
+  test('stdin exit handler can delegate closed exits to caller-owned logic', () => {
+    const stdin = new PassThrough();
+    const cleanup = jest.fn();
+    const exit = jest.fn();
+    const onClosed = jest.fn();
+
+    installStdinExitHandler({
+      stdin,
+      cleanup,
+      exit,
+      source: 'test-stdin-closed',
+      message: 'stdin closed',
+      onClosed,
+    });
+
+    stdin.emit('end');
+
+    expect(onClosed).toHaveBeenCalledWith('test-stdin-closed', 'stdin closed');
+    expect(cleanup).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
   });
 
   test('detects parent death from orphan ppid or ESRCH probe', () => {
@@ -114,5 +137,51 @@ describe('shared process lifecycle guards', () => {
     } finally {
       jest.useRealTimers();
     }
+  });
+
+  test('stdio error handler accepts a caller-owned ignored error message', () => {
+    const stream = new PassThrough();
+    const log = jest.fn();
+
+    installStdioErrorHandlers({
+      streams: [stream],
+      cleanup: jest.fn(),
+      exit: jest.fn(),
+      log,
+      disconnectedSource: 'test-disconnected',
+      disconnectedMessage: 'stdio disconnected',
+      ignoredSource: 'test-stdio-error',
+      ignoredMessage: (error) =>
+        `test stdio error ignored: ${error instanceof Error ? error.message : String(error)}`,
+    });
+
+    stream.emit('error', Object.assign(new Error('ordinary failure'), { code: 'EINVAL' }));
+
+    expect(log).toHaveBeenCalledWith(
+      'test-stdio-error',
+      'test stdio error ignored: ordinary failure'
+    );
+  });
+
+  test('stdio error handler can delegate disconnected exits to caller-owned logic', () => {
+    const stream = new PassThrough();
+    const cleanup = jest.fn();
+    const exit = jest.fn();
+    const onDisconnected = jest.fn();
+
+    installStdioErrorHandlers({
+      streams: [stream],
+      cleanup,
+      exit,
+      disconnectedSource: 'test-disconnected',
+      disconnectedMessage: 'stdio disconnected',
+      onDisconnected,
+    });
+
+    stream.emit('error', Object.assign(new Error('broken pipe'), { code: 'EPIPE' }));
+
+    expect(onDisconnected).toHaveBeenCalledWith('test-disconnected', 'stdio disconnected');
+    expect(cleanup).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
   });
 });

--- a/src/core/utils/processLifecycle.ts
+++ b/src/core/utils/processLifecycle.ts
@@ -1,0 +1,163 @@
+import type { EventEmitter } from 'node:events';
+import type { Readable } from 'node:stream';
+
+export type LifecycleLog = (source: string, message: string) => void;
+
+const DISCONNECTED_STDIO_CODES = new Set([
+  'EPIPE',
+  'ERR_STREAM_DESTROYED',
+  'ECONNRESET',
+  'EIO',
+  'ENXIO',
+]);
+
+export function isDisconnectedStdioError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+  const code = (error as { code?: unknown }).code;
+  if (typeof code === 'string' && DISCONNECTED_STDIO_CODES.has(code)) {
+    return true;
+  }
+  const message = error instanceof Error ? error.message.toLowerCase() : '';
+  return message.includes('epipe') || message.includes('stream destroyed');
+}
+
+/**
+ * Decides whether a child process should exit because its parent process died.
+ *
+ * Platform caveat: on Windows `process.ppid` never becomes 1, so detection relies on
+ * probing the original parent PID. Windows reuses PIDs aggressively, so a dead parent
+ * whose PID was recycled makes the probe succeed and the watchdog never fires. That
+ * failure direction is safe (it keeps a process alive, never kills a healthy one); on
+ * Windows the reliable exit signals are stdin end/close plus the EPIPE stdio guards.
+ */
+export function shouldExitForParentDeath(options: {
+  initialPpid: number;
+  currentPpid: number;
+  platform: NodeJS.Platform;
+  probeParent: () => boolean;
+}): boolean {
+  if (
+    (options.platform === 'darwin' || options.platform === 'linux') &&
+    options.initialPpid > 1 &&
+    options.currentPpid === 1
+  ) {
+    return true;
+  }
+
+  try {
+    options.probeParent();
+    return false;
+  } catch (error) {
+    return Boolean(
+      error &&
+        typeof error === 'object' &&
+        (error as { code?: unknown }).code === 'ESRCH' &&
+        options.initialPpid > 1
+    );
+  }
+}
+
+export function installStdinExitHandler(options: {
+  stdin?: Readable;
+  cleanup: () => void;
+  exit?: (code: number) => void;
+  log?: LifecycleLog;
+  source: string;
+  message: string;
+}): void {
+  const stdin = options.stdin ?? process.stdin;
+  const exit = options.exit ?? ((code: number) => process.exit(code));
+  let exiting = false;
+
+  const exitOnStdinClosed = (): void => {
+    if (exiting) {
+      return;
+    }
+    exiting = true;
+    options.log?.(options.source, options.message);
+    options.cleanup();
+    exit(0);
+  };
+
+  stdin.once('end', exitOnStdinClosed);
+  stdin.once('close', exitOnStdinClosed);
+}
+
+export function installParentDeathWatchdog(options: {
+  cleanup: () => void;
+  exit?: (code: number) => void;
+  log?: LifecycleLog;
+  source: string;
+  message: string;
+  intervalMs?: number;
+  initialPpid?: number;
+  getCurrentPpid?: () => number;
+  platform?: NodeJS.Platform;
+  probeParent?: () => boolean;
+}): NodeJS.Timeout {
+  const initialPpid = options.initialPpid ?? process.ppid;
+  const getCurrentPpid = options.getCurrentPpid ?? (() => process.ppid);
+  const platform = options.platform ?? process.platform;
+  const probeParent = options.probeParent ?? (() => process.kill(initialPpid, 0));
+  const exit = options.exit ?? ((code: number) => process.exit(code));
+  let exiting = false;
+
+  const timer = setInterval(() => {
+    if (exiting) {
+      return;
+    }
+    const shouldExit = shouldExitForParentDeath({
+      initialPpid,
+      currentPpid: getCurrentPpid(),
+      platform,
+      probeParent,
+    });
+    if (!shouldExit) {
+      return;
+    }
+    exiting = true;
+    options.log?.(options.source, options.message);
+    options.cleanup();
+    exit(0);
+  }, options.intervalMs ?? 15_000);
+  timer.unref?.();
+  return timer;
+}
+
+export function installStdioErrorHandlers(options: {
+  streams: EventEmitter[];
+  cleanup: () => void;
+  exit?: (code: number) => void;
+  log?: LifecycleLog;
+  disconnectedSource: string;
+  disconnectedMessage: string;
+  ignoredSource?: string;
+}): void {
+  const exit = options.exit ?? ((code: number) => process.exit(code));
+  let exiting = false;
+
+  for (const stream of options.streams) {
+    stream.on('error', (error) => {
+      if (!isDisconnectedStdioError(error)) {
+        options.log?.(
+          options.ignoredSource ?? 'stdio-error',
+          `Standalone proxy stdio error ignored: ${formatError(error)}`
+        );
+        return;
+      }
+      if (exiting) {
+        return;
+      }
+      exiting = true;
+      options.log?.(options.disconnectedSource, options.disconnectedMessage);
+      options.cleanup();
+      exit(0);
+    });
+  }
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/core/utils/processLifecycle.ts
+++ b/src/core/utils/processLifecycle.ts
@@ -66,6 +66,7 @@ export function installStdinExitHandler(options: {
   log?: LifecycleLog;
   source: string;
   message: string;
+  onClosed?: (source: string, message: string) => void;
 }): void {
   const stdin = options.stdin ?? process.stdin;
   const exit = options.exit ?? ((code: number) => process.exit(code));
@@ -76,6 +77,10 @@ export function installStdinExitHandler(options: {
       return;
     }
     exiting = true;
+    if (options.onClosed) {
+      options.onClosed(options.source, options.message);
+      return;
+    }
     options.log?.(options.source, options.message);
     options.cleanup();
     exit(0);
@@ -133,7 +138,9 @@ export function installStdioErrorHandlers(options: {
   log?: LifecycleLog;
   disconnectedSource: string;
   disconnectedMessage: string;
+  onDisconnected?: (source: string, message: string) => void;
   ignoredSource?: string;
+  ignoredMessage?: (error: unknown) => string;
 }): void {
   const exit = options.exit ?? ((code: number) => process.exit(code));
   let exiting = false;
@@ -143,7 +150,9 @@ export function installStdioErrorHandlers(options: {
       if (!isDisconnectedStdioError(error)) {
         options.log?.(
           options.ignoredSource ?? 'stdio-error',
-          `Standalone proxy stdio error ignored: ${formatError(error)}`
+          options.ignoredMessage
+            ? options.ignoredMessage(error)
+            : `stdio error ignored: ${formatError(error)}`
         );
         return;
       }
@@ -151,6 +160,10 @@ export function installStdioErrorHandlers(options: {
         return;
       }
       exiting = true;
+      if (options.onDisconnected) {
+        options.onDisconnected(options.disconnectedSource, options.disconnectedMessage);
+        return;
+      }
       options.log?.(options.disconnectedSource, options.disconnectedMessage);
       options.cleanup();
       exit(0);

--- a/src/maker/lifecycle.ts
+++ b/src/maker/lifecycle.ts
@@ -1,84 +1,28 @@
 import type { Readable } from 'node:stream';
 import { appendMakerCrashLog } from './crashLog.js';
 import type { TapTapMCPProxy } from '../mcp-proxy/proxy.js';
-
-// EIO/ENXIO: reads on a TTY whose controlling terminal went away (closed window,
-// dropped SSH session) fail with these codes; treat them as "client gone" too,
-// otherwise an orphaned interactive CLI can spin on stdin errors at full CPU.
-const DISCONNECTED_STDIO_CODES = new Set([
-  'EPIPE',
-  'ERR_STREAM_DESTROYED',
-  'ECONNRESET',
-  'EIO',
-  'ENXIO',
-]);
-
-export function isDisconnectedStdioError(error: unknown): boolean {
-  if (!error || typeof error !== 'object') {
-    return false;
-  }
-  const code = (error as { code?: unknown }).code;
-  if (typeof code === 'string' && DISCONNECTED_STDIO_CODES.has(code)) {
-    return true;
-  }
-  const message = error instanceof Error ? error.message.toLowerCase() : '';
-  return message.includes('epipe') || message.includes('stream destroyed');
-}
-
-/**
- * Decides whether the embedded proxy should exit because its parent process died.
- *
- * Platform caveat: on Windows `process.ppid` never becomes 1, so detection relies on
- * probing the original parent PID. Windows reuses PIDs aggressively, so a dead parent
- * whose PID was recycled makes the probe succeed and the watchdog never fires. That
- * failure direction is safe (it keeps a process alive, never kills a healthy one); on
- * Windows the reliable exit signals are stdin end/close plus the EPIPE stdio guards.
- */
-export function shouldExitForParentDeath(options: {
-  initialPpid: number;
-  currentPpid: number;
-  platform: NodeJS.Platform;
-  probeParent: () => boolean;
-}): boolean {
-  if (
-    (options.platform === 'darwin' || options.platform === 'linux') &&
-    options.initialPpid > 1 &&
-    options.currentPpid === 1
-  ) {
-    return true;
-  }
-
-  try {
-    options.probeParent();
-    return false;
-  } catch (error) {
-    return Boolean(
-      error &&
-        typeof error === 'object' &&
-        (error as { code?: unknown }).code === 'ESRCH' &&
-        options.initialPpid > 1
-    );
-  }
-}
+export {
+  isDisconnectedStdioError,
+  shouldExitForParentDeath,
+} from '../core/utils/processLifecycle.js';
+import {
+  installParentDeathWatchdog as installSharedParentDeathWatchdog,
+  installStdinExitHandler,
+} from '../core/utils/processLifecycle.js';
 
 export function installProxyStdinExitHandler(
   proxy: Pick<TapTapMCPProxy, 'cleanup'>,
   stdin: Readable = process.stdin,
   exit: (code: number) => void = (code) => process.exit(code)
 ): void {
-  let exiting = false;
-  const exitOnStdinClosed = (): void => {
-    if (exiting) {
-      return;
-    }
-    exiting = true;
-    logLifecycleEvent('proxy-stdin-closed', 'Embedded Maker proxy stdin closed; exiting.');
-    proxy.cleanup();
-    exit(0);
-  };
-
-  stdin.once('end', exitOnStdinClosed);
-  stdin.once('close', exitOnStdinClosed);
+  installStdinExitHandler({
+    stdin,
+    cleanup: () => proxy.cleanup(),
+    exit,
+    log: logLifecycleEvent,
+    source: 'proxy-stdin-closed',
+    message: 'Embedded Maker proxy stdin closed; exiting.',
+  });
 }
 
 export function installParentDeathWatchdog(
@@ -90,31 +34,16 @@ export function installParentDeathWatchdog(
     exit?: (code: number) => void;
   } = {}
 ): NodeJS.Timeout {
-  const initialPpid = options.initialPpid ?? process.ppid;
-  const getCurrentPpid = options.getCurrentPpid ?? (() => process.ppid);
-  const exit = options.exit ?? ((code: number) => process.exit(code));
-  let exiting = false;
-
-  const timer = setInterval(() => {
-    if (exiting) {
-      return;
-    }
-    const shouldExit = shouldExitForParentDeath({
-      initialPpid,
-      currentPpid: getCurrentPpid(),
-      platform: process.platform,
-      probeParent: () => process.kill(initialPpid, 0),
-    });
-    if (!shouldExit) {
-      return;
-    }
-    exiting = true;
-    logLifecycleEvent('proxy-parent-dead', 'Embedded Maker proxy parent process is gone; exiting.');
-    proxy.cleanup();
-    exit(0);
-  }, options.intervalMs ?? 15_000);
-  timer.unref?.();
-  return timer;
+  return installSharedParentDeathWatchdog({
+    cleanup: () => proxy.cleanup(),
+    exit: options.exit,
+    log: logLifecycleEvent,
+    source: 'proxy-parent-dead',
+    message: 'Embedded Maker proxy parent process is gone; exiting.',
+    intervalMs: options.intervalMs,
+    initialPpid: options.initialPpid,
+    getCurrentPpid: options.getCurrentPpid,
+  });
 }
 
 export function logLifecycleEvent(source: string, message: string): void {

--- a/src/mcp-proxy/index.ts
+++ b/src/mcp-proxy/index.ts
@@ -12,6 +12,7 @@
 
 import { TapTapMCPProxy } from './proxy.js';
 import { loadConfig } from './config.js';
+import { installStandaloneProxyLifecycleHandlers } from './lifecycle.js';
 
 /**
  * 主函数
@@ -37,15 +38,11 @@ async function main() {
     const proxy = new TapTapMCPProxy(config);
     await proxy.start();
 
-    // 3. 处理进程信号
-    const cleanup = () => {
-      console.error('[Proxy] Shutting down...');
-      proxy.cleanup();
-      process.exit(0);
-    };
-
-    process.on('SIGINT', cleanup);
-    process.on('SIGTERM', cleanup);
+    // 3. 处理进程生命周期
+    installStandaloneProxyLifecycleHandlers({
+      proxy,
+      log: (source, message) => proxy.logLifecycleEvent(source, message),
+    });
   } catch (error) {
     console.error('[Proxy] Fatal error:', error instanceof Error ? error.message : String(error));
     process.exit(1);

--- a/src/mcp-proxy/lifecycle.ts
+++ b/src/mcp-proxy/lifecycle.ts
@@ -1,0 +1,87 @@
+import type { EventEmitter } from 'node:events';
+import type { Readable, Writable } from 'node:stream';
+import {
+  installParentDeathWatchdog,
+  installStdinExitHandler,
+  installStdioErrorHandlers,
+  type LifecycleLog,
+} from '../core/utils/processLifecycle.js';
+
+type ProxyWithCleanup = {
+  cleanup: () => void;
+};
+
+export function installStandaloneProxyLifecycleHandlers(options: {
+  proxy: ProxyWithCleanup;
+  stdin?: Readable;
+  stdout?: Writable;
+  stderr?: Writable;
+  exit?: (code: number) => void;
+  log?: LifecycleLog;
+  installSignals?: boolean;
+  installParentWatchdog?: boolean;
+}): NodeJS.Timeout | undefined {
+  const stdin = options.stdin ?? process.stdin;
+  const stdout = options.stdout ?? process.stdout;
+  const stderr = options.stderr ?? process.stderr;
+  const exit = options.exit ?? ((code: number) => process.exit(code));
+  const log = options.log;
+  let exiting = false;
+
+  const exitOnce = (source: string, message: string): void => {
+    if (exiting) {
+      return;
+    }
+    exiting = true;
+    log?.(source, message);
+    options.proxy.cleanup();
+    exit(0);
+  };
+
+  installStdinExitHandler({
+    stdin,
+    cleanup: () =>
+      exitOnce('standalone-proxy-stdin-closed', 'Standalone proxy stdin closed; exiting.'),
+    exit: () => undefined,
+    source: 'standalone-proxy-stdin-closed',
+    message: 'Standalone proxy stdin closed; exiting.',
+  });
+
+  installStdioErrorHandlers({
+    streams: [stdin, stdout, stderr].filter(Boolean) as EventEmitter[],
+    cleanup: () =>
+      exitOnce(
+        'standalone-proxy-stdio-disconnected',
+        'Standalone proxy stdio disconnected; exiting.'
+      ),
+    exit: () => undefined,
+    log: (source, message) => {
+      if (source !== 'standalone-proxy-stdio-disconnected') {
+        log?.(source, message);
+      }
+    },
+    disconnectedSource: 'standalone-proxy-stdio-disconnected',
+    disconnectedMessage: 'Standalone proxy stdio disconnected; exiting.',
+    ignoredSource: 'standalone-proxy-stdio-error',
+  });
+
+  if (options.installSignals !== false) {
+    const signalCleanup = (): void => {
+      exitOnce('standalone-proxy-signal', 'Standalone proxy received shutdown signal; exiting.');
+    };
+    process.on('SIGINT', signalCleanup);
+    process.on('SIGTERM', signalCleanup);
+  }
+
+  if (options.installParentWatchdog === false) {
+    return undefined;
+  }
+
+  return installParentDeathWatchdog({
+    cleanup: () =>
+      exitOnce('standalone-proxy-parent-dead', 'Standalone proxy parent process is gone; exiting.'),
+    exit: () => undefined,
+    source: 'standalone-proxy-parent-dead',
+    message: 'Standalone proxy parent process is gone; exiting.',
+  });
+}

--- a/src/mcp-proxy/lifecycle.ts
+++ b/src/mcp-proxy/lifecycle.ts
@@ -40,29 +40,23 @@ export function installStandaloneProxyLifecycleHandlers(options: {
 
   installStdinExitHandler({
     stdin,
-    cleanup: () =>
-      exitOnce('standalone-proxy-stdin-closed', 'Standalone proxy stdin closed; exiting.'),
+    cleanup: () => undefined,
     exit: () => undefined,
     source: 'standalone-proxy-stdin-closed',
     message: 'Standalone proxy stdin closed; exiting.',
+    onClosed: exitOnce,
   });
 
   installStdioErrorHandlers({
     streams: [stdin, stdout, stderr].filter(Boolean) as EventEmitter[],
-    cleanup: () =>
-      exitOnce(
-        'standalone-proxy-stdio-disconnected',
-        'Standalone proxy stdio disconnected; exiting.'
-      ),
+    cleanup: () => undefined,
     exit: () => undefined,
-    log: (source, message) => {
-      if (source !== 'standalone-proxy-stdio-disconnected') {
-        log?.(source, message);
-      }
-    },
+    log,
     disconnectedSource: 'standalone-proxy-stdio-disconnected',
     disconnectedMessage: 'Standalone proxy stdio disconnected; exiting.',
+    onDisconnected: exitOnce,
     ignoredSource: 'standalone-proxy-stdio-error',
+    ignoredMessage: (error) => `Standalone proxy stdio error ignored: ${formatError(error)}`,
   });
 
   if (options.installSignals !== false) {
@@ -84,4 +78,8 @@ export function installStandaloneProxyLifecycleHandlers(options: {
     source: 'standalone-proxy-parent-dead',
     message: 'Standalone proxy parent process is gone; exiting.',
   });
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/src/mcp-proxy/proxy.ts
+++ b/src/mcp-proxy/proxy.ts
@@ -128,7 +128,11 @@ export class TapTapMCPProxy {
   }
 
   public logLifecycleEvent(source: string, message: string): void {
-    this.log('info', `lifecycle:${source}: ${message}`);
+    try {
+      this.log('info', `lifecycle:${source}: ${message}`);
+    } catch {
+      // Lifecycle logging must not keep a broken stdio process alive.
+    }
   }
 
   /**

--- a/src/mcp-proxy/proxy.ts
+++ b/src/mcp-proxy/proxy.ts
@@ -127,6 +127,10 @@ export class TapTapMCPProxy {
     this.logWriter.writeSync(level, formattedMessage);
   }
 
+  public logLifecycleEvent(source: string, message: string): void {
+    this.log('info', `lifecycle:${source}: ${message}`);
+  }
+
   /**
    * 启动 Proxy
    */


### PR DESCRIPTION
## Summary
- Extract shared process lifecycle guards for stdio disconnect and parent-death handling.
- Wire standalone proxy cleanup to stdin close, stdio disconnect, parent death, and shutdown signals.
- Keep Maker embedded proxy lifecycle exports compatible and document standalone proxy passive-exit semantics.

## Risk
- R1: standalone proxy could stay alive as an orphan after the host process disconnected.
- This change keeps the no-TTL rule: the proxy exits only on explicit disconnect, signal, or parent death.

## Test Plan
- [x] npm run build
- [x] npm test
- [x] Manual smoke: standalone proxy stdin close exits within 1s
- [x] Manual smoke: killed parent causes proxy exit within watchdog interval
- [x] Manual smoke: normal 30 minute idle run does not exit