### PR TITLE
feat(maker): add package update policy check

### DIFF
--- a/.github/workflows/publish-maker.yml
+++ b/.github/workflows/publish-maker.yml
@@ -27,8 +27,9 @@ on:
           - alpha
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
+  pull-requests: write
 
 jobs:
   resolve-version:
@@ -137,3 +138,44 @@ jobs:
           MAKER_PACKAGE_VERSION: ${{ needs.resolve-version.outputs.version }}
           NPM_TAG: ${{ inputs.tag }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Update Maker version policy
+        id: version-policy
+        run: |
+          node scripts/update-maker-version-policy.cjs \
+            --tag "$NPM_TAG" \
+            --version "$MAKER_PACKAGE_VERSION"
+        env:
+          MAKER_PACKAGE_VERSION: ${{ needs.resolve-version.outputs.version }}
+          NPM_TAG: ${{ inputs.tag }}
+
+      - name: Generate version policy PR token
+        id: version-policy-token
+        if: steps.version-policy.outputs.changed == 'true'
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Create Maker version policy PR
+        if: steps.version-policy.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ steps.version-policy-token.outputs.token }}
+          branch: chore/update-maker-version-policy-${{ needs.resolve-version.outputs.version }}
+          delete-branch: true
+          title: 'chore(maker): update maker version policy for ${{ needs.resolve-version.outputs.version }}'
+          commit-message: |
+            chore(maker): update maker version policy
+
+            - Update config/maker-version-policy.json after @taptap/maker publish
+            - Preserve minimum_supported, blacklist, and message policy fields
+            - Verification: publish-maker workflow completed npm publish first
+          body: |
+            Updates `config/maker-version-policy.json` after publishing
+            `@taptap/maker@${{ needs.resolve-version.outputs.version }}` with npm tag
+            `${{ inputs.tag }}`.
+
+            The workflow only updates `latest` or `latest_beta` plus `updated_at`.
+            Manual policy fields such as `minimum_supported`, `blacklist`, and `message`
+            are preserved for review-driven changes.

--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,4 @@ native/node_modules/
 # TapTap Maker local runtime state
 .maker/
 .npm-cache
+docs/superpowers

--- a/config/maker-version-policy.json
+++ b/config/maker-version-policy.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "latest": "0.0.20",
+  "latest_beta": "0.0.19-beta.1",
+  "minimum_supported": "0.0.1",
+  "blacklist": [],
+  "message": "TapTap Maker MCP package policy is current.",
+  "updated_at": "2026-06-23T00:00:00.000Z"
+}

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -205,7 +205,9 @@ Python 运行时策略：
 - `taptap-maker agents update`：只更新当前目录 `AGENTS.md` 中 TapTap Maker 管理的策略块，
   保留用户自己的项目说明；缺少 `AGENTS.md` 时会创建文件。
 - `taptap-maker upgrade`：当前目录的一站式升级入口，刷新 AI 客户端 MCP 配置，并在当前目录
-  已绑定 Maker 项目时执行 `AGENTS.md` 受管策略块更新。它不扫描其它 Maker 项目。
+  已绑定 Maker 项目时执行 `AGENTS.md` 受管策略块更新。它不扫描其它 Maker 项目。升级动作
+  不由 MCP 自己执行；MCP 只做版本检查并输出 `required_upgrade`、`update_available`、
+  `current`、`unavailable` 或 `skipped`。
 - `taptap-maker dev-kit update`：检查当前环境可用的最新 AI dev kit，恢复或更新当前目录。
 
 MCP 运行期能力：
@@ -216,6 +218,20 @@ MCP 运行期能力：
   该 root 识别当前项目，并输出 `MCP client roots` 与 `project_context_source` 诊断。
   这样同一台机器上 Codex、Trae、Cursor 等客户端的用户级 MCP 配置不会因为某个项目写入
   `cwd` 而互相污染。
+- `maker://status` 和 `maker_status_lite` 会在启动后的异步检查完成后，以及最后一次成功远端
+  检查超过 12 小时时懒检查 `Maker MCP package update` 区块。这个检查只读取远端 policy，不执行升级，
+  也不会被业务 tools 触发。远端 policy 使用 `schema_version`、`latest`、`latest_beta`、
+  `minimum_supported`、`blacklist` 和 `message` 字段来决定是否需要升级。
+  状态只会报告 `required_upgrade`、`update_available`、`current`、`unavailable` 或 `skipped`。
+  如果状态是 `required_upgrade`，本地 AI 必须先向用户解释原因并征得同意；用户同意后，
+  若项目目录已确认，再运行 `npx -y -p @taptap/maker taptap-maker upgrade --target-dir <PROJECT_DIR>`；
+  如果还没有确认项目目录，只能说明 machine-level refresh 的取舍，再决定是否运行不带
+  `--target-dir` 的 `taptap-maker upgrade`。升级后要提示用户重启或 reconnect MCP session，
+  然后用 `maker://status` 或 `maker_status_lite` 复核结果。
+- `@taptap/maker` 发版成功后，`publish-maker.yml` 会用 `scripts/update-maker-version-policy.cjs`
+  更新 `config/maker-version-policy.json` 并创建一个可 review 的 PR。`tag=latest` 只自动更新
+  `latest`，`tag=beta` 只自动更新 `latest_beta`，并刷新 `updated_at`；`minimum_supported`、
+  `blacklist` 和 `message` 保持人工策略字段，不由发版流程自动改。
 - `taptap-maker doctor` 会输出 `Maker MCP tools availability`。如果当前 AI 对话里看不到
   Maker proxy tools，先按该段提示重启 AI 客户端、新开 AI 对话，或在支持 `/mcp` 的客户端中
   Reconnect `taptap-maker`；如果客户端不支持 MCP Roots 且输出 `pwd_alignment: cwd_mismatch`，

--- a/scripts/release-scope.cjs
+++ b/scripts/release-scope.cjs
@@ -17,11 +17,13 @@ const MAKER_PATH_PREFIXES = [
 const MAKER_EXACT_PATHS = new Set([
   '.github/workflows/publish-maker.yml',
   'bin/taptap-maker',
+  'config/maker-version-policy.json',
   'docs/MAKER.md',
   'docs/MAKER_CLI_MCP_SKILL_REWORK_OVERVIEW.md',
   'scripts/bundle-maker.js',
   'scripts/prepare-maker-package.js',
   'scripts/resolve-maker-version.js',
+  'scripts/update-maker-version-policy.cjs',
 ]);
 
 const RELEASE_INFRA_EXACT_PATHS = new Set([
@@ -32,6 +34,7 @@ const RELEASE_INFRA_EXACT_PATHS = new Set([
   '.releaserc.cjs',
   'CONTRIBUTING.md',
   'README.md',
+  'config/maker-version-policy.json',
   'docs/CI_CD.md',
   'docs/MAKER.md',
   'package-lock.json',
@@ -41,6 +44,7 @@ const RELEASE_INFRA_EXACT_PATHS = new Set([
   'scripts/release-scope.cjs',
   'scripts/resolve-main-release-version.js',
   'scripts/resolve-maker-version.js',
+  'scripts/update-maker-version-policy.cjs',
   'scripts/semantic-release-main-analyzer.cjs',
   'src/__tests__/mainPackageManifest.test.ts',
   'src/__tests__/mainReleaseVersionPolicy.test.ts',

--- a/scripts/resolve-maker-version.js
+++ b/scripts/resolve-maker-version.js
@@ -68,9 +68,19 @@ function assertVersionMatchesTag(tag, version) {
   if (PRERELEASE_TAGS.has(tag) && !isPrerelease) {
     throw new Error(`Manual ${tag} publish requires a prerelease version like 0.0.1-${tag}.1.`);
   }
+  if (PRERELEASE_TAGS.has(tag) && readPrereleaseTag(version) !== tag) {
+    throw new Error(
+      `Manual ${tag} publish requires ${tag} prerelease version like 0.0.1-${tag}.1.`
+    );
+  }
   if (!PRERELEASE_TAGS.has(tag) && isPrerelease) {
     throw new Error(`Manual ${tag} publish requires a stable version like 0.0.1.`);
   }
+}
+
+function readPrereleaseTag(version) {
+  const match = /^\d+\.\d+\.\d+-([0-9A-Za-z-]+)/.exec(version);
+  return match ? match[1] : '';
 }
 
 function changesMajorOrMinor(previousVersion, nextVersion) {

--- a/scripts/resolve-maker-version.js
+++ b/scripts/resolve-maker-version.js
@@ -59,6 +59,20 @@ function isStableThreeSegmentVersion(version) {
   return /^\d+\.\d+\.\d+$/.test(version);
 }
 
+function isPrereleaseVersion(version) {
+  return version.includes('-');
+}
+
+function assertVersionMatchesTag(tag, version) {
+  const isPrerelease = isPrereleaseVersion(version);
+  if (PRERELEASE_TAGS.has(tag) && !isPrerelease) {
+    throw new Error(`Manual ${tag} publish requires a prerelease version like 0.0.1-${tag}.1.`);
+  }
+  if (!PRERELEASE_TAGS.has(tag) && isPrerelease) {
+    throw new Error(`Manual ${tag} publish requires a stable version like 0.0.1.`);
+  }
+}
+
 function changesMajorOrMinor(previousVersion, nextVersion) {
   const previous = parseVersionCore(previousVersion);
   const next = parseVersionCore(nextVersion);
@@ -320,6 +334,9 @@ function main() {
     mode === 'manual'
       ? resolveManualVersion(currentVersion)
       : resolveAutoVersion(tag, hasPublishedVersions, publishedVersions, currentVersion);
+  if (mode === 'manual') {
+    assertVersionMatchesTag(tag, version);
+  }
   const majorMinorChanged = Boolean(
     mode === 'manual' && currentVersion && changesMajorOrMinor(currentVersion, version)
   );

--- a/scripts/update-maker-version-policy.cjs
+++ b/scripts/update-maker-version-policy.cjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DEFAULT_POLICY_FILE = path.join(__dirname, '..', 'config', 'maker-version-policy.json');
+const VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+function parseArgs(argv) {
+  const parsed = {
+    file: DEFAULT_POLICY_FILE,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--tag' || arg === '--version' || arg === '--file' || arg === '--updated-at') {
+      const value = argv[index + 1];
+      if (!value || value.startsWith('--')) {
+        throw new Error(`Missing value for ${arg}.`);
+      }
+      parsed[toCamelCase(arg.slice(2))] = value;
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!parsed.tag) {
+    throw new Error('Missing required --tag.');
+  }
+  if (!parsed.version) {
+    throw new Error('Missing required --version.');
+  }
+
+  return parsed;
+}
+
+function updateMakerVersionPolicy(options) {
+  const tag = options.tag;
+  const version = options.version;
+  const file = path.resolve(options.file || DEFAULT_POLICY_FILE);
+  const field = tag === 'latest' ? 'latest' : tag === 'beta' ? 'latest_beta' : undefined;
+
+  assertValidVersion(version);
+
+  if (!field) {
+    return {
+      changed: false,
+      field: undefined,
+      version,
+    };
+  }
+
+  const policy = readPolicy(file);
+  assertPolicy(policy, file);
+
+  if (policy[field] === version) {
+    return {
+      changed: false,
+      field,
+      version,
+    };
+  }
+
+  const nextPolicy = {
+    ...policy,
+    [field]: version,
+    updated_at: options.updatedAt || new Date().toISOString(),
+  };
+  fs.writeFileSync(file, `${JSON.stringify(nextPolicy, null, 2)}\n`, 'utf8');
+
+  return {
+    changed: true,
+    field,
+    version,
+  };
+}
+
+function readPolicy(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (error) {
+    throw new Error(
+      `Failed to read Maker version policy ${file}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+}
+
+function assertPolicy(policy, file) {
+  if (!policy || typeof policy !== 'object' || Array.isArray(policy)) {
+    throw new Error(`Invalid Maker version policy ${file}: expected JSON object.`);
+  }
+  if (policy.schema_version !== 1) {
+    throw new Error(`Invalid Maker version policy ${file}: schema_version must be 1.`);
+  }
+  for (const field of ['latest', 'latest_beta', 'minimum_supported']) {
+    assertValidVersion(policy[field], `policy.${field}`);
+  }
+  if (!Array.isArray(policy.blacklist)) {
+    throw new Error(`Invalid Maker version policy ${file}: blacklist must be an array.`);
+  }
+}
+
+function assertValidVersion(version, label = 'version') {
+  if (typeof version !== 'string' || !VERSION_PATTERN.test(version)) {
+    throw new Error(`Invalid ${label}: ${version}. Expected semver like 0.0.1 or 0.0.1-beta.1.`);
+  }
+}
+
+function toCamelCase(value) {
+  return value.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+}
+
+function writeGithubOutput(result) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) {
+    return;
+  }
+  fs.appendFileSync(outputPath, `changed=${String(result.changed)}\n`, 'utf8');
+  fs.appendFileSync(outputPath, `field=${result.field || ''}\n`, 'utf8');
+  fs.appendFileSync(outputPath, `version=${result.version}\n`, 'utf8');
+}
+
+function main() {
+  const parsed = parseArgs(process.argv.slice(2));
+  const result = updateMakerVersionPolicy({
+    file: parsed.file,
+    tag: parsed.tag,
+    version: parsed.version,
+    updatedAt: parsed.updatedAt,
+  });
+  writeGithubOutput(result);
+
+  if (result.changed) {
+    console.log(`Updated Maker version policy ${result.field} to ${result.version}.`);
+  } else {
+    console.log(`Maker version policy unchanged for tag ${parsed.tag}.`);
+  }
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  updateMakerVersionPolicy,
+};

--- a/scripts/update-maker-version-policy.cjs
+++ b/scripts/update-maker-version-policy.cjs
@@ -43,6 +43,7 @@ function updateMakerVersionPolicy(options) {
   const field = tag === 'latest' ? 'latest' : tag === 'beta' ? 'latest_beta' : undefined;
 
   assertValidVersion(version);
+  assertVersionMatchesTag(tag, version);
 
   if (!field) {
     return {
@@ -107,6 +108,16 @@ function assertPolicy(policy, file) {
 function assertValidVersion(version, label = 'version') {
   if (typeof version !== 'string' || !VERSION_PATTERN.test(version)) {
     throw new Error(`Invalid ${label}: ${version}. Expected semver like 0.0.1 or 0.0.1-beta.1.`);
+  }
+}
+
+function assertVersionMatchesTag(tag, version) {
+  const isPrerelease = version.includes('-');
+  if (tag === 'latest' && isPrerelease) {
+    throw new Error(`Invalid latest version: ${version}. The latest tag must publish a stable version.`);
+  }
+  if (tag === 'beta' && !isPrerelease) {
+    throw new Error(`Invalid beta version: ${version}. The beta tag must publish a prerelease version.`);
   }
 }
 

--- a/scripts/update-maker-version-policy.cjs
+++ b/scripts/update-maker-version-policy.cjs
@@ -100,8 +100,11 @@ function assertPolicy(policy, file) {
   for (const field of ['latest', 'latest_beta', 'minimum_supported']) {
     assertValidVersion(policy[field], `policy.${field}`);
   }
-  if (!Array.isArray(policy.blacklist)) {
-    throw new Error(`Invalid Maker version policy ${file}: blacklist must be an array.`);
+  if (
+    !Array.isArray(policy.blacklist) ||
+    policy.blacklist.some((item) => typeof item !== 'string' || !VERSION_PATTERN.test(item))
+  ) {
+    throw new Error(`Invalid Maker version policy ${file}: blacklist must be a semver string array.`);
   }
 }
 

--- a/skills/update-taptap-mcp/SKILL.md
+++ b/skills/update-taptap-mcp/SKILL.md
@@ -17,17 +17,25 @@ This workflow upgrades only the current machine and the current Maker project di
 - Do not batch-upgrade multiple projects.
 - Do not delete old config backup files. Historical `.bak.*` files have no reliable ownership
   marker and must be left untouched.
+- The MCP status surface only checks the package policy and reports
+  `required_upgrade`, `update_available`, `current`, `unavailable`, or `skipped`.
+  It never runs `taptap-maker upgrade` by itself.
 
 ## Required Steps
 
-1. Identify the current Maker project directory. Use `--target-dir` only when the directory is
+1. Read `maker://status`; if resources are unavailable, fall back to `maker_status_lite`.
+   If the `Maker MCP package update` section reports `required_upgrade`, explain the version reason
+   to the user first.
+   Do not run any upgrade command before that explanation and approval step.
+2. Identify the current Maker project directory. Use `--target-dir` only when the directory is
    confirmed to be a Maker project, which means it or one of its parents contains
    `.maker-mcp/config.json`.
-2. If the AI client has exactly one attached workspace and that workspace is the Maker project, use
+3. If the AI client has exactly one attached workspace and that workspace is the Maker project, use
    that workspace as `<PROJECT_DIR>`. If there are multiple workspaces, or the current directory is
    not clearly a Maker project, ask the user for the Maker project directory before using
    `--target-dir`.
-3. Run the current package upgrade command for the confirmed project:
+4. After the user approves the upgrade, run the current package upgrade command for the confirmed
+   project:
 
 ```bash
 npx -y -p @taptap/maker taptap-maker upgrade --target-dir <PROJECT_DIR>
@@ -36,13 +44,25 @@ npx -y -p @taptap/maker taptap-maker upgrade --target-dir <PROJECT_DIR>
 If the user only wants one client, pass `--ide codex`, `--ide cursor`, or `--ide claude`.
 
 If the user only wants to refresh the machine-level MCP command and no Maker project directory is
-confirmed, run `npx -y -p @taptap/maker taptap-maker upgrade` without `--target-dir` only after
-explaining that project `AGENTS.md` will not be updated.
+confirmed, explain that this refresh will not update project `AGENTS.md`, then run
+`npx -y -p @taptap/maker taptap-maker upgrade` without `--target-dir` only after the user agrees.
 
-4. Ask the user to restart/reconnect the AI client MCP session, or open a new AI conversation.
+5. Ask the user to restart/reconnect the AI client MCP session, or open a new AI conversation.
    Current conversations usually do not hot-load a new MCP process or re-read `AGENTS.md`.
-5. After restart/reconnect, verify by reading `maker://status`; if resources are unavailable, call
+6. After restart/reconnect, verify by reading `maker://status`; if resources are unavailable, call
    `maker_status_lite`.
+
+## Status-Driven Upgrade Notes
+
+- Trigger timing is limited to the startup asynchronous check and the 12-hour TTL lazy check from
+  `maker://status` / `maker_status_lite`.
+- Business tools do not trigger version checks.
+- The remote policy fields are `schema_version`, `latest`, `latest_beta`,
+  `minimum_supported`, `blacklist`, and `message`.
+- `required_upgrade` means the local AI must explain the reason, ask the user for approval, and only
+  then run the appropriate upgrade command.
+- After any upgrade, restart or reconnect the MCP session before trusting the new status, then
+  verify with `maker://status` or `maker_status_lite`.
 
 ## Expected Effects
 

--- a/src/__tests__/makerCliCommands.test.ts
+++ b/src/__tests__/makerCliCommands.test.ts
@@ -17,6 +17,7 @@ import {
   installAiDevKit,
   installAiDevKitSkills,
 } from '../maker/cli/devKit';
+import { formatMakerPackageUpdateStatus, getMakerPackageUpdateStatus } from '../maker/versionCheck';
 import { resolveNpxCliCommand, runMakerCli } from '../maker/cli/commands';
 import { loadProjectConfig, saveProjectConfig } from '../maker/storage';
 
@@ -108,6 +109,25 @@ jest.mock('../maker/cli/devKit', () => ({
   installAiDevKitSkills: jest.fn(),
   listPresentDevKitManagedEntries: jest.fn(() => []),
   writeDevKitStagedGitignore: jest.fn(),
+}));
+
+jest.mock('../maker/versionCheck', () => ({
+  formatMakerPackageUpdateStatus: jest.fn(() =>
+    [
+      'Maker MCP package update',
+      '',
+      '- status: current',
+      '- current_version: 0.0.8',
+      '- next_action: Continue normal work; no package upgrade is required.',
+      '- restart_required: no',
+    ].join('\n')
+  ),
+  getMakerPackageUpdateStatus: jest.fn(async () => ({
+    status: 'current',
+    current_version: '0.0.8',
+    next_action: 'Continue normal work; no package upgrade is required.',
+    restart_required: false,
+  })),
 }));
 
 jest.mock('../maker/system/git', () => {
@@ -1498,6 +1518,50 @@ describe('Maker CLI commands', () => {
         latest: expect.objectContaining({ version: '20260605-053736' }),
       })
     );
+    expect(payload.package_update).toEqual(
+      expect.objectContaining({
+        status: 'current',
+        current_version: '0.0.8',
+      })
+    );
+  });
+
+  test('doctor includes Maker package update status in text output', async () => {
+    jest.mocked(getMakerPackageUpdateStatus).mockResolvedValueOnce({
+      status: 'required_upgrade',
+      current_version: '0.0.5',
+      target_version: '0.0.8',
+      reason: 'below_minimum_supported',
+      next_action:
+        'Ask the user for approval, then run `taptap-maker upgrade --target-dir <PROJECT_DIR>`.',
+      restart_required: true,
+    });
+    jest
+      .mocked(formatMakerPackageUpdateStatus)
+      .mockReturnValueOnce(
+        [
+          'Maker MCP package update',
+          '',
+          '- status: required_upgrade',
+          '- current_version: 0.0.5',
+          '- target_version: 0.0.8',
+          '- reason: below_minimum_supported',
+          '- next_action: Ask the user for approval, then run `taptap-maker upgrade --target-dir <PROJECT_DIR>`.',
+          '- restart_required: yes',
+        ].join('\n')
+      );
+
+    await runMakerCli(['doctor', '--target-dir', tempDir, '--env', 'rnd']);
+
+    const output = stdoutSpy.mock.calls.join('');
+    expect(getMakerPackageUpdateStatus).toHaveBeenCalledWith({
+      currentVersion: 'dev',
+      allowRemoteFetch: false,
+    });
+    expect(output).toContain('Maker MCP package update');
+    expect(output).toContain('- status: required_upgrade');
+    expect(output).toContain('- next_action: Ask the user for approval');
+    expect(output).not.toContain('taptap-maker upgrade --target-dir <PROJECT_DIR>\n\n');
   });
 
   test('doctor guides unbound directories to init when PAT is missing', async () => {

--- a/src/__tests__/makerCliCommands.test.ts
+++ b/src/__tests__/makerCliCommands.test.ts
@@ -1557,6 +1557,7 @@ describe('Maker CLI commands', () => {
     expect(getMakerPackageUpdateStatus).toHaveBeenCalledWith({
       currentVersion: 'dev',
       allowRemoteFetch: false,
+      backgroundRefresh: false,
     });
     expect(output).toContain('Maker MCP package update');
     expect(output).toContain('- status: required_upgrade');

--- a/src/__tests__/makerMcpVersionStatus.test.ts
+++ b/src/__tests__/makerMcpVersionStatus.test.ts
@@ -1,0 +1,192 @@
+const mockServers: Array<{
+  handlers: Map<unknown, (...args: any[]) => any>;
+}> = [];
+
+jest.mock('@modelcontextprotocol/sdk/server/index.js', () => ({
+  Server: class MockServer {
+    handlers = new Map<unknown, (...args: any[]) => any>();
+
+    constructor(..._args: unknown[]) {
+      mockServers.push(this);
+    }
+
+    setRequestHandler(schema: unknown, handler: (...args: any[]) => any): void {
+      this.handlers.set(schema, handler);
+    }
+
+    async connect(_transport: unknown): Promise<void> {
+      return undefined;
+    }
+
+    getClientCapabilities(): undefined {
+      return undefined;
+    }
+
+    async listRoots(): Promise<{ roots: [] }> {
+      return { roots: [] };
+    }
+  },
+}));
+
+jest.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
+  StdioServerTransport: class MockStdioServerTransport {},
+}));
+
+jest.mock('@modelcontextprotocol/sdk/types.js', () => ({
+  CallToolRequestSchema: 'call-tool',
+  ListResourcesRequestSchema: 'list-resources',
+  ListToolsRequestSchema: 'list-tools',
+  ReadResourceRequestSchema: 'read-resource',
+  McpError: class MockMcpError extends Error {},
+  ErrorCode: {
+    InvalidParams: 'InvalidParams',
+    MethodNotFound: 'MethodNotFound',
+  },
+}));
+
+jest.mock('../maker/versionCheck', () => ({
+  startMakerPackageUpdateCheck: jest.fn(),
+  getMakerPackageUpdateStatus: jest.fn(async () => ({
+    status: 'required_upgrade',
+    current_version: '0.0.5',
+    target_version: '0.0.8',
+    reason: 'below_minimum_supported',
+    next_action:
+      'Ask the user for approval, then run `taptap-maker upgrade --target-dir <PROJECT_DIR>`.',
+    restart_required: true,
+  })),
+  formatMakerPackageUpdateStatus: jest.fn(() =>
+    [
+      'Maker MCP package update',
+      '',
+      '- status: required_upgrade',
+      '- next_action: Ask the user for approval, then run `taptap-maker upgrade --target-dir <PROJECT_DIR>`.',
+    ].join('\n')
+  ),
+}));
+
+jest.mock('../maker/server/identify', () => ({
+  identifyMakerProject: jest.fn(() => ({
+    source: 'config_not_found',
+    projectId: undefined,
+    projectRoot: undefined,
+    configPath: undefined,
+    config: undefined,
+  })),
+  formatIdentifyHint: jest.fn(() => 'identify hint'),
+}));
+
+jest.mock('../maker/lifecycle', () => ({
+  logLifecycleEvent: jest.fn(),
+}));
+
+jest.mock('../maker/storage', () => ({
+  getPatPath: jest.fn(() => '/tmp/maker/pat.json'),
+  getTapAuthPath: jest.fn(() => '/tmp/maker/tap-auth.json'),
+  loadProjectConfig: jest.fn(),
+  loadJwt: jest.fn(),
+  loadPat: jest.fn(() => undefined),
+  loadTapAuth: jest.fn(() => undefined),
+}));
+
+jest.mock('../maker/cli/projects', () => ({
+  inspectMakerDirectoryGitStatus: jest.fn(() => ({
+    isUsableMakerGitRepo: false,
+    issue: 'unbound',
+    targetDir: '/tmp/maker-project',
+    makerProjectRoot: undefined,
+    gitRoot: undefined,
+    gitDir: undefined,
+    isOwnGitRoot: false,
+    message: undefined,
+  })),
+}));
+
+jest.mock('../maker/auth/patTap', () => ({
+  requestTapAuthWithPat: jest.fn(),
+}));
+
+jest.mock('../maker/config', () => ({
+  getMakerEndpoints: jest.fn(),
+  getMakerEnvironment: jest.fn(() => 'production'),
+  getMakerWebUrl: jest.fn(),
+  requireMakerEndpoint: jest.fn(),
+}));
+
+jest.mock('../maker/system/git', () => ({
+  MakerGitNotFoundError: class MakerGitNotFoundError extends Error {},
+  checkGitEnvironment: jest.fn(() => ({ installed: true })),
+  formatGitEnvironmentStatus: jest.fn(() => 'Git environment\n\n- status: ready'),
+}));
+
+jest.mock('../maker/system/python', () => ({
+  checkMakerPythonEnvironment: jest.fn(() => ({ ready: true })),
+  formatMakerPythonEnvironmentStatus: jest.fn(() => 'Python environment\n\n- status: ready'),
+}));
+
+jest.mock('../maker/system/luaLsp', () => ({
+  checkMakerLuaLspEnvironment: jest.fn(() => ({ ready: true })),
+  formatMakerLuaLspEnvironmentStatus: jest.fn(() => 'Lua LSP environment\n\n- status: ready'),
+}));
+
+jest.mock('../maker/cli/skill', () => ({
+  formatMakerSkillStatus: jest.fn(() => 'Maker skill status\n\n- status: ready'),
+}));
+
+jest.mock('../maker/cli/agentsPolicy', () => ({
+  formatMakerAgentsPolicyStatus: jest.fn(),
+}));
+
+jest.mock('../maker/cli/devKit', () => ({
+  DEV_KIT_GITIGNORE_STAGING_FILE: '.gitignore.dev-kit-before-clone',
+  checkAiDevKitUpdate: jest.fn(),
+  inspectAiDevKit: jest.fn(),
+  inspectAiDevKitSkillInstallStatus: jest.fn(),
+}));
+
+describe('maker MCP version status integration', () => {
+  beforeEach(() => {
+    mockServers.length = 0;
+    jest.clearAllMocks();
+  });
+
+  test('starts package update check on MCP startup and includes update status in maker_status_lite', async () => {
+    const { startMakerMcpServer } = await import('../maker/server/mcp');
+    const { CallToolRequestSchema } = await import('@modelcontextprotocol/sdk/types.js');
+    const versionCheck = await import('../maker/versionCheck');
+
+    await startMakerMcpServer();
+
+    expect(versionCheck.startMakerPackageUpdateCheck).toHaveBeenCalledTimes(1);
+    expect(versionCheck.startMakerPackageUpdateCheck).toHaveBeenCalledWith({
+      currentVersion: expect.any(String),
+    });
+
+    const server = mockServers[0];
+    expect(server).toBeDefined();
+
+    const handler = server.handlers.get(CallToolRequestSchema);
+    expect(handler).toBeDefined();
+
+    const result = await handler(
+      {
+        params: {
+          name: 'maker_status_lite',
+          arguments: {
+            target_dir: '/tmp/maker-project',
+            skip_remote_sync: true,
+          },
+        },
+      },
+      {}
+    );
+
+    expect(versionCheck.getMakerPackageUpdateStatus).toHaveBeenCalledWith({
+      currentVersion: expect.any(String),
+      allowRemoteFetch: false,
+    });
+    expect(result.content[0].text).toContain('Maker MCP package update');
+    expect(result.content[0].text).toContain('- status: required_upgrade');
+    expect(result.content[0].text).toContain('- next_action: Ask the user for approval');
+  });
+});

--- a/src/__tests__/makerVersionCheck.test.ts
+++ b/src/__tests__/makerVersionCheck.test.ts
@@ -290,6 +290,7 @@ describe('maker package version check', () => {
       currentVersion: '0.0.8',
       now,
       fetchImpl,
+      policyUrl: 'https://example.com/policy.json',
       allowRemoteFetch: false,
       backgroundRefresh: false,
     });
@@ -320,6 +321,45 @@ describe('maker package version check', () => {
       error: 'Maker package version check is temporarily unavailable.',
     });
     expect(status.error).not.toContain('background');
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  test('does not expose stale decision fields when non-blocking status uses a different policy url', async () => {
+    const checkedAt = '2026-06-23T00:00:00.000Z';
+    writeCache({
+      checked_at: checkedAt,
+      policy_url: 'https://example.com/old-policy.json',
+      policy,
+      decision: {
+        status: 'update_available',
+        current_version: '0.0.7',
+        target_version: '0.0.8',
+        latest: '0.0.8',
+        latest_beta: '0.0.9-beta.2',
+        minimum_supported: '0.0.7',
+        checked_at: checkedAt,
+        policy_url: 'https://example.com/old-policy.json',
+      },
+    });
+    const fetchImpl = jest.fn<typeof fetch>();
+
+    const status = await getMakerPackageUpdateStatus({
+      currentVersion: '0.0.7',
+      now: new Date('2026-06-23T01:00:00.000Z'),
+      fetchImpl,
+      policyUrl: 'https://example.com/new-policy.json',
+      allowRemoteFetch: false,
+      backgroundRefresh: false,
+    });
+
+    expect(status).toMatchObject({
+      status: 'unavailable',
+      current_version: '0.0.7',
+      policy_url: 'https://example.com/new-policy.json',
+    });
+    expect(status).not.toHaveProperty('target_version');
+    expect(status).not.toHaveProperty('latest');
+    expect(status).not.toHaveProperty('previous_status');
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 

--- a/src/__tests__/makerVersionCheck.test.ts
+++ b/src/__tests__/makerVersionCheck.test.ts
@@ -1,0 +1,531 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  PACKAGE_VERSION_CHECK_CACHE_FILE,
+  PACKAGE_VERSION_CHECK_TTL_MS,
+  DEFAULT_PACKAGE_VERSION_CHECK_TIMEOUT_MS,
+  checkMakerPackageUpdate,
+  decideMakerPackageUpdate,
+  formatMakerPackageUpdateStatus,
+  getMakerPackageUpdateStatus,
+  type MakerPackageVersionPolicy,
+} from '../maker/versionCheck';
+
+describe('maker package version check', () => {
+  const policy: MakerPackageVersionPolicy = {
+    schema_version: 1,
+    latest: '0.0.8',
+    latest_beta: '0.0.9-beta.2',
+    minimum_supported: '0.0.7',
+    blacklist: ['0.0.6'],
+    message: 'Please upgrade TapTap Maker MCP.',
+    updated_at: '2026-06-23T00:00:00.000Z',
+  };
+
+  const originalMakerHome = process.env.TAPTAP_MAKER_HOME;
+  const originalPolicyUrl = process.env.TAPTAP_MAKER_VERSION_POLICY_URL;
+
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'maker-version-check-'));
+    process.env.TAPTAP_MAKER_HOME = path.join(tempDir, 'maker-home');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    restoreEnv('TAPTAP_MAKER_HOME', originalMakerHome);
+    restoreEnv('TAPTAP_MAKER_VERSION_POLICY_URL', originalPolicyUrl);
+  });
+
+  test('decides required and optional updates with stable beta and dev rules', () => {
+    expect(decideMakerPackageUpdate('0.0.5', policy)).toMatchObject({
+      status: 'required_upgrade',
+      reason: 'below_minimum_supported',
+      target_version: '0.0.8',
+    });
+
+    expect(decideMakerPackageUpdate('0.0.6', policy)).toMatchObject({
+      status: 'required_upgrade',
+      reason: 'blacklisted',
+      blacklist_match: '0.0.6',
+    });
+
+    expect(decideMakerPackageUpdate('0.0.8-beta.1', policy)).toMatchObject({
+      status: 'required_upgrade',
+      reason: 'beta_outdated',
+      target_version: '0.0.9-beta.2',
+    });
+
+    expect(decideMakerPackageUpdate('0.0.7', policy)).toMatchObject({
+      status: 'update_available',
+      target_version: '0.0.8',
+    });
+
+    expect(decideMakerPackageUpdate('0.0.8', policy)).toMatchObject({
+      status: 'current',
+      target_version: '0.0.8',
+    });
+
+    expect(decideMakerPackageUpdate('dev', policy)).toMatchObject({
+      status: 'skipped',
+    });
+  });
+
+  test('reuses recent successful cache for exactly under 12 hours', async () => {
+    const cachePath = getCachePath();
+    const checkedAt = '2026-06-23T00:00:00.000Z';
+    const now = new Date(new Date(checkedAt).getTime() + PACKAGE_VERSION_CHECK_TTL_MS - 1);
+    writeCache({
+      checked_at: checkedAt,
+      policy_url: 'https://example.com/policy.json',
+      policy,
+      decision: {
+        status: 'update_available',
+        current_version: '0.0.7',
+        target_version: '0.0.8',
+        latest: '0.0.8',
+        latest_beta: '0.0.9-beta.2',
+        minimum_supported: '0.0.7',
+        checked_at: checkedAt,
+        policy_url: 'https://example.com/policy.json',
+      },
+    });
+    const fetchImpl = jest.fn<typeof fetch>();
+
+    const status = await getMakerPackageUpdateStatus({
+      currentVersion: '0.0.7',
+      now,
+      fetchImpl,
+    });
+
+    expect(status).toMatchObject({
+      status: 'update_available',
+      current_version: '0.0.7',
+      target_version: '0.0.8',
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(fs.existsSync(cachePath)).toBe(true);
+  });
+
+  test('prefers fresh successful cache even when a later error is recorded', async () => {
+    const checkedAt = '2026-06-23T00:00:00.000Z';
+    const now = new Date(new Date(checkedAt).getTime() + PACKAGE_VERSION_CHECK_TTL_MS - 1);
+    writeCache({
+      checked_at: checkedAt,
+      policy_url: 'https://example.com/policy.json',
+      policy,
+      decision: {
+        status: 'update_available',
+        current_version: '0.0.7',
+        target_version: '0.0.8',
+        latest: '0.0.8',
+        latest_beta: '0.0.9-beta.2',
+        minimum_supported: '0.0.7',
+        checked_at: checkedAt,
+        policy_url: 'https://example.com/policy.json',
+      },
+      error: 'temporary network failure',
+      error_checked_at: '2026-06-23T01:00:00.000Z',
+    });
+    const fetchImpl = jest.fn<typeof fetch>();
+
+    const status = await getMakerPackageUpdateStatus({
+      currentVersion: '0.0.7',
+      now,
+      fetchImpl,
+    });
+
+    expect(status).toMatchObject({
+      status: 'update_available',
+      current_version: '0.0.7',
+      target_version: '0.0.8',
+      error: 'temporary network failure',
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  test('does not reuse fresh successful cache for a different current version', async () => {
+    const checkedAt = '2026-06-23T00:00:00.000Z';
+    const now = new Date(new Date(checkedAt).getTime() + PACKAGE_VERSION_CHECK_TTL_MS - 1);
+    writeCache({
+      checked_at: checkedAt,
+      policy_url: 'https://example.com/policy.json',
+      policy,
+      decision: {
+        status: 'required_upgrade',
+        current_version: '0.0.5',
+        target_version: '0.0.8',
+        latest: '0.0.8',
+        latest_beta: '0.0.9-beta.2',
+        minimum_supported: '0.0.7',
+        checked_at: checkedAt,
+        policy_url: 'https://example.com/policy.json',
+      },
+    });
+    const fetchImpl = jest.fn<typeof fetch>(async () => jsonResponse(policy));
+
+    const status = await getMakerPackageUpdateStatus({
+      currentVersion: '0.0.8',
+      now,
+      fetchImpl,
+      policyUrl: 'https://example.com/policy.json',
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(status).toMatchObject({
+      status: 'current',
+      current_version: '0.0.8',
+      target_version: '0.0.8',
+    });
+  });
+
+  test('reuses recent failure-only cache without retrying remote fetch', async () => {
+    const checkedAt = '2026-06-23T00:00:00.000Z';
+    const now = new Date(new Date(checkedAt).getTime() + PACKAGE_VERSION_CHECK_TTL_MS - 1);
+    writeCache({
+      policy_url: 'https://example.com/policy.json',
+      error: 'network unavailable',
+      error_checked_at: checkedAt,
+    });
+    const fetchImpl = jest.fn<typeof fetch>();
+
+    const status = await getMakerPackageUpdateStatus({
+      currentVersion: '0.0.8',
+      now,
+      fetchImpl,
+    });
+
+    expect(status).toMatchObject({
+      status: 'unavailable',
+      current_version: '0.0.8',
+      error: 'network unavailable',
+      policy_url: 'https://example.com/policy.json',
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  test('fetches remote policy once cached success is 12 hours old', async () => {
+    const checkedAt = '2026-06-23T00:00:00.000Z';
+    const now = new Date(new Date(checkedAt).getTime() + PACKAGE_VERSION_CHECK_TTL_MS);
+    writeCache({
+      checked_at: checkedAt,
+      policy_url: 'https://example.com/policy.json',
+      policy,
+      decision: {
+        status: 'current',
+        current_version: '0.0.8',
+        target_version: '0.0.8',
+        latest: '0.0.8',
+        latest_beta: '0.0.9-beta.2',
+        minimum_supported: '0.0.7',
+        checked_at: checkedAt,
+        policy_url: 'https://example.com/policy.json',
+      },
+    });
+    const fetchImpl = jest.fn<typeof fetch>(async () => jsonResponse(policy));
+
+    const status = await getMakerPackageUpdateStatus({
+      currentVersion: '0.0.7',
+      now,
+      fetchImpl,
+      policyUrl: 'https://example.com/policy.json',
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(status).toMatchObject({
+      status: 'update_available',
+      current_version: '0.0.7',
+      target_version: '0.0.8',
+      checked_at: now.toISOString(),
+      policy_url: 'https://example.com/policy.json',
+    });
+  });
+
+  test('returns immediately and starts background check when remote fetch is disabled', async () => {
+    const fetchImpl = jest.fn<typeof fetch>(async () => jsonResponse(policy));
+
+    const status = await getMakerPackageUpdateStatus({
+      currentVersion: '0.0.7',
+      fetchImpl,
+      policyUrl: 'https://example.com/policy.json',
+      now: new Date('2026-06-23T00:00:00.000Z'),
+      allowRemoteFetch: false,
+    });
+
+    expect(status).toMatchObject({
+      status: 'unavailable',
+      current_version: '0.0.7',
+      error: 'Maker package version check is running in the background.',
+      policy_url: 'https://example.com/policy.json',
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns unavailable on fetch failure and preserves previous successful decision fields', async () => {
+    const checkedAt = '2026-06-23T00:00:00.000Z';
+    writeCache({
+      checked_at: checkedAt,
+      policy_url: 'https://example.com/policy.json',
+      policy,
+      decision: {
+        status: 'update_available',
+        current_version: '0.0.7',
+        target_version: '0.0.8',
+        latest: '0.0.8',
+        latest_beta: '0.0.9-beta.2',
+        minimum_supported: '0.0.7',
+        checked_at: checkedAt,
+        policy_url: 'https://example.com/policy.json',
+      },
+    });
+    const fetchImpl = jest.fn<typeof fetch>(async () => {
+      throw new Error('network unavailable');
+    });
+
+    const status = await checkMakerPackageUpdate({
+      currentVersion: '0.0.7',
+      now: new Date('2026-06-24T00:00:00.000Z'),
+      fetchImpl,
+      policyUrl: 'https://example.com/policy.json',
+    });
+
+    expect(status).toMatchObject({
+      status: 'unavailable',
+      current_version: '0.0.7',
+      error: 'network unavailable',
+      last_success_checked_at: checkedAt,
+      previous_status: 'update_available',
+      target_version: '0.0.8',
+      latest: '0.0.8',
+    });
+  });
+
+  test('does not copy previous decision fields when current version differs after fetch failure', async () => {
+    const checkedAt = '2026-06-23T00:00:00.000Z';
+    writeCache({
+      checked_at: checkedAt,
+      policy_url: 'https://example.com/policy.json',
+      policy,
+      decision: {
+        status: 'required_upgrade',
+        current_version: '0.0.5',
+        target_version: '0.0.8',
+        reason: 'below_minimum_supported',
+        latest: '0.0.8',
+        latest_beta: '0.0.9-beta.2',
+        minimum_supported: '0.0.7',
+        checked_at: checkedAt,
+        policy_url: 'https://example.com/policy.json',
+      },
+    });
+    const fetchImpl = jest.fn<typeof fetch>(async () => {
+      throw new Error('network unavailable');
+    });
+
+    const status = await checkMakerPackageUpdate({
+      currentVersion: '0.0.8',
+      now: new Date('2026-06-24T00:00:00.000Z'),
+      fetchImpl,
+      policyUrl: 'https://example.com/policy.json',
+    });
+
+    expect(status).toMatchObject({
+      status: 'unavailable',
+      current_version: '0.0.8',
+      error: 'network unavailable',
+      latest: '0.0.8',
+      latest_beta: '0.0.9-beta.2',
+      minimum_supported: '0.0.7',
+    });
+    expect(status).not.toHaveProperty('target_version');
+    expect(status).not.toHaveProperty('reason');
+    expect(status).not.toHaveProperty('previous_status');
+    expect(status).not.toHaveProperty('last_success_checked_at');
+  });
+
+  test('failed concurrent check preserves a newer successful cache written during fetch', async () => {
+    const fetchImpl = jest.fn<typeof fetch>(async () => {
+      writeCache({
+        checked_at: '2026-06-23T00:00:01.000Z',
+        policy_url: 'https://example.com/policy.json',
+        policy,
+        decision: {
+          status: 'current',
+          current_version: '0.0.8',
+          target_version: '0.0.8',
+          latest: '0.0.8',
+          latest_beta: '0.0.9-beta.2',
+          minimum_supported: '0.0.7',
+          checked_at: '2026-06-23T00:00:01.000Z',
+          policy_url: 'https://example.com/policy.json',
+        },
+      });
+      throw new Error('late startup failure');
+    });
+
+    const status = await checkMakerPackageUpdate({
+      currentVersion: '0.0.8',
+      now: new Date('2026-06-23T00:00:02.000Z'),
+      fetchImpl,
+      policyUrl: 'https://example.com/policy.json',
+    });
+    const cache = JSON.parse(fs.readFileSync(getCachePath(), 'utf8'));
+
+    expect(status).toMatchObject({
+      status: 'unavailable',
+      current_version: '0.0.8',
+      previous_status: 'current',
+      error: 'late startup failure',
+    });
+    expect(cache.decision).toMatchObject({
+      status: 'current',
+      current_version: '0.0.8',
+    });
+    expect(cache.error).toBe('late startup failure');
+  });
+
+  test('returns unavailable on invalid json and schema errors without throwing', async () => {
+    const invalidJsonFetch = jest.fn<typeof fetch>(
+      async () =>
+        ({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: async () => {
+            throw new Error('Unexpected token < in JSON');
+          },
+        }) as Response
+    );
+
+    const invalidJsonStatus = await checkMakerPackageUpdate({
+      currentVersion: '0.0.8',
+      fetchImpl: invalidJsonFetch,
+    });
+
+    expect(invalidJsonStatus).toMatchObject({
+      status: 'unavailable',
+      current_version: '0.0.8',
+      error: expect.stringContaining('Unexpected token < in JSON'),
+    });
+
+    const invalidSchemaFetch = jest.fn<typeof fetch>(async () =>
+      jsonResponse({
+        schema_version: 1,
+        latest: '0.0.8',
+        minimum_supported: '0.0.7',
+        blacklist: ['0.0.6'],
+        updated_at: '2026-06-23T00:00:00.000Z',
+      })
+    );
+
+    const invalidSchemaStatus = await checkMakerPackageUpdate({
+      currentVersion: '0.0.8',
+      fetchImpl: invalidSchemaFetch,
+    });
+
+    expect(invalidSchemaStatus).toMatchObject({
+      status: 'unavailable',
+      current_version: '0.0.8',
+      error: expect.stringContaining('latest_beta'),
+    });
+  });
+
+  test('uses env override policy url and default timeout 3000ms', async () => {
+    process.env.TAPTAP_MAKER_VERSION_POLICY_URL = 'https://override.example/policy.json';
+    const fetchImpl = jest.fn<typeof fetch>(async () => jsonResponse(policy));
+
+    const status = await checkMakerPackageUpdate({
+      currentVersion: '0.0.8',
+      fetchImpl,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://override.example/policy.json',
+      expect.objectContaining({
+        headers: {
+          Accept: 'application/json',
+        },
+        signal: expect.any(AbortSignal),
+      })
+    );
+    expect(status).toMatchObject({
+      status: 'current',
+      policy_url: 'https://override.example/policy.json',
+    });
+    expect(DEFAULT_PACKAGE_VERSION_CHECK_TIMEOUT_MS).toBe(3000);
+  });
+
+  test('writes cache under maker home package-version-check json file', async () => {
+    const fetchImpl = jest.fn<typeof fetch>(async () => jsonResponse(policy));
+
+    await checkMakerPackageUpdate({
+      currentVersion: '0.0.7',
+      fetchImpl,
+      now: new Date('2026-06-23T08:00:00.000Z'),
+    });
+
+    const cachePath = getCachePath();
+    expect(cachePath).toBe(
+      path.join(process.env.TAPTAP_MAKER_HOME as string, PACKAGE_VERSION_CHECK_CACHE_FILE)
+    );
+    expect(fs.existsSync(cachePath)).toBe(true);
+  });
+
+  test('formats required upgrade status as stable machine readable text', () => {
+    const output = formatMakerPackageUpdateStatus({
+      status: 'required_upgrade',
+      current_version: '0.0.6',
+      target_version: '0.0.8',
+      reason: 'blacklisted',
+      latest: '0.0.8',
+      latest_beta: '0.0.9-beta.2',
+      minimum_supported: '0.0.7',
+      blacklist_match: '0.0.6',
+      checked_at: '2026-06-23T10:00:00.000Z',
+      policy_url:
+        'https://raw.githubusercontent.com/taptap/instant-games-open-mcp/main/config/maker-version-policy.json',
+      message: 'Please upgrade TapTap Maker MCP.',
+      next_action:
+        'Ask the user for approval, then run `taptap-maker upgrade --target-dir <PROJECT_DIR>`.',
+      restart_required: true,
+    });
+
+    expect(output).toContain('Maker MCP package update');
+    expect(output).toContain('- status: required_upgrade');
+    expect(output).toContain('- current_version: 0.0.6');
+    expect(output).toContain('- target_version: 0.0.8');
+    expect(output).toContain('- reason: blacklisted');
+    expect(output).toContain('- next_action: Ask the user for approval');
+    expect(output).toContain('- restart_required: yes');
+  });
+});
+
+function getCachePath(): string {
+  return path.join(process.env.TAPTAP_MAKER_HOME as string, PACKAGE_VERSION_CHECK_CACHE_FILE);
+}
+
+function jsonResponse(payload: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => payload,
+  } as Response;
+}
+
+function writeCache(payload: unknown): void {
+  const cachePath = getCachePath();
+  fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+  fs.writeFileSync(cachePath, JSON.stringify(payload, null, 2), 'utf8');
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}

--- a/src/__tests__/makerVersionCheck.test.ts
+++ b/src/__tests__/makerVersionCheck.test.ts
@@ -182,7 +182,33 @@ describe('maker package version check', () => {
     });
   });
 
-  test('reuses recent failure-only cache without retrying remote fetch', async () => {
+  test('retries remote policy fetch when only a recent failure cache exists', async () => {
+    const checkedAt = '2026-06-23T00:00:00.000Z';
+    const now = new Date(new Date(checkedAt).getTime() + PACKAGE_VERSION_CHECK_TTL_MS - 1);
+    writeCache({
+      policy_url: 'https://example.com/policy.json',
+      error: 'network unavailable',
+      error_checked_at: checkedAt,
+    });
+    const fetchImpl = jest.fn<typeof fetch>(async () => jsonResponse(policy));
+
+    const status = await getMakerPackageUpdateStatus({
+      currentVersion: '0.0.7',
+      now,
+      fetchImpl,
+      policyUrl: 'https://example.com/policy.json',
+    });
+
+    expect(status).toMatchObject({
+      status: 'update_available',
+      current_version: '0.0.7',
+      target_version: '0.0.8',
+      policy_url: 'https://example.com/policy.json',
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns recent failure-only cache without fetch when remote fetch and background refresh are disabled', async () => {
     const checkedAt = '2026-06-23T00:00:00.000Z';
     const now = new Date(new Date(checkedAt).getTime() + PACKAGE_VERSION_CHECK_TTL_MS - 1);
     writeCache({
@@ -196,6 +222,8 @@ describe('maker package version check', () => {
       currentVersion: '0.0.8',
       now,
       fetchImpl,
+      allowRemoteFetch: false,
+      backgroundRefresh: false,
     });
 
     expect(status).toMatchObject({

--- a/src/__tests__/makerVersionCheck.test.ts
+++ b/src/__tests__/makerVersionCheck.test.ts
@@ -59,6 +59,19 @@ describe('maker package version check', () => {
       target_version: '0.0.9-beta.2',
     });
 
+    expect(
+      decideMakerPackageUpdate('1.0.0-beta.9007199254740992', {
+        ...policy,
+        latest: '1.0.0',
+        latest_beta: '1.0.0-beta.9007199254740993',
+        minimum_supported: '0.0.1',
+      })
+    ).toMatchObject({
+      status: 'required_upgrade',
+      reason: 'beta_outdated',
+      target_version: '1.0.0-beta.9007199254740993',
+    });
+
     expect(decideMakerPackageUpdate('0.0.7', policy)).toMatchObject({
       status: 'update_available',
       target_version: '0.0.8',
@@ -457,6 +470,46 @@ describe('maker package version check', () => {
       target_version: '0.0.8',
       latest: '0.0.8',
     });
+  });
+
+  test('does not copy previous decision fields when blocking fetch fails for a different policy url', async () => {
+    const checkedAt = '2026-06-23T00:00:00.000Z';
+    writeCache({
+      checked_at: checkedAt,
+      policy_url: 'https://example.com/old-policy.json',
+      policy,
+      decision: {
+        status: 'update_available',
+        current_version: '0.0.7',
+        target_version: '0.0.8',
+        latest: '0.0.8',
+        latest_beta: '0.0.9-beta.2',
+        minimum_supported: '0.0.7',
+        checked_at: checkedAt,
+        policy_url: 'https://example.com/old-policy.json',
+      },
+    });
+    const fetchImpl = jest.fn<typeof fetch>(async () => {
+      throw new Error('network unavailable');
+    });
+
+    const status = await checkMakerPackageUpdate({
+      currentVersion: '0.0.7',
+      now: new Date('2026-06-24T00:00:00.000Z'),
+      fetchImpl,
+      policyUrl: 'https://example.com/new-policy.json',
+    });
+
+    expect(status).toMatchObject({
+      status: 'unavailable',
+      current_version: '0.0.7',
+      error: 'network unavailable',
+      policy_url: 'https://example.com/new-policy.json',
+    });
+    expect(status).not.toHaveProperty('target_version');
+    expect(status).not.toHaveProperty('latest');
+    expect(status).not.toHaveProperty('previous_status');
+    expect(status).not.toHaveProperty('last_success_checked_at');
   });
 
   test('does not copy previous decision fields when current version differs after fetch failure', async () => {

--- a/src/__tests__/makerVersionCheck.test.ts
+++ b/src/__tests__/makerVersionCheck.test.ts
@@ -99,6 +99,7 @@ describe('maker package version check', () => {
       currentVersion: '0.0.7',
       now,
       fetchImpl,
+      policyUrl: 'https://example.com/policy.json',
     });
 
     expect(status).toMatchObject({
@@ -136,6 +137,7 @@ describe('maker package version check', () => {
       currentVersion: '0.0.7',
       now,
       fetchImpl,
+      policyUrl: 'https://example.com/policy.json',
     });
 
     expect(status).toMatchObject({
@@ -182,6 +184,47 @@ describe('maker package version check', () => {
     });
   });
 
+  test('does not reuse fresh successful cache for a different policy url', async () => {
+    const checkedAt = '2026-06-23T00:00:00.000Z';
+    const now = new Date(new Date(checkedAt).getTime() + PACKAGE_VERSION_CHECK_TTL_MS - 1);
+    writeCache({
+      checked_at: checkedAt,
+      policy_url: 'https://example.com/old-policy.json',
+      policy,
+      decision: {
+        status: 'current',
+        current_version: '0.0.8',
+        target_version: '0.0.8',
+        latest: '0.0.8',
+        latest_beta: '0.0.9-beta.2',
+        minimum_supported: '0.0.7',
+        checked_at: checkedAt,
+        policy_url: 'https://example.com/old-policy.json',
+      },
+    });
+    const nextPolicy: MakerPackageVersionPolicy = {
+      ...policy,
+      latest: '0.0.10',
+      updated_at: '2026-06-23T01:00:00.000Z',
+    };
+    const fetchImpl = jest.fn<typeof fetch>(async () => jsonResponse(nextPolicy));
+
+    const status = await getMakerPackageUpdateStatus({
+      currentVersion: '0.0.8',
+      now,
+      fetchImpl,
+      policyUrl: 'https://example.com/new-policy.json',
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(status).toMatchObject({
+      status: 'update_available',
+      current_version: '0.0.8',
+      target_version: '0.0.10',
+      policy_url: 'https://example.com/new-policy.json',
+    });
+  });
+
   test('retries remote policy fetch when only a recent failure cache exists', async () => {
     const checkedAt = '2026-06-23T00:00:00.000Z';
     const now = new Date(new Date(checkedAt).getTime() + PACKAGE_VERSION_CHECK_TTL_MS - 1);
@@ -206,6 +249,31 @@ describe('maker package version check', () => {
       policy_url: 'https://example.com/policy.json',
     });
     expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not reuse fresh failure-only cache for a different policy url', async () => {
+    const checkedAt = '2026-06-23T00:00:00.000Z';
+    const now = new Date(new Date(checkedAt).getTime() + PACKAGE_VERSION_CHECK_TTL_MS - 1);
+    writeCache({
+      policy_url: 'https://example.com/old-policy.json',
+      error: 'network unavailable',
+      error_checked_at: checkedAt,
+    });
+    const fetchImpl = jest.fn<typeof fetch>(async () => jsonResponse(policy));
+
+    const status = await getMakerPackageUpdateStatus({
+      currentVersion: '0.0.8',
+      now,
+      fetchImpl,
+      policyUrl: 'https://example.com/new-policy.json',
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(status).toMatchObject({
+      status: 'current',
+      current_version: '0.0.8',
+      policy_url: 'https://example.com/new-policy.json',
+    });
   });
 
   test('returns recent failure-only cache without fetch when remote fetch and background refresh are disabled', async () => {

--- a/src/__tests__/makerVersionCheck.test.ts
+++ b/src/__tests__/makerVersionCheck.test.ts
@@ -235,6 +235,26 @@ describe('maker package version check', () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
+  test('does not claim background retry when remote fetch and background refresh are disabled', async () => {
+    const fetchImpl = jest.fn<typeof fetch>();
+
+    const status = await getMakerPackageUpdateStatus({
+      currentVersion: '0.0.8',
+      now: new Date('2026-06-23T00:00:00.000Z'),
+      fetchImpl,
+      allowRemoteFetch: false,
+      backgroundRefresh: false,
+    });
+
+    expect(status).toMatchObject({
+      status: 'unavailable',
+      current_version: '0.0.8',
+      error: 'Maker package version check is temporarily unavailable.',
+    });
+    expect(status.error).not.toContain('background');
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
   test('fetches remote policy once cached success is 12 hours old', async () => {
     const checkedAt = '2026-06-23T00:00:00.000Z';
     const now = new Date(new Date(checkedAt).getTime() + PACKAGE_VERSION_CHECK_TTL_MS);

--- a/src/__tests__/makerVersionPolicy.test.ts
+++ b/src/__tests__/makerVersionPolicy.test.ts
@@ -279,13 +279,13 @@ describe('Maker publish version policy', () => {
       PATH: fakeBin,
       MAKER_VERSION_MODE: 'manual',
       MAKER_MANUAL_VERSION: '0.1.0',
-      MAKER_NPM_TAG: 'beta',
+      MAKER_NPM_TAG: 'latest',
       GITHUB_REF_NAME: 'main',
     });
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain('Current online @taptap/maker@beta version: 0.0.5');
-    expect(result.stdout.match(/Current online @taptap\/maker@beta version/g)).toHaveLength(1);
+    expect(result.stdout).toContain('Current online @taptap/maker@latest version: 0.0.5');
+    expect(result.stdout.match(/Current online @taptap\/maker@latest version/g)).toHaveLength(1);
     expect(result.stdout).toContain('Resolved @taptap/maker version: 0.1.0');
     expect(result.stdout).toContain('Major/minor changed: true');
   });
@@ -296,12 +296,40 @@ describe('Maker publish version policy', () => {
       PATH: fakeBin,
       MAKER_VERSION_MODE: 'manual',
       MAKER_MANUAL_VERSION: '0.0.6',
-      MAKER_NPM_TAG: 'beta',
+      MAKER_NPM_TAG: 'latest',
       GITHUB_REF_NAME: 'main',
     });
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('Resolved @taptap/maker version: 0.0.6');
     expect(result.stdout).toContain('Major/minor changed: false');
+  });
+
+  it('rejects manual beta publishes with stable versions before npm publish', () => {
+    const fakeBin = createFakeNpm('0.0.5');
+    const result = runResolver({
+      PATH: fakeBin,
+      MAKER_VERSION_MODE: 'manual',
+      MAKER_MANUAL_VERSION: '0.0.6',
+      MAKER_NPM_TAG: 'beta',
+      GITHUB_REF_NAME: 'main',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Manual beta publish requires a prerelease version');
+  });
+
+  it('rejects manual latest publishes with prerelease versions before npm publish', () => {
+    const fakeBin = createFakeNpm('0.0.5');
+    const result = runResolver({
+      PATH: fakeBin,
+      MAKER_VERSION_MODE: 'manual',
+      MAKER_MANUAL_VERSION: '0.0.6-beta.1',
+      MAKER_NPM_TAG: 'latest',
+      GITHUB_REF_NAME: 'main',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Manual latest publish requires a stable version');
   });
 });

--- a/src/__tests__/makerVersionPolicy.test.ts
+++ b/src/__tests__/makerVersionPolicy.test.ts
@@ -319,6 +319,20 @@ describe('Maker publish version policy', () => {
     expect(result.stderr).toContain('Manual beta publish requires a prerelease version');
   });
 
+  it('rejects manual prerelease publishes when the version identifier does not match the tag', () => {
+    const fakeBin = createFakeNpm('0.0.5-beta.1');
+    const result = runResolver({
+      PATH: fakeBin,
+      MAKER_VERSION_MODE: 'manual',
+      MAKER_MANUAL_VERSION: '0.0.6-beta.1',
+      MAKER_NPM_TAG: 'alpha',
+      GITHUB_REF_NAME: 'main',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Manual alpha publish requires alpha prerelease version');
+  });
+
   it('rejects manual latest publishes with prerelease versions before npm publish', () => {
     const fakeBin = createFakeNpm('0.0.5');
     const result = runResolver({

--- a/src/__tests__/makerVersionPolicyUpdate.test.ts
+++ b/src/__tests__/makerVersionPolicyUpdate.test.ts
@@ -1,0 +1,115 @@
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const nodeRequire = createRequire(__filename);
+const { updateMakerVersionPolicy } = nodeRequire('../../scripts/update-maker-version-policy.cjs');
+
+describe('Maker version policy updater', () => {
+  test('updates latest for stable publishes without touching manual policy fields', () => {
+    const file = writePolicy({
+      latest: '0.0.20',
+      latest_beta: '0.0.19-beta.1',
+      minimum_supported: '0.0.1',
+      blacklist: ['0.0.5'],
+      message: 'Manual operator note.',
+      updated_at: '2026-06-23T00:00:00.000Z',
+    });
+
+    const result = updateMakerVersionPolicy({
+      file,
+      tag: 'latest',
+      version: '0.0.21',
+      updatedAt: '2026-06-24T00:00:00.000Z',
+    });
+
+    const policy = JSON.parse(fs.readFileSync(file, 'utf8'));
+    expect(result).toEqual({
+      changed: true,
+      field: 'latest',
+      version: '0.0.21',
+    });
+    expect(policy).toMatchObject({
+      latest: '0.0.21',
+      latest_beta: '0.0.19-beta.1',
+      minimum_supported: '0.0.1',
+      blacklist: ['0.0.5'],
+      message: 'Manual operator note.',
+      updated_at: '2026-06-24T00:00:00.000Z',
+    });
+  });
+
+  test('updates latest_beta for beta publishes', () => {
+    const file = writePolicy({
+      latest: '0.0.20',
+      latest_beta: '0.0.19-beta.1',
+      minimum_supported: '0.0.1',
+      blacklist: [],
+      message: 'Manual operator note.',
+      updated_at: '2026-06-23T00:00:00.000Z',
+    });
+
+    const result = updateMakerVersionPolicy({
+      file,
+      tag: 'beta',
+      version: '0.0.21-beta.1',
+      updatedAt: '2026-06-24T00:00:00.000Z',
+    });
+
+    const policy = JSON.parse(fs.readFileSync(file, 'utf8'));
+    expect(result).toEqual({
+      changed: true,
+      field: 'latest_beta',
+      version: '0.0.21-beta.1',
+    });
+    expect(policy.latest).toBe('0.0.20');
+    expect(policy.latest_beta).toBe('0.0.21-beta.1');
+    expect(policy.minimum_supported).toBe('0.0.1');
+    expect(policy.blacklist).toEqual([]);
+  });
+
+  test('does not update policy for alpha or next publishes', () => {
+    const file = writePolicy({
+      latest: '0.0.20',
+      latest_beta: '0.0.19-beta.1',
+      minimum_supported: '0.0.1',
+      blacklist: [],
+      message: 'Manual operator note.',
+      updated_at: '2026-06-23T00:00:00.000Z',
+    });
+    const before = fs.readFileSync(file, 'utf8');
+
+    const result = updateMakerVersionPolicy({
+      file,
+      tag: 'next',
+      version: '0.0.21-next.1',
+      updatedAt: '2026-06-24T00:00:00.000Z',
+    });
+
+    expect(result).toEqual({
+      changed: false,
+      field: undefined,
+      version: '0.0.21-next.1',
+    });
+    expect(fs.readFileSync(file, 'utf8')).toBe(before);
+  });
+});
+
+function writePolicy(overrides: Record<string, unknown>): string {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'maker-policy-update-'));
+  const file = path.join(tempDir, 'maker-version-policy.json');
+  fs.writeFileSync(
+    file,
+    `${JSON.stringify(
+      {
+        schema_version: 1,
+        ...overrides,
+      },
+      null,
+      2
+    )}\n`,
+    'utf8'
+  );
+  return file;
+}

--- a/src/__tests__/makerVersionPolicyUpdate.test.ts
+++ b/src/__tests__/makerVersionPolicyUpdate.test.ts
@@ -69,6 +69,44 @@ describe('Maker version policy updater', () => {
     expect(policy.blacklist).toEqual([]);
   });
 
+  test('rejects prerelease versions for latest publishes', () => {
+    const file = writePolicy({
+      latest: '0.0.20',
+      latest_beta: '0.0.19-beta.1',
+      minimum_supported: '0.0.1',
+      blacklist: [],
+      updated_at: '2026-06-23T00:00:00.000Z',
+    });
+
+    expect(() =>
+      updateMakerVersionPolicy({
+        file,
+        tag: 'latest',
+        version: '0.0.21-beta.1',
+        updatedAt: '2026-06-24T00:00:00.000Z',
+      })
+    ).toThrow('latest tag must publish a stable version');
+  });
+
+  test('rejects stable versions for beta publishes', () => {
+    const file = writePolicy({
+      latest: '0.0.20',
+      latest_beta: '0.0.19-beta.1',
+      minimum_supported: '0.0.1',
+      blacklist: [],
+      updated_at: '2026-06-23T00:00:00.000Z',
+    });
+
+    expect(() =>
+      updateMakerVersionPolicy({
+        file,
+        tag: 'beta',
+        version: '0.0.21',
+        updatedAt: '2026-06-24T00:00:00.000Z',
+      })
+    ).toThrow('beta tag must publish a prerelease version');
+  });
+
   test('does not update policy for alpha or next publishes', () => {
     const file = writePolicy({
       latest: '0.0.20',

--- a/src/__tests__/makerVersionPolicyUpdate.test.ts
+++ b/src/__tests__/makerVersionPolicyUpdate.test.ts
@@ -107,6 +107,27 @@ describe('Maker version policy updater', () => {
     ).toThrow('beta tag must publish a prerelease version');
   });
 
+  test('rejects invalid blacklist entries before writing policy', () => {
+    const file = writePolicy({
+      latest: '0.0.20',
+      latest_beta: '0.0.19-beta.1',
+      minimum_supported: '0.0.1',
+      blacklist: ['0.0.5', 'not-a-version'],
+      updated_at: '2026-06-23T00:00:00.000Z',
+    });
+    const before = fs.readFileSync(file, 'utf8');
+
+    expect(() =>
+      updateMakerVersionPolicy({
+        file,
+        tag: 'latest',
+        version: '0.0.21',
+        updatedAt: '2026-06-24T00:00:00.000Z',
+      })
+    ).toThrow('blacklist must be a semver string array');
+    expect(fs.readFileSync(file, 'utf8')).toBe(before);
+  });
+
   test('does not update policy for alpha or next publishes', () => {
     const file = writePolicy({
       latest: '0.0.20',

--- a/src/__tests__/releaseScope.test.ts
+++ b/src/__tests__/releaseScope.test.ts
@@ -12,6 +12,8 @@ describe('release-scope classifier', () => {
     expect(releaseScope.isMakerOwnedPath('src/maker/server/mcp.ts')).toBe(true);
     expect(releaseScope.isMakerOwnedPath('packages/maker/package.json')).toBe(true);
     expect(releaseScope.isMakerOwnedPath('src/__tests__/makerRuntimeLogs.test.ts')).toBe(true);
+    expect(releaseScope.isMakerOwnedPath('config/maker-version-policy.json')).toBe(true);
+    expect(releaseScope.isMakerOwnedPath('scripts/update-maker-version-policy.cjs')).toBe(true);
     expect(releaseScope.isMakerOwnedPath('.github/workflows/release.yml')).toBe(false);
     expect(releaseScope.isMakerOwnedPath('package.json')).toBe(false);
   });
@@ -44,8 +46,10 @@ describe('release-scope classifier', () => {
       '.github/workflows/release.yml',
       '.github/workflows/publish-maker.yml',
       'scripts/release-scope.cjs',
+      'scripts/update-maker-version-policy.cjs',
       'scripts/resolve-main-release-version.js',
       'scripts/resolve-maker-version.js',
+      'config/maker-version-policy.json',
       'src/__tests__/releaseScope.test.ts',
       'src/__tests__/makerVersionPolicy.test.ts',
       'CONTRIBUTING.md',

--- a/src/__tests__/releaseWorkflowGuards.test.ts
+++ b/src/__tests__/releaseWorkflowGuards.test.ts
@@ -112,6 +112,24 @@ describe('release PR required workflow guards', () => {
     expect(releaseStep).not.toContain('git checkout -B main origin/main');
   });
 
+  it('creates a reviewable Maker version policy PR after Maker package publish', () => {
+    const workflow = readWorkflow('publish-maker.yml');
+
+    expect(workflow).toContain('contents: write');
+    expect(workflow).toContain('pull-requests: write');
+    expect(workflow).toContain('node scripts/update-maker-version-policy.cjs');
+    expect(workflow).toContain('--tag "$NPM_TAG"');
+    expect(workflow).toContain('--version "$MAKER_PACKAGE_VERSION"');
+    expect(workflow).toContain('uses: actions/create-github-app-token@v2');
+    expect(workflow).toContain('id: version-policy-token');
+    expect(workflow).toContain('uses: peter-evans/create-pull-request@v6');
+    expect(workflow).toContain('token: ${{ steps.version-policy-token.outputs.token }}');
+    expect(workflow).toContain(
+      'chore/update-maker-version-policy-${{ needs.resolve-version.outputs.version }}'
+    );
+    expect(workflow).toContain('Preserve minimum_supported, blacklist, and message policy fields');
+  });
+
   it('refreshes the release app token after waiting for PR merge', () => {
     const workflow = readWorkflow('release.yml');
 

--- a/src/maker/cli/commands.ts
+++ b/src/maker/cli/commands.ts
@@ -397,6 +397,7 @@ async function runDoctor(parsed: ParsedArgs, ctx: CliContext): Promise<void> {
   const packageUpdate = await getMakerPackageUpdateStatus({
     currentVersion: VERSION,
     allowRemoteFetch: false,
+    backgroundRefresh: false,
   });
   const agentsPolicy = isProjectBound ? inspectMakerAgentsPolicy(projectRoot) : undefined;
   const orphanProcessCheck = inspectMakerOrphanProcesses();

--- a/src/maker/cli/commands.ts
+++ b/src/maker/cli/commands.ts
@@ -74,6 +74,10 @@ import {
   setupMakerLuaLspEnvironment,
 } from '../system/luaLsp.js';
 import { formatMakerSkillStatus } from './skill.js';
+import { formatMakerPackageUpdateStatus, getMakerPackageUpdateStatus } from '../versionCheck.js';
+
+declare const __MAKER_VERSION__: string | undefined;
+const VERSION = typeof __MAKER_VERSION__ !== 'undefined' ? __MAKER_VERSION__ : 'dev';
 
 const DEFAULT_MCP_NAME = 'taptap-maker';
 const MAKER_NPM_PACKAGE = '@taptap/maker';
@@ -390,6 +394,10 @@ async function runDoctor(parsed: ParsedArgs, ctx: CliContext): Promise<void> {
   const projectRoot = identify.projectRoot || targetDir;
   const devKit = inspectAiDevKit(projectRoot);
   const devKitUpdate = await checkAiDevKitUpdate(projectRoot, { environment: env });
+  const packageUpdate = await getMakerPackageUpdateStatus({
+    currentVersion: VERSION,
+    allowRemoteFetch: false,
+  });
   const agentsPolicy = isProjectBound ? inspectMakerAgentsPolicy(projectRoot) : undefined;
   const orphanProcessCheck = inspectMakerOrphanProcesses();
   const mcpToolsAvailability = inspectMakerMcpToolsAvailability({
@@ -410,6 +418,7 @@ async function runDoctor(parsed: ParsedArgs, ctx: CliContext): Promise<void> {
       agents_policy: agentsPolicy,
       dev_kit: devKit,
       dev_kit_update: devKitUpdate,
+      package_update: packageUpdate,
       mcp_tools_availability: mcpToolsAvailability,
       orphan_process_check: orphanProcessCheck,
     });
@@ -450,6 +459,8 @@ async function runDoctor(parsed: ParsedArgs, ctx: CliContext): Promise<void> {
       `- latest_version: ${devKitUpdate.latest?.version || '(unknown)'}`,
       `- update_available: ${devKitUpdate.updateAvailable ? 'yes' : 'no'}`,
       devKitUpdate.versionCheckError ? `- version_check: ${devKitUpdate.versionCheckError}` : '',
+      '',
+      formatMakerPackageUpdateStatus(packageUpdate),
       '',
       formatMakerMcpToolsAvailability(mcpToolsAvailability),
       '',

--- a/src/maker/server/mcp.ts
+++ b/src/maker/server/mcp.ts
@@ -90,6 +90,11 @@ import {
   type RuntimeLogQueryResult,
 } from './runtimeLogs.js';
 import {
+  formatMakerPackageUpdateStatus,
+  getMakerPackageUpdateStatus,
+  startMakerPackageUpdateCheck,
+} from '../versionCheck.js';
+import {
   RemoteProxyToolResultError,
   formatRemoteProxyToolResult,
   materializeRemoteProxyToolAssets,
@@ -508,6 +513,8 @@ export function createRemoteProxyCallToolOptions(
 }
 
 export async function startMakerMcpServer(): Promise<void> {
+  startMakerPackageUpdateCheck({ currentVersion: VERSION });
+
   const server = new Server(
     {
       name: 'taptap-maker',
@@ -744,6 +751,12 @@ async function formatStatus(
   const git = checkGitEnvironment();
   const python = checkMakerPythonEnvironment();
   const luaLsp = checkMakerLuaLspEnvironment({ pythonEnvironment: python });
+  const packageUpdateText = formatMakerPackageUpdateStatus(
+    await getMakerPackageUpdateStatus({
+      currentVersion: VERSION,
+      allowRemoteFetch: false,
+    })
+  );
   const projectSection = identify.projectId
     ? [
         '目标目录已绑定 Maker 项目。',
@@ -777,6 +790,8 @@ async function formatStatus(
     formatMakerPythonEnvironmentStatus(python),
     '',
     formatMakerLuaLspEnvironmentStatus(luaLsp),
+    '',
+    packageUpdateText,
     '',
     formatMakerGitDirectoryStatus(gitDirectoryStatus),
     '',

--- a/src/maker/versionCheck.ts
+++ b/src/maker/versionCheck.ts
@@ -492,34 +492,38 @@ function buildUnavailableStatus(options: {
 }): MakerPackageUpdateStatus {
   const previousDecision = options.cache?.decision;
   const hasCurrentVersionDecision = previousDecision?.current_version === options.currentVersion;
-  const lastSuccessCheckedAt = hasCurrentVersionDecision
+  const hasCurrentPolicyUrl =
+    !options.policyUrl ||
+    options.cache?.policy_url === options.policyUrl ||
+    previousDecision?.policy_url === options.policyUrl;
+  const canUsePreviousDecision = hasCurrentVersionDecision && hasCurrentPolicyUrl;
+  const lastSuccessCheckedAt = canUsePreviousDecision
     ? getLastSuccessCheckedAt(options.cache)
     : undefined;
-  const previousPolicy = options.cache?.policy;
+  const previousPolicy = hasCurrentPolicyUrl ? options.cache?.policy : undefined;
 
   return compactStatus({
     status: 'unavailable',
     current_version: options.currentVersion,
-    target_version: hasCurrentVersionDecision ? previousDecision?.target_version : undefined,
-    reason: hasCurrentVersionDecision ? previousDecision?.reason : undefined,
+    target_version: canUsePreviousDecision ? previousDecision?.target_version : undefined,
+    reason: canUsePreviousDecision ? previousDecision?.reason : undefined,
     minimum_supported:
-      (hasCurrentVersionDecision ? previousDecision?.minimum_supported : undefined) ??
+      (canUsePreviousDecision ? previousDecision?.minimum_supported : undefined) ??
       previousPolicy?.minimum_supported,
     latest:
-      (hasCurrentVersionDecision ? previousDecision?.latest : undefined) ?? previousPolicy?.latest,
+      (canUsePreviousDecision ? previousDecision?.latest : undefined) ?? previousPolicy?.latest,
     latest_beta:
-      (hasCurrentVersionDecision ? previousDecision?.latest_beta : undefined) ??
+      (canUsePreviousDecision ? previousDecision?.latest_beta : undefined) ??
       previousPolicy?.latest_beta,
-    blacklist_match: hasCurrentVersionDecision ? previousDecision?.blacklist_match : undefined,
+    blacklist_match: canUsePreviousDecision ? previousDecision?.blacklist_match : undefined,
     checked_at: options.checkedAt,
-    policy_url: options.cache?.policy_url ?? options.policyUrl,
+    policy_url: options.policyUrl ?? options.cache?.policy_url,
     message:
-      (hasCurrentVersionDecision ? previousDecision?.message : undefined) ??
-      previousPolicy?.message,
+      (canUsePreviousDecision ? previousDecision?.message : undefined) ?? previousPolicy?.message,
     error: options.error,
     last_success_checked_at: lastSuccessCheckedAt,
     previous_status:
-      hasCurrentVersionDecision &&
+      canUsePreviousDecision &&
       previousDecision?.status &&
       previousDecision.status !== 'unavailable'
         ? previousDecision.status

--- a/src/maker/versionCheck.ts
+++ b/src/maker/versionCheck.ts
@@ -243,18 +243,23 @@ export async function getMakerPackageUpdateStatus(
 
   const cache = readCache();
   const now = options.now ?? new Date();
+  const policyUrl = resolvePolicyUrl(options.policyUrl);
   const lastSuccessCheckedAt = getLastSuccessCheckedAt(cache);
   const lastErrorCheckedAt = getLastErrorCheckedAt(cache);
   const hasCurrentVersionDecision = cache?.decision?.current_version === currentVersion;
+  const hasCurrentPolicyUrl =
+    cache?.policy_url === policyUrl || cache?.decision?.policy_url === policyUrl;
   const hasFreshErrorOnlyCache =
     Boolean(cache?.error) &&
     !cache?.decision &&
+    hasCurrentPolicyUrl &&
     lastErrorCheckedAt !== undefined &&
     isCacheFresh(lastErrorCheckedAt, now);
 
   if (
     cache?.decision &&
     hasCurrentVersionDecision &&
+    hasCurrentPolicyUrl &&
     lastSuccessCheckedAt &&
     isCacheFresh(lastSuccessCheckedAt, now)
   ) {
@@ -287,7 +292,7 @@ export async function getMakerPackageUpdateStatus(
       currentVersion,
       error: formatUnavailableNonBlockingError(cache?.error, shouldStartBackgroundRefresh),
       checkedAt: now.toISOString(),
-      policyUrl: resolvePolicyUrl(options.policyUrl),
+      policyUrl,
     });
   }
 

--- a/src/maker/versionCheck.ts
+++ b/src/maker/versionCheck.ts
@@ -212,6 +212,7 @@ export async function checkMakerPackageUpdate(
       cache: latestCache,
       currentVersion,
       error: message,
+      policyUrl,
     });
 
     writeCache({
@@ -653,7 +654,7 @@ function comparePrereleaseIdentifier(left: string, right: string): number {
   const rightNumeric = /^\d+$/.test(right);
 
   if (leftNumeric && rightNumeric) {
-    return Number(left) - Number(right);
+    return compareNumericPrereleaseIdentifier(left, right);
   }
   if (leftNumeric) {
     return -1;
@@ -662,4 +663,15 @@ function comparePrereleaseIdentifier(left: string, right: string): number {
     return 1;
   }
   return left.localeCompare(right);
+}
+
+function compareNumericPrereleaseIdentifier(left: string, right: string): number {
+  const normalizedLeft = left.replace(/^0+(?=\d)/, '');
+  const normalizedRight = right.replace(/^0+(?=\d)/, '');
+
+  if (normalizedLeft.length !== normalizedRight.length) {
+    return normalizedLeft.length - normalizedRight.length;
+  }
+
+  return normalizedLeft.localeCompare(normalizedRight);
 }

--- a/src/maker/versionCheck.ts
+++ b/src/maker/versionCheck.ts
@@ -1,0 +1,639 @@
+/**
+ * Maker MCP package version policy check helpers.
+ *
+ * This module only checks version policy, caches results, and formats
+ * status output. It never runs upgrade commands.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fetchWithTimeout } from './fetchTimeout.js';
+import { getMakerHome } from './storage.js';
+
+const DEFAULT_POLICY_URL =
+  'https://raw.githubusercontent.com/taptap/instant-games-open-mcp/main/config/maker-version-policy.json';
+const POLICY_URL_ENV = 'TAPTAP_MAKER_VERSION_POLICY_URL';
+
+export const DEFAULT_PACKAGE_VERSION_CHECK_TIMEOUT_MS = 3000;
+export const PACKAGE_VERSION_CHECK_TTL_MS = 12 * 60 * 60 * 1000;
+export const PACKAGE_VERSION_CHECK_CACHE_FILE = 'package-version-check.json';
+
+type MakerPackageUpdateDecisionStatus =
+  | 'current'
+  | 'update_available'
+  | 'required_upgrade'
+  | 'unavailable'
+  | 'skipped';
+
+type MakerPackageUpdateReason =
+  | 'blacklisted'
+  | 'below_minimum_supported'
+  | 'beta_outdated'
+  | 'dev_version';
+
+export interface MakerPackageVersionPolicy {
+  schema_version: 1;
+  latest: string;
+  latest_beta: string;
+  minimum_supported: string;
+  blacklist: string[];
+  message?: string;
+  updated_at: string;
+}
+
+export interface MakerPackageUpdateStatus {
+  status: MakerPackageUpdateDecisionStatus;
+  current_version: string;
+  target_version?: string;
+  reason?: MakerPackageUpdateReason;
+  minimum_supported?: string;
+  latest?: string;
+  latest_beta?: string;
+  blacklist_match?: string;
+  checked_at?: string;
+  policy_url?: string;
+  message?: string;
+  next_action?: string;
+  restart_required?: boolean;
+  error?: string;
+  last_success_checked_at?: string;
+  previous_status?: Exclude<MakerPackageUpdateDecisionStatus, 'unavailable'>;
+}
+
+export interface MakerPackageUpdateCheckOptions {
+  currentVersion: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+  policyUrl?: string;
+  now?: Date;
+  allowRemoteFetch?: boolean;
+}
+
+interface MakerPackageVersionCheckCache {
+  checked_at?: string;
+  policy_url?: string;
+  policy?: MakerPackageVersionPolicy;
+  decision?: MakerPackageUpdateStatus;
+  error?: string;
+  error_checked_at?: string;
+}
+
+interface ParsedVersion {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string[];
+}
+
+export function decideMakerPackageUpdate(
+  currentVersion: string,
+  policy: MakerPackageVersionPolicy
+): MakerPackageUpdateStatus {
+  if (currentVersion === 'dev') {
+    return {
+      status: 'skipped',
+      current_version: currentVersion,
+      reason: 'dev_version',
+      latest: policy.latest,
+      latest_beta: policy.latest_beta,
+      minimum_supported: policy.minimum_supported,
+      message: policy.message,
+      next_action: 'Continue normal work; dev builds do not use remote version policy.',
+      restart_required: false,
+    };
+  }
+
+  const current = parseVersion(currentVersion);
+  const latest = parseVersion(policy.latest);
+  const latestBeta = parseVersion(policy.latest_beta);
+  const minimumSupported = parseVersion(policy.minimum_supported);
+
+  if (!current || !latest || !latestBeta || !minimumSupported) {
+    throw new Error('Invalid version data for Maker package update decision.');
+  }
+
+  const isPrerelease = current.prerelease.length > 0;
+  if (policy.blacklist.includes(currentVersion)) {
+    return buildDecision('required_upgrade', currentVersion, policy, {
+      reason: 'blacklisted',
+      target_version: isPrerelease ? policy.latest_beta : policy.latest,
+      blacklist_match: currentVersion,
+      restart_required: true,
+      next_action:
+        'Ask the user for approval, then run `taptap-maker upgrade --target-dir <PROJECT_DIR>`.',
+    });
+  }
+
+  if (compareVersions(current, minimumSupported) < 0) {
+    return buildDecision('required_upgrade', currentVersion, policy, {
+      reason: 'below_minimum_supported',
+      target_version: isPrerelease ? policy.latest_beta : policy.latest,
+      restart_required: true,
+      next_action:
+        'Ask the user for approval, then run `taptap-maker upgrade --target-dir <PROJECT_DIR>`.',
+    });
+  }
+
+  if (isPrerelease && compareVersions(current, latestBeta) < 0) {
+    return buildDecision('required_upgrade', currentVersion, policy, {
+      reason: 'beta_outdated',
+      target_version: policy.latest_beta,
+      restart_required: true,
+      next_action:
+        'Ask the user for approval, then run `taptap-maker upgrade --target-dir <PROJECT_DIR>`.',
+    });
+  }
+
+  if (!isPrerelease && compareVersions(current, latest) < 0) {
+    return buildDecision('update_available', currentVersion, policy, {
+      target_version: policy.latest,
+      restart_required: false,
+      next_action:
+        'Tell the user an update is available. Only run `taptap-maker upgrade` after approval.',
+    });
+  }
+
+  return buildDecision('current', currentVersion, policy, {
+    target_version: isPrerelease ? policy.latest_beta : policy.latest,
+    restart_required: false,
+    next_action: 'Continue normal work; no package upgrade is required.',
+  });
+}
+
+export async function checkMakerPackageUpdate(
+  options: MakerPackageUpdateCheckOptions
+): Promise<MakerPackageUpdateStatus> {
+  const now = options.now ?? new Date();
+  const currentVersion = options.currentVersion;
+
+  if (currentVersion === 'dev') {
+    return {
+      status: 'skipped',
+      current_version: currentVersion,
+      reason: 'dev_version',
+      checked_at: now.toISOString(),
+      next_action: 'Continue normal work; dev builds do not use remote version policy.',
+      restart_required: false,
+    };
+  }
+
+  const policyUrl = resolvePolicyUrl(options.policyUrl);
+
+  try {
+    const policy = await fetchMakerPackageVersionPolicy({
+      fetchImpl: options.fetchImpl,
+      policyUrl,
+      timeoutMs: options.timeoutMs,
+    });
+    const decision = decideMakerPackageUpdate(currentVersion, policy);
+    const status: MakerPackageUpdateStatus = {
+      ...decision,
+      current_version: currentVersion,
+      checked_at: now.toISOString(),
+      policy_url: policyUrl,
+      latest: policy.latest,
+      latest_beta: policy.latest_beta,
+      minimum_supported: policy.minimum_supported,
+      message: policy.message,
+    };
+
+    writeCache({
+      checked_at: status.checked_at,
+      policy_url: policyUrl,
+      policy,
+      decision: status,
+    });
+    return status;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const latestCache = readCache();
+    const unavailableStatus = buildUnavailableStatus({
+      cache: latestCache,
+      currentVersion,
+      error: message,
+    });
+
+    writeCache({
+      checked_at: latestCache?.checked_at,
+      policy_url: latestCache?.policy_url || policyUrl,
+      policy: latestCache?.policy,
+      decision: latestCache?.decision,
+      error: message,
+      error_checked_at: now.toISOString(),
+    });
+    return unavailableStatus;
+  }
+}
+
+export async function getMakerPackageUpdateStatus(
+  options: MakerPackageUpdateCheckOptions
+): Promise<MakerPackageUpdateStatus> {
+  const currentVersion = options.currentVersion;
+  if (currentVersion === 'dev') {
+    return {
+      status: 'skipped',
+      current_version: currentVersion,
+      reason: 'dev_version',
+      checked_at: (options.now ?? new Date()).toISOString(),
+      next_action: 'Continue normal work; dev builds do not use remote version policy.',
+      restart_required: false,
+    };
+  }
+
+  const cache = readCache();
+  const now = options.now ?? new Date();
+  const lastSuccessCheckedAt = getLastSuccessCheckedAt(cache);
+  const lastErrorCheckedAt = getLastErrorCheckedAt(cache);
+  const hasCurrentVersionDecision = cache?.decision?.current_version === currentVersion;
+
+  if (
+    cache?.decision &&
+    hasCurrentVersionDecision &&
+    lastSuccessCheckedAt &&
+    isCacheFresh(lastSuccessCheckedAt, now)
+  ) {
+    return cache.error
+      ? {
+          ...cache.decision,
+          error: cache.error,
+        }
+      : cache.decision;
+  }
+
+  if (
+    cache?.error &&
+    !cache?.decision &&
+    lastErrorCheckedAt &&
+    isCacheFresh(lastErrorCheckedAt, now)
+  ) {
+    return buildUnavailableStatus({
+      cache,
+      currentVersion,
+      error: cache.error,
+    });
+  }
+
+  if (options.allowRemoteFetch === false) {
+    startMakerPackageUpdateCheck(options);
+    return buildUnavailableStatus({
+      cache,
+      currentVersion,
+      error: cache?.error
+        ? `${cache.error}; background retry started.`
+        : 'Maker package version check is running in the background.',
+      checkedAt: now.toISOString(),
+      policyUrl: resolvePolicyUrl(options.policyUrl),
+    });
+  }
+
+  return checkMakerPackageUpdate(options);
+}
+
+let backgroundCheck:
+  | {
+      key: string;
+      promise: Promise<void>;
+    }
+  | undefined;
+
+export function startMakerPackageUpdateCheck(options: MakerPackageUpdateCheckOptions): void {
+  const key = `${options.currentVersion}\n${resolvePolicyUrl(options.policyUrl)}`;
+  if (backgroundCheck?.key === key) {
+    return;
+  }
+  const promise = checkMakerPackageUpdate(options)
+    .then(() => undefined)
+    .catch(() => undefined)
+    .finally(() => {
+      if (backgroundCheck?.promise === promise) {
+        backgroundCheck = undefined;
+      }
+    });
+  backgroundCheck = { key, promise };
+}
+
+export function formatMakerPackageUpdateStatus(status: MakerPackageUpdateStatus): string {
+  const lines = ['Maker MCP package update', ''];
+
+  lines.push(`- status: ${status.status}`);
+  lines.push(`- current_version: ${status.current_version}`);
+
+  if (status.target_version) {
+    lines.push(`- target_version: ${status.target_version}`);
+  }
+  if (status.reason) {
+    lines.push(`- reason: ${status.reason}`);
+  }
+  if (status.minimum_supported) {
+    lines.push(`- minimum_supported: ${status.minimum_supported}`);
+  }
+  if (status.latest) {
+    lines.push(`- latest: ${status.latest}`);
+  }
+  if (status.latest_beta) {
+    lines.push(`- latest_beta: ${status.latest_beta}`);
+  }
+  if (status.blacklist_match) {
+    lines.push(`- blacklist_match: ${status.blacklist_match}`);
+  } else if (status.status !== 'skipped') {
+    lines.push('- blacklist_match: no');
+  }
+  if (status.checked_at) {
+    lines.push(`- checked_at: ${status.checked_at}`);
+  }
+  if (status.policy_url) {
+    lines.push(`- policy_url: ${status.policy_url}`);
+  }
+  if (status.message) {
+    lines.push(`- message: ${status.message}`);
+  }
+  if (status.error) {
+    lines.push(`- error: ${status.error}`);
+  }
+  if (status.last_success_checked_at) {
+    lines.push(`- last_success_checked_at: ${status.last_success_checked_at}`);
+  }
+  if (status.previous_status) {
+    lines.push(`- previous_status: ${status.previous_status}`);
+  }
+  if (status.next_action) {
+    lines.push(`- next_action: ${status.next_action}`);
+  }
+  if (typeof status.restart_required === 'boolean') {
+    lines.push(`- restart_required: ${status.restart_required ? 'yes' : 'no'}`);
+  }
+
+  return lines.join('\n');
+}
+
+async function fetchMakerPackageVersionPolicy(options: {
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+  policyUrl: string;
+}): Promise<MakerPackageVersionPolicy> {
+  const fetchImpl = options.fetchImpl || fetch;
+  const response = await fetchWithTimeout(
+    fetchImpl,
+    options.policyUrl,
+    {
+      headers: {
+        Accept: 'application/json',
+      },
+    },
+    options.timeoutMs ?? DEFAULT_PACKAGE_VERSION_CHECK_TIMEOUT_MS,
+    'Maker package version check'
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `Maker package version check failed: HTTP ${response.status} ${response.statusText}`
+    );
+  }
+
+  const payload = await response.json();
+  return parsePolicy(payload);
+}
+
+function parsePolicy(payload: unknown): MakerPackageVersionPolicy {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Invalid Maker package version policy schema: expected an object.');
+  }
+
+  const policy = payload as Partial<MakerPackageVersionPolicy>;
+  if (policy.schema_version !== 1) {
+    throw new Error('Invalid Maker package version policy schema: schema_version must be 1.');
+  }
+  if (!isValidVersionString(policy.latest)) {
+    throw new Error('Invalid Maker package version policy schema: latest must be a semver string.');
+  }
+  if (!isValidVersionString(policy.latest_beta)) {
+    throw new Error(
+      'Invalid Maker package version policy schema: latest_beta must be a semver string.'
+    );
+  }
+  if (!isValidVersionString(policy.minimum_supported)) {
+    throw new Error(
+      'Invalid Maker package version policy schema: minimum_supported must be a semver string.'
+    );
+  }
+  if (
+    !Array.isArray(policy.blacklist) ||
+    policy.blacklist.some((item) => !isValidVersionString(item))
+  ) {
+    throw new Error(
+      'Invalid Maker package version policy schema: blacklist must be a semver string array.'
+    );
+  }
+  if (typeof policy.updated_at !== 'string' || Number.isNaN(Date.parse(policy.updated_at))) {
+    throw new Error(
+      'Invalid Maker package version policy schema: updated_at must be an ISO timestamp string.'
+    );
+  }
+  if (policy.message !== undefined && typeof policy.message !== 'string') {
+    throw new Error('Invalid Maker package version policy schema: message must be a string.');
+  }
+
+  return {
+    schema_version: 1,
+    latest: policy.latest,
+    latest_beta: policy.latest_beta,
+    minimum_supported: policy.minimum_supported,
+    blacklist: [...policy.blacklist],
+    message: policy.message,
+    updated_at: policy.updated_at,
+  };
+}
+
+function buildDecision(
+  status: Exclude<MakerPackageUpdateDecisionStatus, 'unavailable' | 'skipped'>,
+  currentVersion: string,
+  policy: MakerPackageVersionPolicy,
+  overrides: Partial<MakerPackageUpdateStatus>
+): MakerPackageUpdateStatus {
+  return {
+    status,
+    current_version: currentVersion,
+    latest: policy.latest,
+    latest_beta: policy.latest_beta,
+    minimum_supported: policy.minimum_supported,
+    message: policy.message,
+    ...overrides,
+  };
+}
+
+function buildUnavailableStatus(options: {
+  cache?: MakerPackageVersionCheckCache;
+  currentVersion: string;
+  error: string;
+  checkedAt?: string;
+  policyUrl?: string;
+}): MakerPackageUpdateStatus {
+  const previousDecision = options.cache?.decision;
+  const hasCurrentVersionDecision = previousDecision?.current_version === options.currentVersion;
+  const lastSuccessCheckedAt = hasCurrentVersionDecision
+    ? getLastSuccessCheckedAt(options.cache)
+    : undefined;
+  const previousPolicy = options.cache?.policy;
+
+  return compactStatus({
+    status: 'unavailable',
+    current_version: options.currentVersion,
+    target_version: hasCurrentVersionDecision ? previousDecision?.target_version : undefined,
+    reason: hasCurrentVersionDecision ? previousDecision?.reason : undefined,
+    minimum_supported:
+      (hasCurrentVersionDecision ? previousDecision?.minimum_supported : undefined) ??
+      previousPolicy?.minimum_supported,
+    latest:
+      (hasCurrentVersionDecision ? previousDecision?.latest : undefined) ?? previousPolicy?.latest,
+    latest_beta:
+      (hasCurrentVersionDecision ? previousDecision?.latest_beta : undefined) ??
+      previousPolicy?.latest_beta,
+    blacklist_match: hasCurrentVersionDecision ? previousDecision?.blacklist_match : undefined,
+    checked_at: options.checkedAt,
+    policy_url: options.cache?.policy_url ?? options.policyUrl,
+    message:
+      (hasCurrentVersionDecision ? previousDecision?.message : undefined) ??
+      previousPolicy?.message,
+    error: options.error,
+    last_success_checked_at: lastSuccessCheckedAt,
+    previous_status:
+      hasCurrentVersionDecision &&
+      previousDecision?.status &&
+      previousDecision.status !== 'unavailable'
+        ? previousDecision.status
+        : undefined,
+    next_action: 'Continue normal work; retry status later.',
+    restart_required: false,
+  });
+}
+
+function compactStatus(status: MakerPackageUpdateStatus): MakerPackageUpdateStatus {
+  return Object.fromEntries(
+    Object.entries(status).filter(([, value]) => value !== undefined)
+  ) as unknown as MakerPackageUpdateStatus;
+}
+
+function readCache(): MakerPackageVersionCheckCache | undefined {
+  const cachePath = getMakerPackageVersionCheckCachePath();
+  if (!fs.existsSync(cachePath)) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(fs.readFileSync(cachePath, 'utf8')) as MakerPackageVersionCheckCache;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeCache(cache: MakerPackageVersionCheckCache): void {
+  const cachePath = getMakerPackageVersionCheckCachePath();
+  fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+  fs.writeFileSync(cachePath, `${JSON.stringify(cache, null, 2)}\n`, 'utf8');
+}
+
+function getMakerPackageVersionCheckCachePath(): string {
+  return path.join(getMakerHome(), PACKAGE_VERSION_CHECK_CACHE_FILE);
+}
+
+function getLastSuccessCheckedAt(cache?: MakerPackageVersionCheckCache): string | undefined {
+  if (!cache) {
+    return undefined;
+  }
+  if (cache.decision?.status && cache.decision.status !== 'unavailable') {
+    return cache.decision.checked_at || cache.checked_at;
+  }
+  return cache.checked_at;
+}
+
+function getLastErrorCheckedAt(cache?: MakerPackageVersionCheckCache): string | undefined {
+  return cache?.error_checked_at;
+}
+
+function isCacheFresh(checkedAt: string, now: Date): boolean {
+  const checkedMs = Date.parse(checkedAt);
+  if (Number.isNaN(checkedMs)) {
+    return false;
+  }
+  return now.getTime() - checkedMs < PACKAGE_VERSION_CHECK_TTL_MS;
+}
+
+function resolvePolicyUrl(policyUrl?: string): string {
+  return policyUrl || process.env[POLICY_URL_ENV] || DEFAULT_POLICY_URL;
+}
+
+function isValidVersionString(value: unknown): value is string {
+  return typeof value === 'string' && parseVersion(value) !== undefined;
+}
+
+function parseVersion(version: string): ParsedVersion | undefined {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/.exec(version.trim());
+  if (!match) {
+    return undefined;
+  }
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] ? match[4].split('.') : [],
+  };
+}
+
+function compareVersions(left: ParsedVersion, right: ParsedVersion): number {
+  if (left.major !== right.major) {
+    return left.major - right.major;
+  }
+  if (left.minor !== right.minor) {
+    return left.minor - right.minor;
+  }
+  if (left.patch !== right.patch) {
+    return left.patch - right.patch;
+  }
+
+  const leftPre = left.prerelease;
+  const rightPre = right.prerelease;
+  if (leftPre.length === 0 && rightPre.length === 0) {
+    return 0;
+  }
+  if (leftPre.length === 0) {
+    return 1;
+  }
+  if (rightPre.length === 0) {
+    return -1;
+  }
+
+  const length = Math.max(leftPre.length, rightPre.length);
+  for (let index = 0; index < length; index += 1) {
+    const leftIdentifier = leftPre[index];
+    const rightIdentifier = rightPre[index];
+    if (leftIdentifier === undefined) {
+      return -1;
+    }
+    if (rightIdentifier === undefined) {
+      return 1;
+    }
+    const compared = comparePrereleaseIdentifier(leftIdentifier, rightIdentifier);
+    if (compared !== 0) {
+      return compared;
+    }
+  }
+
+  return 0;
+}
+
+function comparePrereleaseIdentifier(left: string, right: string): number {
+  const leftNumeric = /^\d+$/.test(left);
+  const rightNumeric = /^\d+$/.test(right);
+
+  if (leftNumeric && rightNumeric) {
+    return Number(left) - Number(right);
+  }
+  if (leftNumeric) {
+    return -1;
+  }
+  if (rightNumeric) {
+    return 1;
+  }
+  return left.localeCompare(right);
+}

--- a/src/maker/versionCheck.ts
+++ b/src/maker/versionCheck.ts
@@ -67,6 +67,7 @@ export interface MakerPackageUpdateCheckOptions {
   policyUrl?: string;
   now?: Date;
   allowRemoteFetch?: boolean;
+  backgroundRefresh?: boolean;
 }
 
 interface MakerPackageVersionCheckCache {
@@ -245,6 +246,11 @@ export async function getMakerPackageUpdateStatus(
   const lastSuccessCheckedAt = getLastSuccessCheckedAt(cache);
   const lastErrorCheckedAt = getLastErrorCheckedAt(cache);
   const hasCurrentVersionDecision = cache?.decision?.current_version === currentVersion;
+  const hasFreshErrorOnlyCache =
+    Boolean(cache?.error) &&
+    !cache?.decision &&
+    lastErrorCheckedAt !== undefined &&
+    isCacheFresh(lastErrorCheckedAt, now);
 
   if (
     cache?.decision &&
@@ -260,21 +266,21 @@ export async function getMakerPackageUpdateStatus(
       : cache.decision;
   }
 
-  if (
-    cache?.error &&
-    !cache?.decision &&
-    lastErrorCheckedAt &&
-    isCacheFresh(lastErrorCheckedAt, now)
-  ) {
+  if (hasFreshErrorOnlyCache && options.allowRemoteFetch === false) {
+    if (options.backgroundRefresh !== false) {
+      startMakerPackageUpdateCheck(options);
+    }
     return buildUnavailableStatus({
       cache,
       currentVersion,
-      error: cache.error,
+      error: cache?.error || 'Maker package version check is temporarily unavailable.',
     });
   }
 
   if (options.allowRemoteFetch === false) {
-    startMakerPackageUpdateCheck(options);
+    if (options.backgroundRefresh !== false) {
+      startMakerPackageUpdateCheck(options);
+    }
     return buildUnavailableStatus({
       cache,
       currentVersion,

--- a/src/maker/versionCheck.ts
+++ b/src/maker/versionCheck.ts
@@ -278,15 +278,14 @@ export async function getMakerPackageUpdateStatus(
   }
 
   if (options.allowRemoteFetch === false) {
-    if (options.backgroundRefresh !== false) {
+    const shouldStartBackgroundRefresh = options.backgroundRefresh !== false;
+    if (shouldStartBackgroundRefresh) {
       startMakerPackageUpdateCheck(options);
     }
     return buildUnavailableStatus({
       cache,
       currentVersion,
-      error: cache?.error
-        ? `${cache.error}; background retry started.`
-        : 'Maker package version check is running in the background.',
+      error: formatUnavailableNonBlockingError(cache?.error, shouldStartBackgroundRefresh),
       checkedAt: now.toISOString(),
       policyUrl: resolvePolicyUrl(options.policyUrl),
     });
@@ -370,6 +369,18 @@ export function formatMakerPackageUpdateStatus(status: MakerPackageUpdateStatus)
   }
 
   return lines.join('\n');
+}
+
+function formatUnavailableNonBlockingError(
+  previousError: string | undefined,
+  backgroundRefresh: boolean
+): string {
+  if (backgroundRefresh) {
+    return previousError
+      ? `${previousError}; background retry started.`
+      : 'Maker package version check is running in the background.';
+  }
+  return previousError || 'Maker package version check is temporarily unavailable.';
 }
 
 async function fetchMakerPackageVersionPolicy(options: {


### PR DESCRIPTION
## 改动内容
- 为 Maker MCP 增加远端版本策略检查，只输出升级建议，不自动执行升级。
- 在 MCP 启动时异步检查，在 status/doctor 中输出结构化 package update 状态。
- status/doctor 不等待远端 raw 请求，GitHub 不可访问时只降级为 unavailable，不影响使用。
- 发布 latest/beta 成功后自动更新版本策略并创建可审核 PR。

## 预期行为
- 低于 minimum_supported、命中 blacklist、过期 beta 会提示 required_upgrade。
- 普通 stable 落后 latest 只提示 update_available。
- 网络不可用时继续正常工作，不执行升级命令。

## 验证
- npm test -- --runTestsByPath src/__tests__/makerVersionCheck.test.ts src/__tests__/makerMcpVersionStatus.test.ts src/__tests__/makerCliCommands.test.ts src/__tests__/makerBuildLocalChanges.test.ts src/__tests__/makerVersionPolicyUpdate.test.ts src/__tests__/releaseScope.test.ts src/__tests__/releaseScopeCli.test.ts src/__tests__/releaseWorkflowGuards.test.ts
- npm run build
- npm run lint

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

此 PR 为 Maker MCP 增加了远端版本策略检查功能：MCP 启动时异步拉取策略 JSON，在 `status`/`doctor` 命令中输出结构化升级建议，网络不可用时降级为 `unavailable` 不影响正常使用；发布后通过 CI 自动更新策略文件并创建可审核 PR。

- **`src/maker/versionCheck.ts`**：新增核心模块，包含版本决策逻辑（blacklist / minimum_supported / beta_outdated / update_available）、12 小时 TTL 缓存、后台刷新去重，以及数值型 prerelease identifier 的精确字符串比较（避免 `Number()` 精度丢失）。
- **`scripts/update-maker-version-policy.cjs`**：发布后策略文件更新脚本，仅更新 `latest` / `latest_beta` 字段，保留 `minimum_supported`、`blacklist`、`message` 等手动策略字段；`scripts/resolve-maker-version.js` 新增 manual 模式下 prerelease identifier 与 dist-tag 一致性校验。
- **`.github/workflows/publish-maker.yml`**：npm publish 成功后自动运行策略更新脚本并使用 GitHub App token 创建可审核 PR；权限从 `contents: read` 升级为 `contents: write`（工作流级），覆盖范围超出实际需要。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

整体改动逻辑正确、测试覆盖充分，可安全合并；工作流权限配置略有改进空间。

核心版本检查逻辑、缓存机制、后台刷新去重均有对应测试验证，策略文件更新脚本的字段校验与运行时解析保持一致，doctor 命令通过 backgroundRefresh:false 避免了进程延迟退出。工作流权限在工作流级设置了 contents: write，但该写权限在实际执行路径中由 App token 承担，GITHUB_TOKEN 的写权限未被实际使用，属于可改进但不影响功能的配置。

.github/workflows/publish-maker.yml 的权限配置值得在合并前确认是否需要将写权限下放至 job 级别。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/maker/versionCheck.ts | 新增版本策略检查核心模块：缓存、后台刷新、版本决策逻辑均已完整实现，数值型 prerelease identifier 比较用长度加字典序避免精度丢失，整体逻辑正确。 |
| scripts/update-maker-version-policy.cjs | 发布后策略文件更新脚本：对 latest/beta tag 做了版本格式校验，blacklist 元素逐项校验 semver，发布前字段验证与运行时 parsePolicy 保持一致。 |
| .github/workflows/publish-maker.yml | 新增发布后策略更新与 PR 创建步骤；工作流级 `contents: write` 权限比实际所需更宽泛，`resolve-version` job 获得了不必要的写权限。 |
| scripts/resolve-maker-version.js | 新增 `assertVersionMatchesTag` 在 manual 模式下校验 prerelease identifier 与 dist-tag 一致，填补了之前的发布前验证空缺。 |
| src/maker/cli/commands.ts | doctor 命令集成包更新状态检查，使用 `allowRemoteFetch: false, backgroundRefresh: false` 确保 CLI 进程不会因后台检查而延迟退出。 |
| src/maker/server/mcp.ts | MCP 启动时触发异步后台检查，status 工具使用缓存结果避免阻塞，逻辑正确。 |
| config/maker-version-policy.json | 新增策略文件初始内容，字段齐全，schema_version 正确。 |
| scripts/release-scope.cjs | 将策略文件和更新脚本加入 MAKER 与 release_infra 两个范围的路径集合，确保相关变更触发正确的 CI 检查。 |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant MCP as MCP Server / CLI
    participant VC as versionCheck.ts
    participant Cache as 本地缓存 (JSON)
    participant GH as GitHub Raw (policy JSON)

    MCP->>VC: "startMakerPackageUpdateCheck({ currentVersion })"
    VC-->>Cache: 后台异步 checkMakerPackageUpdate
    Cache-->>VC: 读取旧缓存
    VC->>GH: fetchWithTimeout (3s)
    GH-->>VC: MakerPackageVersionPolicy
    VC->>Cache: writeCache(decision)

    MCP->>VC: "getMakerPackageUpdateStatus({ allowRemoteFetch:false })"
    VC-->>Cache: readCache()
    alt 缓存新鲜 (TTL 12h)
        Cache-->>VC: decision
        VC-->>MCP: 返回缓存决策
    else 缓存过期 / 无缓存
        VC-->>MCP: unavailable (后台已触发刷新)
    end

    Note over VC,GH: doctor 命令使用 backgroundRefresh:false，不触发后台请求

    participant WF as publish-maker workflow
    participant NPM as npm registry
    participant PR as GitHub PR

    WF->>NPM: "npm publish @taptap/maker@version"
    NPM-->>WF: 发布成功
    WF->>WF: update-maker-version-policy.cjs
    WF->>PR: peter-evans/create-pull-request (App token)
    PR-->>WF: PR URL
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant MCP as MCP Server / CLI
    participant VC as versionCheck.ts
    participant Cache as 本地缓存 (JSON)
    participant GH as GitHub Raw (policy JSON)

    MCP->>VC: "startMakerPackageUpdateCheck({ currentVersion })"
    VC-->>Cache: 后台异步 checkMakerPackageUpdate
    Cache-->>VC: 读取旧缓存
    VC->>GH: fetchWithTimeout (3s)
    GH-->>VC: MakerPackageVersionPolicy
    VC->>Cache: writeCache(decision)

    MCP->>VC: "getMakerPackageUpdateStatus({ allowRemoteFetch:false })"
    VC-->>Cache: readCache()
    alt 缓存新鲜 (TTL 12h)
        Cache-->>VC: decision
        VC-->>MCP: 返回缓存决策
    else 缓存过期 / 无缓存
        VC-->>MCP: unavailable (后台已触发刷新)
    end

    Note over VC,GH: doctor 命令使用 backgroundRefresh:false，不触发后台请求

    participant WF as publish-maker workflow
    participant NPM as npm registry
    participant PR as GitHub PR

    WF->>NPM: "npm publish @taptap/maker@version"
    NPM-->>WF: 发布成功
    WF->>WF: update-maker-version-policy.cjs
    WF->>PR: peter-evans/create-pull-request (App token)
    PR-->>WF: PR URL
```

</a>
</details>

<sub>Reviews (7): Last reviewed commit: ["fix(maker): harden review edge cases"](https://github.com/taptap/instant-games-open-mcp/commit/23798c4a072c11fecc3721f663be1153e1d333d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39255088)</sub>

<!-- /greptile_comment -->