### PR TITLE
feat(maker): 支持更多 AI 编辑器 MCP 安装

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,10 +350,17 @@ Maker 本地开发的默认路径是 CLI-first + PAT-first：
 - CLI 写 MCP 配置时优先支持 Windows：Windows 通过 `cmd.exe` 包装 `npx.cmd`，
   避免无 shell 的 MCP 启动器直接 spawn `.cmd` 失败；Git 引导优先指向 Git for
   Windows；macOS 用户可通过 `git --version` 触发 Xcode Command Line Tools 或安装官方
-  Git。`taptap-maker init` 默认写入不带项目 `cwd` 的用户级 MCP 配置，避免 Codex、Trae、
+  Git。`taptap-maker init` 默认写入不带项目 `cwd` 的用户级 MCP 配置，默认覆盖 Codex、
+  Cursor、Claude，并自动检测已存在配置文件的 Trae、OpenCode、WorkBuddy；避免 Codex、Trae、
   Cursor 等客户端或多个 Maker 项目互相覆盖全局 cwd；支持 MCP Roots 的客户端由当前
   workspace root 决定 Maker 项目。只有显式运行 `taptap-maker mcp install --target-dir <PROJECT_DIR>`
   或 `taptap-maker upgrade --target-dir <PROJECT_DIR>` 时，才把该目录写入 MCP 配置的 `cwd`。
+  Trae 需同时检测 Solo、非 Solo 和 CN 版 `User/` 目录，并创建或合并 `User/mcp.json`；
+  OpenCode 使用官方 `mcp` schema 和 command 数组，
+  不写环境变量；
+  WorkBuddy 会写已存在的 `~/.workbuddy/.mcp.json` 或 `~/.workbuddy/mcp.json`；通用
+  `mcpServers` JSON 只作为 README/文档片段引导其它 AI 编辑器识别自己的实际配置文件后合并写入，
+  CLI 不生成额外通用配置文件。
 - `taptap-maker mcp verify` 默认验证 `mcp install` 写入配置的 npx 包命令能否启动；本地开发只验证当前 CLI 时使用 `--mode self`。
 - MCP 公共能力保留 `maker://status`、`maker_status_lite` 和
   `maker_build_current_directory`；初始化、PAT 保存、app 列表和 clone 由 CLI/skill 承担。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,10 +355,12 @@ Maker 本地开发的默认路径是 CLI-first + PAT-first：
   Cursor 等客户端或多个 Maker 项目互相覆盖全局 cwd；支持 MCP Roots 的客户端由当前
   workspace root 决定 Maker 项目。只有显式运行 `taptap-maker mcp install --target-dir <PROJECT_DIR>`
   或 `taptap-maker upgrade --target-dir <PROJECT_DIR>` 时，才把该目录写入 MCP 配置的 `cwd`。
-  Trae 需同时检测 Solo、非 Solo 和 CN 版 `User/` 目录，并创建或合并 `User/mcp.json`；
+  Trae Solo/Solo CN 优先支持，按 `User/` 目录创建或合并 `User/mcp.json`，普通 Trae
+  只在 `mcp.json` 已存在时更新；
   OpenCode 使用官方 `mcp` schema 和 command 数组，
   不写环境变量；
-  WorkBuddy 会写已存在的 `~/.workbuddy/.mcp.json` 或 `~/.workbuddy/mcp.json`；通用
+  WorkBuddy 按平台写配置，macOS 写 `~/.workbuddy/.mcp.json`，
+  Windows 写 `%USERPROFILE%\.workbuddy\mcp.json`；通用
   `mcpServers` JSON 只作为 README/文档片段引导其它 AI 编辑器识别自己的实际配置文件后合并写入，
   CLI 不生成额外通用配置文件。
 - `taptap-maker mcp verify` 默认验证 `mcp install` 写入配置的 npx 包命令能否启动；本地开发只验证当前 CLI 时使用 `--mode self`。

--- a/README.md
+++ b/README.md
@@ -84,10 +84,12 @@ taptap-maker dev-kit update
 自动化场景可用 `--pat-stdin` 从标准输入读取。`taptap-maker install` 是
 `taptap-maker mcp install` 的快捷别名，二者都会写入 AI 客户端 MCP 配置。
 默认会写入 Codex、Cursor、Claude，并自动检测本机已有的 Trae、OpenCode、WorkBuddy
-配置文件；命中后会合并安装 `taptap-maker`。Trae 版本较多，CLI 会检查 Solo、非 Solo
-和 CN 版的常见路径；只要对应版本的 `User/` 目录存在，就会创建或合并 `User/mcp.json`。
-OpenCode 只在 `~/.config/opencode/opencode.jsonc` 已存在时写入。WorkBuddy 会写已存在的
-`~/.workbuddy/.mcp.json` 或 `~/.workbuddy/mcp.json`。
+配置文件；命中后会合并安装 `taptap-maker`。Trae Solo 是重点支持目标，CLI 会在 Solo
+或 Solo CN 的 `User/` 目录存在时创建或合并 `User/mcp.json`；普通 Trae/Trae CN 仍作为
+候选路径保留，但只有 `mcp.json` 已存在时才合并写入。WorkBuddy 在 macOS 写
+`~/.workbuddy/.mcp.json`，Windows 写 `%USERPROFILE%\.workbuddy\mcp.json`，另一配置文件
+仅在已存在时作为 fallback 合并。OpenCode 只在
+`~/.config/opencode/opencode.jsonc` 已存在时写入。
 其它 AI 编辑器可按下面的通用 `mcpServers` 片段，让本地 AI 识别自己的配置文件位置后合并写入：
 
 ```json

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ npx -y @taptap/maker init
 CLI 负责一次性流程：Git 检查、Python 和 maker-lua-lsp 本地 Lua 诊断环境检查、CLI 登录、
 TapTap token 换取、app 列表选择或新建 Maker 项目、Maker Git clone、AI dev kit 准备、MCP 配置写入与基础验证。Python 环境准备连续 3 次失败时，
 初始化会暂停在登录、项目拉取和 MCP 配置之前；修复后重新运行 `taptap-maker init`。安装或修改 MCP 配置后，Claude Code /
-Codex / Cursor 通常需要重启会话、刷新 MCP 或新开窗口才会出现新的 MCP tools；但当前终端
+Codex / Cursor / Trae / OpenCode / WorkBuddy 通常需要重启会话、刷新 MCP 或新开窗口才会出现新的 MCP tools；但当前终端
 里的 CLI 初始化流程可以继续完成到 PAT 鉴权和项目绑定。
 
 常用 CLI：
@@ -64,7 +64,8 @@ taptap-maker init
 taptap-maker login
 taptap-maker doctor
 taptap-maker apps --json
-taptap-maker install --ide codex,cursor,claude
+taptap-maker install
+taptap-maker install --ide codex,cursor,claude,trae,opencode,workbuddy
 taptap-maker agents update
 taptap-maker upgrade
 taptap-maker mcp verify
@@ -82,6 +83,27 @@ taptap-maker dev-kit update
 `taptap-maker init` 缺 PAT 时会自动进入该流程。`taptap-maker pat set` 保留为兼容入口；
 自动化场景可用 `--pat-stdin` 从标准输入读取。`taptap-maker install` 是
 `taptap-maker mcp install` 的快捷别名，二者都会写入 AI 客户端 MCP 配置。
+默认会写入 Codex、Cursor、Claude，并自动检测本机已有的 Trae、OpenCode、WorkBuddy
+配置文件；命中后会合并安装 `taptap-maker`。Trae 版本较多，CLI 会检查 Solo、非 Solo
+和 CN 版的常见路径；只要对应版本的 `User/` 目录存在，就会创建或合并 `User/mcp.json`。
+OpenCode 只在 `~/.config/opencode/opencode.jsonc` 已存在时写入。WorkBuddy 会写已存在的
+`~/.workbuddy/.mcp.json` 或 `~/.workbuddy/mcp.json`。
+其它 AI 编辑器可按下面的通用 `mcpServers` 片段，让本地 AI 识别自己的配置文件位置后合并写入：
+
+```json
+{
+  "mcpServers": {
+    "taptap-maker": {
+      "command": "npx",
+      "args": ["-y", "-p", "@taptap/maker", "taptap-maker"]
+    }
+  }
+}
+```
+
+`production` 是默认环境，通常不需要写 `env`。只有要切到 RND 时再增加
+`"env": { "TAPTAP_MCP_ENV": "rnd" }`。
+
 `taptap-maker init` 默认写入不带项目 `cwd` 的用户级 MCP 配置；支持 MCP Roots 的客户端
 会用当前 workspace root 识别 Maker 项目，避免多个客户端或多个项目互相覆盖 cwd。需要兼容
 不支持 Roots 的客户端时，可显式运行 `taptap-maker mcp install --target-dir <PROJECT_DIR>`。
@@ -118,8 +140,9 @@ Maker MCP 也提供部分生成类能力，当前包括 `generate_image`、`batc
 已绑定 Maker 项目中建议优先使用这些 proxy tools；代理转发、错误透出和白名单细节见
 [TapTap Maker 本地开发](docs/MAKER.md)。
 
-Windows 是默认优先级：CLI 写 MCP 配置时会在 Windows 通过 `cmd.exe` 包装 `npx.cmd`，
-避免无 shell 的 MCP 启动器直接 spawn `.cmd` 失败；Git 引导优先提示 Git for Windows，
+Windows 是默认优先级：CLI 写通用 `mcpServers` 配置时会在 Windows 通过 `cmd.exe`
+包装 `npx.cmd`，避免无 shell 的 MCP 启动器直接 spawn `.cmd` 失败；OpenCode 使用自己的
+`mcp` schema 和 command 数组，在 Windows 下写入 `npx.cmd`，不写环境变量；Git 引导优先提示 Git for Windows，
 并要求安装选项允许命令行和第三方工具通过 PATH 找到 Git。macOS 用户可通过 `git --version`
 触发 Xcode Command Line Tools，或安装官方 Git。
 

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -150,7 +150,7 @@ Python 未就绪时自动准备，失败最多重试 2 次
 或创建新 Maker 项目
 clone Maker 项目
 准备 AI dev-kit
-写入 Codex / Cursor / Claude MCP 配置
+写入 AI 客户端 MCP 配置
 taptap-maker doctor
 ```
 
@@ -196,11 +196,17 @@ Python 运行时策略：
   或自行安装 Python 3.12 后运行 `taptap-maker python doctor`。
 - `taptap-maker install`：`taptap-maker mcp install` 的快捷别名，用于写入当前机器的
   AI 客户端 MCP 配置。
-- `taptap-maker mcp install`：写入当前机器的 AI 客户端 MCP 配置。Codex 配置写入
-  会同时清理 `[mcp_servers.taptap-maker]` 与 `[mcp_servers."taptap-maker"]`
-  两种 TOML 等价写法，重复运行或从旧配置升级时应保持幂等。配置内容未变化时不会写文件，
-  也不会生成备份；内容变化时只覆盖一份 `<config>.taptap-maker.bak.latest`，不会创建新的
-  时间戳备份，也不会删除历史 `.bak.*` 文件。
+- `taptap-maker mcp install`：写入当前机器的 AI 客户端 MCP 配置。无 `--ide` 时默认写入
+  Codex、Cursor、Claude，并自动检测已存在配置文件的 Trae、OpenCode、WorkBuddy。可用
+  `--ide codex,cursor,claude,trae,opencode,workbuddy` 显式指定目标。
+  Codex 配置写入会同时清理 `[mcp_servers.taptap-maker]` 与
+  `[mcp_servers."taptap-maker"]` 两种 TOML 等价写法，重复运行或从旧配置升级时应保持幂等。
+  JSON/JSONC 配置写入前会解析并保留其它 server；写入后会重新校验 JSON 结构和
+  `taptap-maker` server 内容。配置内容未变化时不会写文件，也不会生成备份；内容变化时只覆盖一份
+  `<config>.taptap-maker.bak.latest`，不会创建新的时间戳备份，也不会删除历史 `.bak.*` 文件。
+  如果已有 JSON 配置无法解析，CLI 会停止该目标写入并保留原文件。
+  其它 AI 编辑器可使用 README 中的通用 `mcpServers` JSON 片段，让本地 AI 先识别该编辑器的
+  实际配置文件位置，再合并写入；CLI 不会额外生成通用配置文件。
 - `taptap-maker mcp verify`：默认验证 AI 客户端 MCP 配置使用的 npx 包命令可启动；`--mode self` 只验证当前 CLI 二进制。验证失败时若出现 `failure_type` 或 `status: null`，表示本地启动命令还没正常退出，Maker MCP server 尚未启动，不要当作 PAT、项目或 Maker 业务接口错误。
 - `taptap-maker agents update`：只更新当前目录 `AGENTS.md` 中 TapTap Maker 管理的策略块，
   保留用户自己的项目说明；缺少 `AGENTS.md` 时会创建文件。
@@ -485,6 +491,16 @@ Windows 兼容注意：
 
 - 写入 MCP 配置时，Windows 下通过 `cmd.exe /d /s /c npx.cmd ...` 启动，避免部分客户端
   无 shell 直接 `spawn` `.cmd` 时返回 `EINVAL`。
+- OpenCode 使用官方 `mcp` 配置 schema：`~/.config/opencode/opencode.jsonc` 中的
+  `mcp.<name>.command` 是数组，Windows 下写入 `npx.cmd`，不会套 `cmd.exe`，也不写环境变量。
+- Trae 会检测 Solo、非 Solo 和 CN 版配置路径；只要对应版本的 `User/` 目录存在，
+  就会创建或合并 `User/mcp.json`。macOS 常见位置包括
+  `~/Library/Application Support/TRAE SOLO/User/mcp.json`、
+  `Trae/User/mcp.json`、`Trae CN/User/mcp.json`，并兼容 `TRAE SOLO CN/User/mcp.json`；
+  Windows 常见位置包括 `%APPDATA%\TRAE SOLO\User\mcp.json`、
+  `%APPDATA%\Trae\User\mcp.json` 和 `%APPDATA%\Trae CN\User\mcp.json`。
+- WorkBuddy 会写已存在的 `~/.workbuddy/.mcp.json` 或 `~/.workbuddy/mcp.json`。
+- OpenCode 只在 `~/.config/opencode/opencode.jsonc` 已存在时写入，不主动创建。
 - `taptap-maker init` 默认写入不带项目 `cwd` 的用户级 MCP 配置，避免多个项目或多个 AI
   客户端互相覆盖全局 cwd。支持 MCP Roots 的客户端由当前 workspace root 决定 Maker 项目。
   单独运行 `taptap-maker mcp install --target-dir <PROJECT_DIR>` 时才会显式写入该目录，

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -493,13 +493,15 @@ Windows 兼容注意：
   无 shell 直接 `spawn` `.cmd` 时返回 `EINVAL`。
 - OpenCode 使用官方 `mcp` 配置 schema：`~/.config/opencode/opencode.jsonc` 中的
   `mcp.<name>.command` 是数组，Windows 下写入 `npx.cmd`，不会套 `cmd.exe`，也不写环境变量。
-- Trae 会检测 Solo、非 Solo 和 CN 版配置路径；只要对应版本的 `User/` 目录存在，
-  就会创建或合并 `User/mcp.json`。macOS 常见位置包括
+- Trae Solo 是重点支持目标；Solo 或 Solo CN 的 `User/` 目录存在时会创建或合并
+  `User/mcp.json`。普通 Trae/Trae CN 仍作为候选路径保留，但只有 `mcp.json` 已存在时才合并写入。
+  macOS 常见位置包括
   `~/Library/Application Support/TRAE SOLO/User/mcp.json`、
   `Trae/User/mcp.json`、`Trae CN/User/mcp.json`，并兼容 `TRAE SOLO CN/User/mcp.json`；
   Windows 常见位置包括 `%APPDATA%\TRAE SOLO\User\mcp.json`、
   `%APPDATA%\Trae\User\mcp.json` 和 `%APPDATA%\Trae CN\User\mcp.json`。
-- WorkBuddy 会写已存在的 `~/.workbuddy/.mcp.json` 或 `~/.workbuddy/mcp.json`。
+- WorkBuddy 在 macOS 写 `~/.workbuddy/.mcp.json`，Windows 写
+  `%USERPROFILE%\.workbuddy\mcp.json`，另一配置文件仅在已存在时作为 fallback 合并。
 - OpenCode 只在 `~/.config/opencode/opencode.jsonc` 已存在时写入，不主动创建。
 - `taptap-maker init` 默认写入不带项目 `cwd` 的用户级 MCP 配置，避免多个项目或多个 AI
   客户端互相覆盖全局 cwd。支持 MCP Roots 的客户端由当前 workspace root 决定 Maker 项目。

--- a/docs/MAKER_CLI_MCP_SKILL_REWORK_OVERVIEW.md
+++ b/docs/MAKER_CLI_MCP_SKILL_REWORK_OVERVIEW.md
@@ -69,8 +69,9 @@ CLI 负责所有与本机环境、账号、项目绑定相关的低频动作：
 - 本地分支测试可直接用 `node dist/maker.js`，不依赖 npm 发布。
 - Windows 下生成通用 `mcpServers` 配置时通过 `cmd.exe` 包装 `npx.cmd`，兼容无 shell 的 MCP 启动器。
 - OpenCode 使用官方 `mcp` schema 和 command 数组，不写环境变量，且只写已存在配置文件；
-  Trae 同时检测 Solo、非 Solo 和 CN 版 `User/` 目录，并创建或合并 `User/mcp.json`；
-  WorkBuddy 会写已存在的 `~/.workbuddy/.mcp.json` 或 `~/.workbuddy/mcp.json`。
+  Trae Solo/Solo CN 优先支持，按 `User/` 目录创建或合并 `User/mcp.json`，普通 Trae
+  只在 `mcp.json` 已存在时更新；WorkBuddy 按平台写配置，macOS 写
+  `~/.workbuddy/.mcp.json`，Windows 写 `%USERPROFILE%\.workbuddy\mcp.json`。
 - 初始化失败时保留现场，返回可重试状态，不自动删除用户文件。
 - 用户选择 app 后立即写入 `.maker-mcp/config.json`；clone/fetch 失败后重复执行
   `taptap-maker init` 会复用这个选择继续，后续缺失状态交给 `taptap-maker doctor` 判断。

--- a/docs/MAKER_CLI_MCP_SKILL_REWORK_OVERVIEW.md
+++ b/docs/MAKER_CLI_MCP_SKILL_REWORK_OVERVIEW.md
@@ -43,7 +43,7 @@ CLI 负责所有与本机环境、账号、项目绑定相关的低频动作：
 | `taptap-maker lua-lsp doctor` | 检查 maker-lua-lsp 是否可用于本地 Lua 诊断                                    |
 | `taptap-maker lua-lsp setup`  | 安装/升级 maker-lua-lsp 并执行 `install --ide codex,cursor,claude`            |
 | `taptap-maker install`        | `taptap-maker mcp install` 的快捷别名，写入 AI 客户端 MCP 配置                |
-| `taptap-maker mcp install`    | 写入 Codex / Cursor / Claude 的 MCP 配置                                      |
+| `taptap-maker mcp install`    | 写入默认客户端，并自动检测已存在配置文件的 Trae/OpenCode/WorkBuddy            |
 | `taptap-maker mcp verify`     | 验证 MCP 配置使用的 npx 包命令是否可启动；`--mode self` 验证当前 CLI          |
 | `taptap-maker agents update`  | 更新当前项目 `AGENTS.md` 中 TapTap Maker 管理的策略块                         |
 | `taptap-maker upgrade`        | 刷新当前机器 MCP 配置，并更新当前绑定项目的 `AGENTS.md` 受管策略块            |
@@ -67,7 +67,10 @@ CLI 负责所有与本机环境、账号、项目绑定相关的低频动作：
   可能无法稳定安装诊断依赖，自动准备时会走 uv managed Python。Lua LSP 依赖安装在 Maker
   私有 venv 中，不直接修改 uv-managed Python。
 - 本地分支测试可直接用 `node dist/maker.js`，不依赖 npm 发布。
-- Windows 下生成 MCP 配置时通过 `cmd.exe` 包装 `npx.cmd`，兼容无 shell 的 MCP 启动器。
+- Windows 下生成通用 `mcpServers` 配置时通过 `cmd.exe` 包装 `npx.cmd`，兼容无 shell 的 MCP 启动器。
+- OpenCode 使用官方 `mcp` schema 和 command 数组，不写环境变量，且只写已存在配置文件；
+  Trae 同时检测 Solo、非 Solo 和 CN 版 `User/` 目录，并创建或合并 `User/mcp.json`；
+  WorkBuddy 会写已存在的 `~/.workbuddy/.mcp.json` 或 `~/.workbuddy/mcp.json`。
 - 初始化失败时保留现场，返回可重试状态，不自动删除用户文件。
 - 用户选择 app 后立即写入 `.maker-mcp/config.json`；clone/fetch 失败后重复执行
   `taptap-maker init` 会复用这个选择继续，后续缺失状态交给 `taptap-maker doctor` 判断。
@@ -195,12 +198,14 @@ CLI 先完成初始化、PAT、app 选择、clone
 不支持 MCP Roots 的客户端仍可显式运行
 `taptap-maker mcp install --target-dir <PROJECT_DIR>` 固定 cwd，但这不是默认路径，
 避免 Codex、Trae、Cursor 等多个客户端共用用户级配置时互相覆盖项目目录。
+其它 AI 编辑器可复用 README 中的通用 `mcpServers` JSON 片段，由本地 AI 先识别该编辑器的
+实际配置文件位置后合并写入；CLI 不会额外生成通用配置文件。
 
 ## Windows 优先支持
 
 本轮重构按 Windows 优先做了这些约束：
 
-- MCP 配置 command 在 Windows 使用 `cmd.exe` 包装 `npx.cmd`，避免直接 spawn `.cmd`。
+- 通用 MCP 配置 command 在 Windows 使用 `cmd.exe` 包装 `npx.cmd`，避免直接 spawn `.cmd`。
 - Git 安装引导优先提示 Git for Windows。
 - 提醒用户安装时确保命令行和第三方工具可从 PATH 找到 Git。
 - 代码路径处理使用 Node `path` API，不手写 POSIX 分隔符。

--- a/src/__tests__/makerCliCommands.test.ts
+++ b/src/__tests__/makerCliCommands.test.ts
@@ -166,6 +166,10 @@ describe('Maker CLI commands', () => {
   const spawnSyncMock = jest.mocked(spawnSync);
   const cliLoginMock = jest.mocked(loginWithCliAuthCode);
   const expectedNpxLaunch = resolveNpxCliCommand('@taptap/maker');
+  const expectedOpenCodeCommand =
+    process.platform === 'win32'
+      ? ['npx.cmd', '-y', '-p', '@taptap/maker', 'taptap-maker']
+      : ['npx', '-y', '-p', '@taptap/maker', 'taptap-maker'];
 
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'maker-cli-commands-'));
@@ -379,6 +383,284 @@ describe('Maker CLI commands', () => {
     expect(
       fs.readdirSync(path.dirname(configPath)).filter((entry) => /^mcp\.json\.bak\.\d+/.test(entry))
     ).toEqual(['mcp.json.bak.20260101000000']);
+  });
+
+  test('default mcp install updates detected editor configs only', async () => {
+    const traePath =
+      process.platform === 'win32'
+        ? path.join(tempDir, 'AppData', 'Roaming', 'TRAE SOLO', 'User', 'mcp.json')
+        : path.join(tempDir, 'Library', 'Application Support', 'TRAE SOLO CN', 'User', 'mcp.json');
+    const openCodePath = path.join(tempDir, '.config', 'opencode', 'opencode.jsonc');
+    const workBuddyPath = path.join(tempDir, '.workbuddy', 'mcp.json');
+    fs.mkdirSync(path.dirname(traePath), { recursive: true });
+    fs.mkdirSync(path.dirname(openCodePath), { recursive: true });
+    fs.mkdirSync(path.dirname(workBuddyPath), { recursive: true });
+    fs.writeFileSync(traePath, '{ "mcpServers": {} }\n', 'utf8');
+    fs.writeFileSync(
+      openCodePath,
+      '{ "$schema": "https://opencode.ai/config.json", "mcp": {} }\n',
+      'utf8'
+    );
+    fs.writeFileSync(workBuddyPath, '{ "mcpServers": {} }\n', 'utf8');
+
+    await runMakerCli(['mcp', 'install', '--env', 'rnd', '--json']);
+
+    const payloads = JSON.parse(String(stdoutSpy.mock.calls[0][0]));
+    expect(payloads.map((entry: { ide: string }) => entry.ide)).toEqual(
+      expect.arrayContaining(['codex', 'cursor', 'claude', 'trae', 'opencode', 'workbuddy'])
+    );
+    expect(JSON.parse(fs.readFileSync(traePath, 'utf8')).mcpServers['taptap-maker']).toEqual({
+      command: expectedNpxLaunch.command,
+      args: expectedNpxLaunch.args,
+      env: { TAPTAP_MCP_ENV: 'rnd' },
+    });
+    expect(JSON.parse(fs.readFileSync(openCodePath, 'utf8')).mcp['taptap-maker']).toEqual({
+      type: 'local',
+      command: expectedOpenCodeCommand,
+      enabled: true,
+    });
+    expect(JSON.parse(fs.readFileSync(workBuddyPath, 'utf8')).mcpServers['taptap-maker']).toEqual({
+      command: expectedNpxLaunch.command,
+      args: expectedNpxLaunch.args,
+      env: { TAPTAP_MCP_ENV: 'rnd' },
+    });
+    expect(fs.existsSync(path.join(tempDir, 'maker-home', 'mcp.json'))).toBe(false);
+  });
+
+  test('trae mcp install updates both solo and non-solo configs when both exist', async () => {
+    const traePaths =
+      process.platform === 'win32'
+        ? [
+            path.join(tempDir, 'AppData', 'Roaming', 'TRAE SOLO', 'User', 'mcp.json'),
+            path.join(tempDir, 'AppData', 'Roaming', 'Trae', 'User', 'mcp.json'),
+          ]
+        : [
+            path.join(
+              tempDir,
+              'Library',
+              'Application Support',
+              'TRAE SOLO CN',
+              'User',
+              'mcp.json'
+            ),
+            path.join(tempDir, 'Library', 'Application Support', 'Trae', 'User', 'mcp.json'),
+          ];
+    for (const configPath of traePaths) {
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      fs.writeFileSync(configPath, '{ "mcpServers": {} }\n', 'utf8');
+    }
+
+    await runMakerCli(['mcp', 'install', '--ide', 'trae', '--env', 'rnd', '--json']);
+
+    const payloads = JSON.parse(String(stdoutSpy.mock.calls[0][0]));
+    expect(payloads.filter((entry: { ide: string }) => entry.ide === 'trae')).toHaveLength(2);
+    for (const configPath of traePaths) {
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+      expect(config.mcpServers['taptap-maker'].env.TAPTAP_MCP_ENV).toBe('rnd');
+    }
+  });
+
+  test('default mcp install creates Trae CN config when the user directory exists', async () => {
+    const traeCnConfigPath =
+      process.platform === 'win32'
+        ? path.join(tempDir, 'AppData', 'Roaming', 'Trae CN', 'User', 'mcp.json')
+        : path.join(tempDir, 'Library', 'Application Support', 'Trae CN', 'User', 'mcp.json');
+    fs.mkdirSync(path.dirname(traeCnConfigPath), { recursive: true });
+
+    await runMakerCli(['mcp', 'install', '--env', 'rnd', '--json']);
+
+    const payloads = JSON.parse(String(stdoutSpy.mock.calls[0][0]));
+    expect(payloads.map((entry: { ide: string }) => entry.ide)).toContain('trae');
+    expect(
+      JSON.parse(fs.readFileSync(traeCnConfigPath, 'utf8')).mcpServers['taptap-maker']
+    ).toEqual({
+      command: expectedNpxLaunch.command,
+      args: expectedNpxLaunch.args,
+      env: { TAPTAP_MCP_ENV: 'rnd' },
+    });
+  });
+
+  test('explicit trae mcp install creates config when the user directory exists', async () => {
+    const traeCnConfigPath =
+      process.platform === 'win32'
+        ? path.join(tempDir, 'AppData', 'Roaming', 'Trae CN', 'User', 'mcp.json')
+        : path.join(tempDir, 'Library', 'Application Support', 'Trae CN', 'User', 'mcp.json');
+    fs.mkdirSync(path.dirname(traeCnConfigPath), { recursive: true });
+
+    await runMakerCli(['mcp', 'install', '--ide', 'trae', '--env', 'rnd', '--json']);
+
+    const payloads = JSON.parse(String(stdoutSpy.mock.calls[0][0]));
+    expect(payloads).toEqual([
+      expect.objectContaining({
+        ide: 'trae',
+        ok: true,
+        path: traeCnConfigPath,
+      }),
+    ]);
+    expect(
+      JSON.parse(fs.readFileSync(traeCnConfigPath, 'utf8')).mcpServers['taptap-maker']
+    ).toEqual({
+      command: expectedNpxLaunch.command,
+      args: expectedNpxLaunch.args,
+      env: { TAPTAP_MCP_ENV: 'rnd' },
+    });
+  });
+
+  test('opencode mcp install uses the official mcp schema without environment fields', async () => {
+    const configPath = path.join(tempDir, '.config', 'opencode', 'opencode.jsonc');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      [
+        '{',
+        '  "$schema": "https://opencode.ai/config.json",',
+        '  // Existing user setting must survive JSONC parsing.',
+        '  "autoupdate": false,',
+        '  "mcpServers": {',
+        '    "taptap-maker": { "command": "old", "args": [] }',
+        '  },',
+        '  "mcp": {',
+        '    "other": { "type": "local", "command": ["node", "other.js"] },',
+        '  },',
+        '}',
+      ].join('\n'),
+      'utf8'
+    );
+
+    await runMakerCli(['mcp', 'install', '--ide', 'opencode', '--env', 'rnd']);
+
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(config.autoupdate).toBe(false);
+    expect(config.mcp.other).toEqual({ type: 'local', command: ['node', 'other.js'] });
+    expect(config.mcp['taptap-maker']).toEqual({
+      type: 'local',
+      command: expectedOpenCodeCommand,
+      enabled: true,
+    });
+    expect(config.mcp['taptap-maker']).not.toHaveProperty('env');
+    expect(config.mcp['taptap-maker']).not.toHaveProperty('environment');
+    expect(config.mcpServers?.['taptap-maker']).toBeUndefined();
+  });
+
+  test('opencode mcp install omits production environment by default', async () => {
+    const configPath = path.join(tempDir, '.config', 'opencode', 'opencode.jsonc');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, '{ "mcp": {} }\n', 'utf8');
+
+    await runMakerCli(['mcp', 'install', '--ide', 'opencode']);
+
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(config.mcp['taptap-maker']).toEqual({
+      type: 'local',
+      command: expectedOpenCodeCommand,
+      enabled: true,
+    });
+    expect(config.mcp['taptap-maker']).not.toHaveProperty('env');
+    expect(config.mcp['taptap-maker']).not.toHaveProperty('environment');
+  });
+
+  test('explicit opencode mcp install does not create a missing config file', async () => {
+    const configPath = path.join(tempDir, '.config', 'opencode', 'opencode.jsonc');
+
+    await runMakerCli(['mcp', 'install', '--ide', 'opencode', '--json']);
+
+    const payloads = JSON.parse(String(stdoutSpy.mock.calls[0][0]));
+    expect(payloads).toEqual([
+      expect.objectContaining({
+        ide: 'opencode',
+        ok: false,
+        message: expect.stringContaining('no supported config file found'),
+      }),
+    ]);
+    expect(fs.existsSync(configPath)).toBe(false);
+  });
+
+  test('explicit workbuddy mcp install writes existing dot mcp config', async () => {
+    const configPath = path.join(tempDir, '.workbuddy', '.mcp.json');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify(
+        { mcpServers: { 'connector-proxy': { type: 'http', url: 'http://127.0.0.1:1/mcp' } } },
+        null,
+        2
+      ),
+      'utf8'
+    );
+
+    await runMakerCli(['mcp', 'install', '--ide', 'workbuddy', '--env', 'rnd', '--json']);
+
+    const payloads = JSON.parse(String(stdoutSpy.mock.calls[0][0]));
+    expect(payloads).toEqual([
+      expect.objectContaining({
+        ide: 'workbuddy',
+        ok: true,
+        path: configPath,
+      }),
+    ]);
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(config.mcpServers['connector-proxy']).toEqual({
+      type: 'http',
+      url: 'http://127.0.0.1:1/mcp',
+    });
+    expect(config.mcpServers['taptap-maker']).toEqual({
+      command: expectedNpxLaunch.command,
+      args: expectedNpxLaunch.args,
+      env: { TAPTAP_MCP_ENV: 'rnd' },
+    });
+  });
+
+  test('workbuddy auto install writes existing dot mcp config', async () => {
+    const runtimeConfigPath = path.join(tempDir, '.workbuddy', '.mcp.json');
+    fs.mkdirSync(path.dirname(runtimeConfigPath), { recursive: true });
+    const runtimeConfig = `${JSON.stringify(
+      {
+        mcpServers: {
+          'connector-proxy': {
+            type: 'http',
+            url: 'http://127.0.0.1:60000/mcp',
+          },
+        },
+      },
+      null,
+      2
+    )}\n`;
+    fs.writeFileSync(runtimeConfigPath, runtimeConfig, 'utf8');
+
+    await runMakerCli(['mcp', 'install', '--env', 'rnd', '--json']);
+
+    const payloads = JSON.parse(String(stdoutSpy.mock.calls[0][0]));
+    expect(payloads.map((entry: { ide: string }) => entry.ide)).toContain('workbuddy');
+    const config = JSON.parse(fs.readFileSync(runtimeConfigPath, 'utf8'));
+    expect(config.mcpServers['connector-proxy']).toEqual({
+      type: 'http',
+      url: 'http://127.0.0.1:60000/mcp',
+    });
+    expect(config.mcpServers['taptap-maker']).toEqual({
+      command: expectedNpxLaunch.command,
+      args: expectedNpxLaunch.args,
+      env: { TAPTAP_MCP_ENV: 'rnd' },
+    });
+  });
+
+  test('json mcp install rejects invalid existing JSON without overwriting it', async () => {
+    const configPath = path.join(tempDir, '.cursor', 'mcp.json');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    const invalidJson = '{ "mcpServers": { "other": true, }\n';
+    fs.writeFileSync(configPath, invalidJson, 'utf8');
+
+    await runMakerCli(['mcp', 'install', '--ide', 'cursor', '--env', 'rnd', '--json']);
+
+    const payloads = JSON.parse(String(stdoutSpy.mock.calls[0][0]));
+    expect(payloads).toEqual([
+      expect.objectContaining({
+        ide: 'cursor',
+        ok: false,
+        message: expect.stringContaining('Invalid JSON'),
+      }),
+    ]);
+    expect(fs.readFileSync(configPath, 'utf8')).toBe(invalidJson);
+    expect(fs.existsSync(`${configPath}.taptap-maker.bak.latest`)).toBe(false);
   });
 
   test('claude mcp install invokes Claude CLI through a Windows spawn-compatible command', async () => {
@@ -773,10 +1055,8 @@ describe('Maker CLI commands', () => {
     expect(config.mcpServers['taptap-maker']).toEqual({
       command: expectedNpxLaunch.command,
       args: expectedNpxLaunch.args,
-      env: {
-        TAPTAP_MCP_ENV: 'production',
-      },
     });
+    expect(config.mcpServers['taptap-maker']).not.toHaveProperty('env');
     expect(config.mcpServers['taptap-maker']).not.toHaveProperty('cwd');
   });
 

--- a/src/__tests__/makerCliCommands.test.ts
+++ b/src/__tests__/makerCliCommands.test.ts
@@ -460,7 +460,7 @@ describe('Maker CLI commands', () => {
     }
   });
 
-  test('default mcp install creates Trae CN config when the user directory exists', async () => {
+  test('default mcp install does not create unverified non-solo Trae config from user directory only', async () => {
     const traeCnConfigPath =
       process.platform === 'win32'
         ? path.join(tempDir, 'AppData', 'Roaming', 'Trae CN', 'User', 'mcp.json')
@@ -470,21 +470,15 @@ describe('Maker CLI commands', () => {
     await runMakerCli(['mcp', 'install', '--env', 'rnd', '--json']);
 
     const payloads = JSON.parse(String(stdoutSpy.mock.calls[0][0]));
-    expect(payloads.map((entry: { ide: string }) => entry.ide)).toContain('trae');
-    expect(
-      JSON.parse(fs.readFileSync(traeCnConfigPath, 'utf8')).mcpServers['taptap-maker']
-    ).toEqual({
-      command: expectedNpxLaunch.command,
-      args: expectedNpxLaunch.args,
-      env: { TAPTAP_MCP_ENV: 'rnd' },
-    });
+    expect(payloads.map((entry: { ide: string }) => entry.ide)).not.toContain('trae');
+    expect(fs.existsSync(traeCnConfigPath)).toBe(false);
   });
 
-  test('explicit trae mcp install creates config when the user directory exists', async () => {
+  test('explicit trae mcp install creates solo config when the user directory exists', async () => {
     const traeCnConfigPath =
       process.platform === 'win32'
-        ? path.join(tempDir, 'AppData', 'Roaming', 'Trae CN', 'User', 'mcp.json')
-        : path.join(tempDir, 'Library', 'Application Support', 'Trae CN', 'User', 'mcp.json');
+        ? path.join(tempDir, 'AppData', 'Roaming', 'TRAE SOLO', 'User', 'mcp.json')
+        : path.join(tempDir, 'Library', 'Application Support', 'TRAE SOLO CN', 'User', 'mcp.json');
     fs.mkdirSync(path.dirname(traeCnConfigPath), { recursive: true });
 
     await runMakerCli(['mcp', 'install', '--ide', 'trae', '--env', 'rnd', '--json']);
@@ -500,6 +494,31 @@ describe('Maker CLI commands', () => {
     expect(
       JSON.parse(fs.readFileSync(traeCnConfigPath, 'utf8')).mcpServers['taptap-maker']
     ).toEqual({
+      command: expectedNpxLaunch.command,
+      args: expectedNpxLaunch.args,
+      env: { TAPTAP_MCP_ENV: 'rnd' },
+    });
+  });
+
+  test('explicit trae mcp install updates existing unverified non-solo config', async () => {
+    const traeConfigPath =
+      process.platform === 'win32'
+        ? path.join(tempDir, 'AppData', 'Roaming', 'Trae', 'User', 'mcp.json')
+        : path.join(tempDir, 'Library', 'Application Support', 'Trae CN', 'User', 'mcp.json');
+    fs.mkdirSync(path.dirname(traeConfigPath), { recursive: true });
+    fs.writeFileSync(traeConfigPath, '{ "mcpServers": {} }\n', 'utf8');
+
+    await runMakerCli(['mcp', 'install', '--ide', 'trae', '--env', 'rnd', '--json']);
+
+    const payloads = JSON.parse(String(stdoutSpy.mock.calls[0][0]));
+    expect(payloads).toEqual([
+      expect.objectContaining({
+        ide: 'trae',
+        ok: true,
+        path: traeConfigPath,
+      }),
+    ]);
+    expect(JSON.parse(fs.readFileSync(traeConfigPath, 'utf8')).mcpServers['taptap-maker']).toEqual({
       command: expectedNpxLaunch.command,
       args: expectedNpxLaunch.args,
       env: { TAPTAP_MCP_ENV: 'rnd' },
@@ -575,8 +594,11 @@ describe('Maker CLI commands', () => {
     expect(fs.existsSync(configPath)).toBe(false);
   });
 
-  test('explicit workbuddy mcp install writes existing dot mcp config', async () => {
-    const configPath = path.join(tempDir, '.workbuddy', '.mcp.json');
+  test('explicit workbuddy mcp install writes platform config file', async () => {
+    const configPath =
+      process.platform === 'win32'
+        ? path.join(tempDir, '.workbuddy', 'mcp.json')
+        : path.join(tempDir, '.workbuddy', '.mcp.json');
     fs.mkdirSync(path.dirname(configPath), { recursive: true });
     fs.writeFileSync(
       configPath,
@@ -610,9 +632,12 @@ describe('Maker CLI commands', () => {
     });
   });
 
-  test('workbuddy auto install writes existing dot mcp config', async () => {
-    const runtimeConfigPath = path.join(tempDir, '.workbuddy', '.mcp.json');
-    fs.mkdirSync(path.dirname(runtimeConfigPath), { recursive: true });
+  test('workbuddy auto install writes existing platform config file', async () => {
+    const workBuddyConfigPath =
+      process.platform === 'win32'
+        ? path.join(tempDir, '.workbuddy', 'mcp.json')
+        : path.join(tempDir, '.workbuddy', '.mcp.json');
+    fs.mkdirSync(path.dirname(workBuddyConfigPath), { recursive: true });
     const runtimeConfig = `${JSON.stringify(
       {
         mcpServers: {
@@ -625,13 +650,13 @@ describe('Maker CLI commands', () => {
       null,
       2
     )}\n`;
-    fs.writeFileSync(runtimeConfigPath, runtimeConfig, 'utf8');
+    fs.writeFileSync(workBuddyConfigPath, runtimeConfig, 'utf8');
 
     await runMakerCli(['mcp', 'install', '--env', 'rnd', '--json']);
 
     const payloads = JSON.parse(String(stdoutSpy.mock.calls[0][0]));
     expect(payloads.map((entry: { ide: string }) => entry.ide)).toContain('workbuddy');
-    const config = JSON.parse(fs.readFileSync(runtimeConfigPath, 'utf8'));
+    const config = JSON.parse(fs.readFileSync(workBuddyConfigPath, 'utf8'));
     expect(config.mcpServers['connector-proxy']).toEqual({
       type: 'http',
       url: 'http://127.0.0.1:60000/mcp',

--- a/src/__tests__/makerCliCommands.test.ts
+++ b/src/__tests__/makerCliCommands.test.ts
@@ -315,6 +315,24 @@ describe('Maker CLI commands', () => {
     }
   });
 
+  test('json mcp install accepts existing UTF-8 BOM config files', async () => {
+    const configPath = path.join(tempDir, '.cursor', 'mcp.json');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, '\uFEFF{ "mcpServers": { "other": { "command": "node" } } }\n');
+
+    await runMakerCli(['mcp', 'install', '--ide', 'cursor', '--env', 'rnd', '--json']);
+
+    const payloads = JSON.parse(String(stdoutSpy.mock.calls[0][0]));
+    expect(payloads[0]).toEqual(expect.objectContaining({ ide: 'cursor', ok: true }));
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(config.mcpServers.other).toEqual({ command: 'node' });
+    expect(config.mcpServers['taptap-maker']).toEqual({
+      command: expectedNpxLaunch.command,
+      args: expectedNpxLaunch.args,
+      env: { TAPTAP_MCP_ENV: 'rnd' },
+    });
+  });
+
   test('json mcp install pins cwd when target directory is provided', async () => {
     const configPath = path.join(tempDir, '.cursor', 'mcp.json');
     const projectDir = path.join(tempDir, 'maker-project');
@@ -615,6 +633,27 @@ describe('Maker CLI commands', () => {
 
     const payloads = JSON.parse(String(stdoutSpy.mock.calls[0][0]));
     expect(payloads[0].message).toContain('standard JSON');
+  });
+
+  test('opencode mcp install accepts existing UTF-8 BOM JSONC files', async () => {
+    const configPath = path.join(tempDir, '.config', 'opencode', 'opencode.jsonc');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      ['\uFEFF{', '  // user note', '  "mcp": {', '  },', '}'].join('\n'),
+      'utf8'
+    );
+
+    await runMakerCli(['mcp', 'install', '--ide', 'opencode', '--json']);
+
+    const payloads = JSON.parse(String(stdoutSpy.mock.calls[0][0]));
+    expect(payloads[0]).toEqual(expect.objectContaining({ ide: 'opencode', ok: true }));
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(config.mcp['taptap-maker']).toEqual({
+      type: 'local',
+      command: expectedOpenCodeCommand,
+      enabled: true,
+    });
   });
 
   test('opencode mcp install omits production environment by default', async () => {

--- a/src/__tests__/makerCliCommands.test.ts
+++ b/src/__tests__/makerCliCommands.test.ts
@@ -460,6 +460,47 @@ describe('Maker CLI commands', () => {
     }
   });
 
+  test('trae mcp install continues when one matched config is invalid', async () => {
+    const soloConfigPath =
+      process.platform === 'win32'
+        ? path.join(tempDir, 'AppData', 'Roaming', 'TRAE SOLO', 'User', 'mcp.json')
+        : path.join(tempDir, 'Library', 'Application Support', 'TRAE SOLO CN', 'User', 'mcp.json');
+    const invalidConfigPath =
+      process.platform === 'win32'
+        ? path.join(tempDir, 'AppData', 'Roaming', 'Trae', 'User', 'mcp.json')
+        : path.join(tempDir, 'Library', 'Application Support', 'Trae CN', 'User', 'mcp.json');
+    fs.mkdirSync(path.dirname(soloConfigPath), { recursive: true });
+    fs.mkdirSync(path.dirname(invalidConfigPath), { recursive: true });
+    fs.writeFileSync(invalidConfigPath, '{ "mcpServers": { "broken": true, }\n', 'utf8');
+
+    await runMakerCli(['mcp', 'install', '--ide', 'trae', '--env', 'rnd', '--json']);
+
+    const payloads = JSON.parse(String(stdoutSpy.mock.calls[0][0]));
+    expect(payloads).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ide: 'trae',
+          ok: true,
+          path: soloConfigPath,
+        }),
+        expect.objectContaining({
+          ide: 'trae',
+          ok: false,
+          path: invalidConfigPath,
+          message: expect.stringContaining('Invalid JSON'),
+        }),
+      ])
+    );
+    expect(JSON.parse(fs.readFileSync(soloConfigPath, 'utf8')).mcpServers['taptap-maker']).toEqual({
+      command: expectedNpxLaunch.command,
+      args: expectedNpxLaunch.args,
+      env: { TAPTAP_MCP_ENV: 'rnd' },
+    });
+    expect(fs.readFileSync(invalidConfigPath, 'utf8')).toBe(
+      '{ "mcpServers": { "broken": true, }\n'
+    );
+  });
+
   test('default mcp install does not create unverified non-solo Trae config from user directory only', async () => {
     const traeCnConfigPath =
       process.platform === 'win32'
@@ -559,6 +600,21 @@ describe('Maker CLI commands', () => {
     expect(config.mcp['taptap-maker']).not.toHaveProperty('env');
     expect(config.mcp['taptap-maker']).not.toHaveProperty('environment');
     expect(config.mcpServers?.['taptap-maker']).toBeUndefined();
+  });
+
+  test('opencode mcp install reports that JSONC is rewritten as standard JSON', async () => {
+    const configPath = path.join(tempDir, '.config', 'opencode', 'opencode.jsonc');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      ['{', '  // user note', '  "mcp": {', '  },', '}'].join('\n'),
+      'utf8'
+    );
+
+    await runMakerCli(['mcp', 'install', '--ide', 'opencode', '--json']);
+
+    const payloads = JSON.parse(String(stdoutSpy.mock.calls[0][0]));
+    expect(payloads[0].message).toContain('standard JSON');
   });
 
   test('opencode mcp install omits production environment by default', async () => {

--- a/src/__tests__/makerCliCommands.test.ts
+++ b/src/__tests__/makerCliCommands.test.ts
@@ -635,6 +635,18 @@ describe('Maker CLI commands', () => {
     expect(payloads[0].message).toContain('standard JSON');
   });
 
+  test('opencode mcp install does not report JSON rewrite for standard JSON files', async () => {
+    const configPath = path.join(tempDir, '.config', 'opencode', 'opencode.jsonc');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, '{ "mcp": {} }\n', 'utf8');
+
+    await runMakerCli(['mcp', 'install', '--ide', 'opencode', '--json']);
+
+    const payloads = JSON.parse(String(stdoutSpy.mock.calls[0][0]));
+    expect(payloads[0]).toEqual(expect.objectContaining({ ide: 'opencode', ok: true }));
+    expect(payloads[0].message).not.toContain('standard JSON');
+  });
+
   test('opencode mcp install accepts existing UTF-8 BOM JSONC files', async () => {
     const configPath = path.join(tempDir, '.config', 'opencode', 'opencode.jsonc');
     fs.mkdirSync(path.dirname(configPath), { recursive: true });

--- a/src/maker/cli/commands.ts
+++ b/src/maker/cli/commands.ts
@@ -133,6 +133,15 @@ type ConfigWriteResult = {
   backupPath?: string;
 };
 
+type McpInstallResult = {
+  ide: string;
+  ok: boolean;
+  message: string;
+  path?: string;
+  changed?: boolean;
+  backupPath?: string;
+};
+
 export async function runMakerCli(argv: string[]): Promise<void> {
   const parsed = parseArgs(argv);
   setMakerEnvironmentOverride(makerEnvOption(parsed));
@@ -355,9 +364,9 @@ async function runInit(parsed: ParsedArgs, ctx: CliContext): Promise<void> {
   });
 
   if (!skipMcpInstall) {
-    const ides = parseIdeList(stringOption(parsed, 'register_mcp') || 'codex,cursor,claude');
+    const ides = parseIdeList(stringOption(parsed, 'register_mcp') || '');
     const installResults = installMcpConfigs({
-      ides,
+      ides: ides.length > 0 ? ides : getDefaultMcpInstallIdes(),
       env,
       pkg: MAKER_NPM_PACKAGE,
       mcpName: DEFAULT_MCP_NAME,
@@ -921,7 +930,7 @@ async function runMcpInstall(parsed: ParsedArgs, ctx: CliContext): Promise<void>
   const ides = parseIdeList(stringOption(parsed, 'ide') || stringOption(parsed, 'ides') || '');
   const explicitTargetDir = stringOption(parsed, 'target_dir');
   const results = installMcpConfigs({
-    ides: ides.length > 0 ? ides : ['codex', 'cursor', 'claude'],
+    ides: ides.length > 0 ? ides : getDefaultMcpInstallIdes(),
     env: makerEnvOption(parsed),
     pkg: MAKER_NPM_PACKAGE,
     mcpName: stringOption(parsed, 'name') || DEFAULT_MCP_NAME,
@@ -1018,7 +1027,7 @@ async function runUpgrade(parsed: ParsedArgs, ctx: CliContext): Promise<void> {
   const env = makerEnvOption(parsed);
   const ides = parseIdeList(stringOption(parsed, 'ide') || stringOption(parsed, 'ides') || '');
   const installResults = installMcpConfigs({
-    ides: ides.length > 0 ? ides : ['codex', 'cursor', 'claude'],
+    ides: ides.length > 0 ? ides : getDefaultMcpInstallIdes(),
     env,
     pkg: MAKER_NPM_PACKAGE,
     mcpName: stringOption(parsed, 'name') || DEFAULT_MCP_NAME,
@@ -1545,98 +1554,194 @@ function installMcpConfigs(options: {
   pkg: string;
   mcpName: string;
   cwd?: string;
-}): Array<{
-  ide: string;
-  ok: boolean;
-  message: string;
-  path?: string;
-  changed?: boolean;
-  backupPath?: string;
-}> {
-  return options.ides.map((ide) => installMcpConfig(ide, options));
+}): McpInstallResult[] {
+  return uniqueStrings(options.ides).flatMap((ide) => installMcpConfig(ide, options));
 }
 
 function installMcpConfig(
   ide: string,
   options: { env: MakerEnvironment; pkg: string; mcpName: string; cwd?: string }
-): {
-  ide: string;
-  ok: boolean;
-  message: string;
-  path?: string;
-  changed?: boolean;
-  backupPath?: string;
-} {
+): McpInstallResult[] {
   try {
     return installMcpConfigUnsafe(ide, options);
   } catch (error) {
-    return {
-      ide,
-      ok: false,
-      message: `✗ ${ide} MCP config update failed: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    };
+    return [
+      {
+        ide,
+        ok: false,
+        message: `✗ ${ide} MCP config update failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      },
+    ];
   }
 }
 
 function installMcpConfigUnsafe(
   ide: string,
   options: { env: MakerEnvironment; pkg: string; mcpName: string; cwd?: string }
-): {
-  ide: string;
-  ok: boolean;
-  message: string;
-  path?: string;
-  changed?: boolean;
-  backupPath?: string;
-} {
+): McpInstallResult[] {
   if (ide === 'codex') {
     const configPath = path.join(os.homedir(), '.codex', 'config.toml');
     const write = mergeCodexMcpConfig(configPath, options);
-    return {
-      ide,
-      ok: true,
-      path: configPath,
-      changed: write.changed,
-      backupPath: write.backupPath,
-      message: formatMcpInstallMessage('Codex', configPath, write),
-    };
+    return [createMcpInstallResult(ide, 'Codex', configPath, write)];
   }
 
   if (ide === 'cursor') {
     const configPath = path.join(os.homedir(), '.cursor', 'mcp.json');
     const write = mergeJsonMcpConfig(configPath, options);
-    return {
-      ide,
-      ok: true,
-      path: configPath,
-      changed: write.changed,
-      backupPath: write.backupPath,
-      message: formatMcpInstallMessage('Cursor', configPath, write),
-    };
+    return [createMcpInstallResult(ide, 'Cursor', configPath, write)];
   }
 
   if (ide === 'claude') {
     if (!options.cwd) {
       const claudeResult = tryClaudeMcpAdd(options);
       if (claudeResult.ok) {
-        return { ide, ok: true, message: '✓ Claude Code MCP config updated with claude mcp add' };
+        return [
+          {
+            ide,
+            ok: true,
+            message: '✓ Claude Code MCP config updated with claude mcp add',
+          },
+        ];
       }
     }
     const configPath = path.join(os.homedir(), '.claude.json');
     const write = mergeJsonMcpConfig(configPath, options);
-    return {
-      ide,
-      ok: true,
-      path: configPath,
-      changed: write.changed,
-      backupPath: write.backupPath,
-      message: formatMcpInstallMessage('Claude fallback', configPath, write),
-    };
+    return [createMcpInstallResult(ide, 'Claude fallback', configPath, write)];
   }
 
-  return { ide, ok: false, message: `Skipped unknown IDE: ${ide}` };
+  if (ide === 'trae') {
+    return installJsonMcpConfigTargets(ide, getTraeMcpInstallPaths(true), 'Trae', options);
+  }
+
+  if (ide === 'opencode') {
+    const configPath = getOpenCodeMcpConfigPath();
+    if (!fs.existsSync(configPath)) {
+      return [{ ide, ok: false, message: 'Skipped OpenCode: no supported config file found' }];
+    }
+    const write = mergeOpenCodeMcpConfig(configPath, options);
+    return [createMcpInstallResult(ide, 'OpenCode', configPath, write)];
+  }
+
+  if (ide === 'workbuddy') {
+    return installJsonMcpConfigTargets(
+      ide,
+      getWorkBuddyMcpInstallPaths(options.mcpName),
+      'WorkBuddy',
+      options
+    );
+  }
+
+  return [{ ide, ok: false, message: `Skipped unknown IDE: ${ide}` }];
+}
+
+function installJsonMcpConfigTargets(
+  ide: string,
+  configPaths: string[],
+  label: string,
+  options: { env: MakerEnvironment; pkg: string; mcpName: string; cwd?: string }
+): McpInstallResult[] {
+  if (configPaths.length === 0) {
+    return [{ ide, ok: false, message: `Skipped ${label}: no supported config file found` }];
+  }
+
+  return configPaths.map((configPath) => {
+    const write = mergeJsonMcpConfig(configPath, options);
+    return createMcpInstallResult(ide, label, configPath, write);
+  });
+}
+
+function createMcpInstallResult(
+  ide: string,
+  label: string,
+  configPath: string,
+  write: ConfigWriteResult
+): McpInstallResult {
+  return {
+    ide,
+    ok: true,
+    path: configPath,
+    changed: write.changed,
+    backupPath: write.backupPath,
+    message: formatMcpInstallMessage(label, configPath, write),
+  };
+}
+
+function getDefaultMcpInstallIdes(): string[] {
+  const ides = ['codex', 'cursor', 'claude'];
+  if (getTraeMcpInstallPaths(false).length > 0) {
+    ides.push('trae');
+  }
+  if (fs.existsSync(getOpenCodeMcpConfigPath())) {
+    ides.push('opencode');
+  }
+  if (getWorkBuddyMcpInstallPaths(DEFAULT_MCP_NAME).length > 0) {
+    ides.push('workbuddy');
+  }
+  return ides;
+}
+
+function getTraeMcpInstallPaths(_createDefault: boolean): string[] {
+  return getExistingTraeUserConfigPaths(getTraeMcpConfigPaths());
+}
+
+function getExistingTraeUserConfigPaths(paths: string[]): string[] {
+  const seen = new Set<string>();
+  return paths.filter((configPath) => {
+    const key = normalizeConfigPathKey(configPath);
+    if (seen.has(key) || !fs.existsSync(path.dirname(configPath))) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+function normalizeConfigPathKey(configPath: string): string {
+  const resolved = path.resolve(configPath);
+  return process.platform === 'win32' || process.platform === 'darwin'
+    ? resolved.toLowerCase()
+    : resolved;
+}
+
+function getTraeMcpConfigPaths(): string[] {
+  if (process.platform === 'win32') {
+    const roaming = process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming');
+    return [
+      path.join(roaming, 'TRAE SOLO', 'User', 'mcp.json'),
+      path.join(roaming, 'TRAE SOLO CN', 'User', 'mcp.json'),
+      path.join(roaming, 'Trae', 'User', 'mcp.json'),
+      path.join(roaming, 'TRAE', 'User', 'mcp.json'),
+      path.join(roaming, 'Trae CN', 'User', 'mcp.json'),
+    ];
+  }
+
+  const appSupport = path.join(os.homedir(), 'Library', 'Application Support');
+  return [
+    path.join(appSupport, 'TRAE SOLO CN', 'User', 'mcp.json'),
+    path.join(appSupport, 'TRAE SOLO', 'User', 'mcp.json'),
+    path.join(appSupport, 'Trae', 'User', 'mcp.json'),
+    path.join(appSupport, 'TRAE', 'User', 'mcp.json'),
+    path.join(appSupport, 'Trae CN', 'User', 'mcp.json'),
+  ];
+}
+
+function getOpenCodeMcpConfigPath(): string {
+  return path.join(os.homedir(), '.config', 'opencode', 'opencode.jsonc');
+}
+
+function getWorkBuddyMcpInstallPaths(_mcpName: string): string[] {
+  const primary = path.join(os.homedir(), '.workbuddy', 'mcp.json');
+  const runtime = path.join(os.homedir(), '.workbuddy', '.mcp.json');
+  const paths: string[] = [];
+  if (fs.existsSync(primary)) {
+    paths.push(primary);
+  }
+  if (fs.existsSync(runtime)) {
+    paths.push(runtime);
+  }
+  return paths;
 }
 
 function mergeJsonMcpConfig(
@@ -1647,7 +1752,41 @@ function mergeJsonMcpConfig(
   const mcpServers = asObject(existing.mcpServers);
   mcpServers[options.mcpName] = createJsonMcpServerConfig(options);
   existing.mcpServers = mcpServers;
-  return writeConfigWithTapTapBackupIfChanged(configPath, `${JSON.stringify(existing, null, 2)}\n`);
+  return writeConfigWithTapTapBackupIfChanged(
+    configPath,
+    `${JSON.stringify(existing, null, 2)}\n`,
+    (updated) => validateJsonMcpServersConfig(updated, options)
+  );
+}
+
+function mergeOpenCodeMcpConfig(
+  configPath: string,
+  options: { env: MakerEnvironment; pkg: string; mcpName: string; cwd?: string }
+): ConfigWriteResult {
+  const existing = readJsonObject(configPath, { jsonc: true });
+  const mcp = asObject(existing.mcp);
+  mcp[options.mcpName] = createOpenCodeMcpServerConfig(options);
+  existing.mcp = mcp;
+
+  const mcpServers = asObject(existing.mcpServers);
+  if (Object.prototype.hasOwnProperty.call(mcpServers, options.mcpName)) {
+    delete mcpServers[options.mcpName];
+    if (Object.keys(mcpServers).length === 0) {
+      delete existing.mcpServers;
+    } else {
+      existing.mcpServers = mcpServers;
+    }
+  }
+
+  if (!existing.$schema) {
+    existing.$schema = 'https://opencode.ai/config.json';
+  }
+
+  return writeConfigWithTapTapBackupIfChanged(
+    configPath,
+    `${JSON.stringify(existing, null, 2)}\n`,
+    (updated) => validateOpenCodeMcpConfig(updated, options)
+  );
 }
 
 function mergeCodexMcpConfig(
@@ -1658,14 +1797,16 @@ function mergeCodexMcpConfig(
   const sectionPattern = createCodexMcpSectionPattern(options.mcpName);
   const withoutOld = existing.replace(sectionPattern, '').trimEnd();
   const launch = getNpxCliCommand(options.pkg);
+  const envSection =
+    options.env === 'production'
+      ? []
+      : ['', `[mcp_servers."${options.mcpName}".env]`, `TAPTAP_MCP_ENV = "${options.env}"`];
   const section = [
     `[mcp_servers."${options.mcpName}"]`,
     `command = "${escapeToml(launch.command)}"`,
     `args = [${launch.args.map((arg) => `"${escapeToml(arg)}"`).join(', ')}]`,
     options.cwd ? `cwd = "${escapeToml(options.cwd)}"` : '',
-    '',
-    `[mcp_servers."${options.mcpName}".env]`,
-    `TAPTAP_MCP_ENV = "${options.env}"`,
+    ...envSection,
     '',
   ].join('\n');
   return writeConfigWithTapTapBackupIfChanged(
@@ -1739,8 +1880,7 @@ function tryClaudeMcpAdd(options: { env: MakerEnvironment; pkg: string; mcpName:
     'user',
     '--transport',
     'stdio',
-    '--env',
-    `TAPTAP_MCP_ENV=${options.env}`,
+    ...(options.env === 'production' ? [] : ['--env', `TAPTAP_MCP_ENV=${options.env}`]),
     options.mcpName,
     '--',
     ...npxLaunch.commandAndArgs,
@@ -1758,17 +1898,48 @@ function createJsonMcpServerConfig(options: { env: MakerEnvironment; pkg: string
   command: string;
   args: string[];
   cwd?: string;
-  env: Record<string, string>;
+  env?: Record<string, string>;
 } {
   const launch = getNpxCliCommand(options.pkg);
   return {
     command: launch.command,
     args: launch.args,
     ...(options.cwd ? { cwd: options.cwd } : {}),
-    env: {
-      TAPTAP_MCP_ENV: options.env,
-    },
+    ...createOptionalMcpEnvironment(options.env, 'env'),
   };
+}
+
+function createOpenCodeMcpServerConfig(options: { pkg: string; cwd?: string }): {
+  type: 'local';
+  command: string[];
+  cwd?: string;
+  enabled: true;
+} {
+  return {
+    type: 'local',
+    command: getOpenCodeNpxCliCommand(options.pkg),
+    ...(options.cwd ? { cwd: options.cwd } : {}),
+    enabled: true,
+  };
+}
+
+function createOptionalMcpEnvironment<Key extends 'env' | 'environment'>(
+  env: MakerEnvironment,
+  key: Key
+): Record<Key, Record<string, string>> | Record<string, never> {
+  if (env === 'production') {
+    return {};
+  }
+  return {
+    [key]: {
+      TAPTAP_MCP_ENV: env,
+    },
+  } as Record<Key, Record<string, string>>;
+}
+
+function getOpenCodeNpxCliCommand(pkg: string): string[] {
+  const executable = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+  return [executable, '-y', '-p', pkg, 'taptap-maker'];
 }
 
 function getCurrentCliCommand(): { command: string; args: string[] } {
@@ -1822,11 +1993,25 @@ function rejectPackageOption(parsed: ParsedArgs): void {
   }
 }
 
-function readJsonObject(filePath: string): Record<string, unknown> {
+function readJsonObject(
+  filePath: string,
+  options: { jsonc?: boolean } = {}
+): Record<string, unknown> {
   if (!fs.existsSync(filePath)) {
     return {};
   }
-  return JSON.parse(fs.readFileSync(filePath, 'utf8')) as Record<string, unknown>;
+  const raw = fs.readFileSync(filePath, 'utf8');
+  try {
+    const normalized = options.jsonc ? normalizeJsonc(raw) : raw;
+    const parsed = JSON.parse(normalized);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('top-level value must be an object');
+    }
+    return parsed as Record<string, unknown>;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid JSON in ${filePath}: ${detail}`);
+  }
 }
 
 function asObject(value: unknown): Record<string, unknown> {
@@ -1865,6 +2050,158 @@ function writeConfigWithTapTapBackupIfChanged(
     }
     throw error;
   }
+}
+
+function validateJsonMcpServersConfig(
+  content: string,
+  options: { env: MakerEnvironment; pkg: string; mcpName: string; cwd?: string }
+): void {
+  const parsed = parseGeneratedJsonObject(content);
+  const server = asObject(asObject(parsed.mcpServers)[options.mcpName]);
+  const expected = createJsonMcpServerConfig(options);
+  if (!deepJsonEqual(server, expected)) {
+    throw new Error(`Generated MCP config for ${options.mcpName} failed validation.`);
+  }
+}
+
+function validateOpenCodeMcpConfig(
+  content: string,
+  options: { env: MakerEnvironment; pkg: string; mcpName: string; cwd?: string }
+): void {
+  const parsed = parseGeneratedJsonObject(content);
+  const server = asObject(asObject(parsed.mcp)[options.mcpName]);
+  const expected = createOpenCodeMcpServerConfig(options);
+  if (!deepJsonEqual(server, expected)) {
+    throw new Error(`Generated OpenCode MCP config for ${options.mcpName} failed validation.`);
+  }
+  const legacyServer = asObject(parsed.mcpServers)[options.mcpName];
+  if (legacyServer !== undefined) {
+    throw new Error(
+      `Generated OpenCode config still contains legacy mcpServers.${options.mcpName}.`
+    );
+  }
+}
+
+function parseGeneratedJsonObject(content: string): Record<string, unknown> {
+  const parsed = JSON.parse(content);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('Generated JSON config top-level value must be an object.');
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function deepJsonEqual(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function normalizeJsonc(content: string): string {
+  return removeTrailingCommas(stripJsonComments(content));
+}
+
+function stripJsonComments(content: string): string {
+  let result = '';
+  let inString = false;
+  let escaped = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+
+  for (let index = 0; index < content.length; index += 1) {
+    const char = content[index];
+    const next = content[index + 1];
+
+    if (inLineComment) {
+      if (char === '\n' || char === '\r') {
+        inLineComment = false;
+        result += char;
+      }
+      continue;
+    }
+
+    if (inBlockComment) {
+      if (char === '*' && next === '/') {
+        inBlockComment = false;
+        index += 1;
+      } else if (char === '\n' || char === '\r') {
+        result += char;
+      }
+      continue;
+    }
+
+    if (inString) {
+      result += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      result += char;
+      continue;
+    }
+
+    if (char === '/' && next === '/') {
+      inLineComment = true;
+      index += 1;
+      continue;
+    }
+
+    if (char === '/' && next === '*') {
+      inBlockComment = true;
+      index += 1;
+      continue;
+    }
+
+    result += char;
+  }
+
+  return result;
+}
+
+function removeTrailingCommas(content: string): string {
+  let result = '';
+  let inString = false;
+  let escaped = false;
+
+  for (let index = 0; index < content.length; index += 1) {
+    const char = content[index];
+    if (inString) {
+      result += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      result += char;
+      continue;
+    }
+
+    if (char === ',') {
+      let lookahead = index + 1;
+      while (/\s/.test(content[lookahead] || '')) {
+        lookahead += 1;
+      }
+      if (content[lookahead] === '}' || content[lookahead] === ']') {
+        continue;
+      }
+    }
+
+    result += char;
+  }
+
+  return result;
 }
 
 function formatMcpInstallMessage(
@@ -2116,6 +2453,10 @@ function parseIdeList(value: string): string[] {
     .filter(Boolean);
 }
 
+function uniqueStrings(values: string[]): string[] {
+  return Array.from(new Set(values));
+}
+
 function mask(value: string): string {
   if (value.length <= 12) {
     return '***';
@@ -2155,7 +2496,8 @@ function printHelp(): void {
       '  taptap-maker                         Start MCP server mode',
       '  taptap-maker init [--env rnd|production] [--app-id ID] [--target-dir DIR] [--pat PAT]',
       '                     [--create --name NAME]',
-      '                     [--skip-confirm] [--skip-mcp-install] [--register-mcp codex,cursor,claude]',
+      '                     [--skip-confirm] [--skip-mcp-install]',
+      '                     [--register-mcp codex,cursor,claude,trae,opencode,workbuddy]',
       '                     [--json]',
       '',
       'Init flows:',
@@ -2175,10 +2517,12 @@ function printHelp(): void {
       '  taptap-maker login [--env rnd|production] [--json]',
       '  taptap-maker pat set [--pat-stdin] [--json]',
       '  taptap-maker pat set [PAT|--pat PAT] [--json]  # fallback; warns: PAT appears in ps/history',
-      '  taptap-maker install [--ide codex,cursor,claude] [--env rnd|production]',
+      '  taptap-maker install [--ide codex,cursor,claude,trae,opencode,workbuddy]',
+      '                        [--env rnd|production]',
       '                        [--target-dir DIR]',
       '                        [--json]  # alias for mcp install',
-      '  taptap-maker mcp install [--ide codex,cursor,claude] [--env rnd|production]',
+      '  taptap-maker mcp install [--ide codex,cursor,claude,trae,opencode,workbuddy]',
+      '                             [--env rnd|production]',
       '                             [--target-dir DIR] [--json]',
       '  taptap-maker mcp verify [--mode npx|self] [--json]',
       '  taptap-maker agents update [--target-dir DIR] [--json]',
@@ -2190,8 +2534,13 @@ function printHelp(): void {
       'MCP verify defaults to the npx command written into AI client config.',
       'Maker MCP configs and npx verification use @taptap/maker.',
       '',
+      'MCP install defaults:',
+      '  Writes Codex, Cursor, Claude, detected Trae/OpenCode/WorkBuddy configs,',
+      '  unless --ide is specified. It does not create missing Trae config files.',
+      '',
       'Windows note:',
-      '  Generated MCP configs wrap npx.cmd with cmd.exe on Windows for spawn compatibility.',
+      '  mcpServers configs wrap npx.cmd with cmd.exe on Windows for spawn compatibility.',
+      '  OpenCode uses its own mcp schema and writes a command array with npx.cmd.',
       '',
     ].join('\n')
   );

--- a/src/maker/cli/commands.ts
+++ b/src/maker/cli/commands.ts
@@ -1683,7 +1683,9 @@ function getDefaultMcpInstallIdes(): string[] {
 }
 
 function getTraeMcpInstallPaths(_createDefault: boolean): string[] {
-  return getExistingTraeUserConfigPaths(getTraeMcpConfigPaths());
+  const soloPaths = getExistingTraeUserConfigPaths(getTraeSoloMcpConfigPaths());
+  const unverifiedPaths = getExistingConfigPaths(getTraeUnverifiedMcpConfigPaths());
+  return uniqueStrings([...soloPaths, ...unverifiedPaths]);
 }
 
 function getExistingTraeUserConfigPaths(paths: string[]): string[] {
@@ -1698,6 +1700,18 @@ function getExistingTraeUserConfigPaths(paths: string[]): string[] {
   });
 }
 
+function getExistingConfigPaths(paths: string[]): string[] {
+  const seen = new Set<string>();
+  return paths.filter((configPath) => {
+    const key = normalizeConfigPathKey(configPath);
+    if (seen.has(key) || !fs.existsSync(configPath)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
 function normalizeConfigPathKey(configPath: string): string {
   const resolved = path.resolve(configPath);
   return process.platform === 'win32' || process.platform === 'darwin'
@@ -1705,12 +1719,26 @@ function normalizeConfigPathKey(configPath: string): string {
     : resolved;
 }
 
-function getTraeMcpConfigPaths(): string[] {
+function getTraeSoloMcpConfigPaths(): string[] {
   if (process.platform === 'win32') {
     const roaming = process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming');
     return [
       path.join(roaming, 'TRAE SOLO', 'User', 'mcp.json'),
       path.join(roaming, 'TRAE SOLO CN', 'User', 'mcp.json'),
+    ];
+  }
+
+  const appSupport = path.join(os.homedir(), 'Library', 'Application Support');
+  return [
+    path.join(appSupport, 'TRAE SOLO CN', 'User', 'mcp.json'),
+    path.join(appSupport, 'TRAE SOLO', 'User', 'mcp.json'),
+  ];
+}
+
+function getTraeUnverifiedMcpConfigPaths(): string[] {
+  if (process.platform === 'win32') {
+    const roaming = process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming');
+    return [
       path.join(roaming, 'Trae', 'User', 'mcp.json'),
       path.join(roaming, 'TRAE', 'User', 'mcp.json'),
       path.join(roaming, 'Trae CN', 'User', 'mcp.json'),
@@ -1719,8 +1747,6 @@ function getTraeMcpConfigPaths(): string[] {
 
   const appSupport = path.join(os.homedir(), 'Library', 'Application Support');
   return [
-    path.join(appSupport, 'TRAE SOLO CN', 'User', 'mcp.json'),
-    path.join(appSupport, 'TRAE SOLO', 'User', 'mcp.json'),
     path.join(appSupport, 'Trae', 'User', 'mcp.json'),
     path.join(appSupport, 'TRAE', 'User', 'mcp.json'),
     path.join(appSupport, 'Trae CN', 'User', 'mcp.json'),
@@ -1734,12 +1760,14 @@ function getOpenCodeMcpConfigPath(): string {
 function getWorkBuddyMcpInstallPaths(_mcpName: string): string[] {
   const primary = path.join(os.homedir(), '.workbuddy', 'mcp.json');
   const runtime = path.join(os.homedir(), '.workbuddy', '.mcp.json');
+  const preferred = process.platform === 'win32' ? primary : runtime;
+  const fallback = process.platform === 'win32' ? runtime : primary;
   const paths: string[] = [];
-  if (fs.existsSync(primary)) {
-    paths.push(primary);
+  if (fs.existsSync(preferred)) {
+    paths.push(preferred);
   }
-  if (fs.existsSync(runtime)) {
-    paths.push(runtime);
+  if (fs.existsSync(fallback)) {
+    paths.push(fallback);
   }
   return paths;
 }

--- a/src/maker/cli/commands.ts
+++ b/src/maker/cli/commands.ts
@@ -1612,7 +1612,7 @@ function installMcpConfigUnsafe(
   }
 
   if (ide === 'trae') {
-    return installJsonMcpConfigTargets(ide, getTraeMcpInstallPaths(true), 'Trae', options);
+    return installJsonMcpConfigTargets(ide, getTraeMcpInstallPaths(), 'Trae', options);
   }
 
   if (ide === 'opencode') {
@@ -1621,7 +1621,11 @@ function installMcpConfigUnsafe(
       return [{ ide, ok: false, message: 'Skipped OpenCode: no supported config file found' }];
     }
     const write = mergeOpenCodeMcpConfig(configPath, options);
-    return [createMcpInstallResult(ide, 'OpenCode', configPath, write)];
+    const result = createMcpInstallResult(ide, 'OpenCode', configPath, write);
+    if (write.changed) {
+      result.message += '\n  Note: OpenCode config was rewritten as standard JSON.';
+    }
+    return [result];
   }
 
   if (ide === 'workbuddy') {
@@ -1647,8 +1651,19 @@ function installJsonMcpConfigTargets(
   }
 
   return configPaths.map((configPath) => {
-    const write = mergeJsonMcpConfig(configPath, options);
-    return createMcpInstallResult(ide, label, configPath, write);
+    try {
+      const write = mergeJsonMcpConfig(configPath, options);
+      return createMcpInstallResult(ide, label, configPath, write);
+    } catch (error) {
+      return {
+        ide,
+        ok: false,
+        path: configPath,
+        message: `✗ ${label} MCP config update failed for ${configPath}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      };
+    }
   });
 }
 
@@ -1670,7 +1685,7 @@ function createMcpInstallResult(
 
 function getDefaultMcpInstallIdes(): string[] {
   const ides = ['codex', 'cursor', 'claude'];
-  if (getTraeMcpInstallPaths(false).length > 0) {
+  if (getTraeMcpInstallPaths().length > 0) {
     ides.push('trae');
   }
   if (fs.existsSync(getOpenCodeMcpConfigPath())) {
@@ -1682,7 +1697,7 @@ function getDefaultMcpInstallIdes(): string[] {
   return ides;
 }
 
-function getTraeMcpInstallPaths(_createDefault: boolean): string[] {
+function getTraeMcpInstallPaths(): string[] {
   const soloPaths = getExistingTraeUserConfigPaths(getTraeSoloMcpConfigPaths());
   const unverifiedPaths = getExistingConfigPaths(getTraeUnverifiedMcpConfigPaths());
   return uniqueStrings([...soloPaths, ...unverifiedPaths]);

--- a/src/maker/cli/commands.ts
+++ b/src/maker/cli/commands.ts
@@ -2045,7 +2045,7 @@ function readJsonObject(
   }
   const raw = fs.readFileSync(filePath, 'utf8');
   try {
-    const normalized = options.jsonc ? normalizeJsonc(raw) : raw;
+    const normalized = normalizeJsonConfigContent(raw, options);
     const parsed = JSON.parse(normalized);
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
       throw new Error('top-level value must be an object');
@@ -2126,7 +2126,7 @@ function validateOpenCodeMcpConfig(
 }
 
 function parseGeneratedJsonObject(content: string): Record<string, unknown> {
-  const parsed = JSON.parse(content);
+  const parsed = JSON.parse(stripLeadingBom(content));
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
     throw new Error('Generated JSON config top-level value must be an object.');
   }
@@ -2135,6 +2135,15 @@ function parseGeneratedJsonObject(content: string): Record<string, unknown> {
 
 function deepJsonEqual(left: unknown, right: unknown): boolean {
   return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function normalizeJsonConfigContent(content: string, options: { jsonc?: boolean } = {}): string {
+  const withoutBom = stripLeadingBom(content);
+  return options.jsonc ? normalizeJsonc(withoutBom) : withoutBom;
+}
+
+function stripLeadingBom(content: string): string {
+  return content.charCodeAt(0) === 0xfeff ? content.slice(1) : content;
 }
 
 function normalizeJsonc(content: string): string {

--- a/src/maker/cli/commands.ts
+++ b/src/maker/cli/commands.ts
@@ -131,6 +131,7 @@ type MakerMcpToolsAvailability = {
 type ConfigWriteResult = {
   changed: boolean;
   backupPath?: string;
+  rewroteJsonc?: boolean;
 };
 
 type McpInstallResult = {
@@ -1622,19 +1623,14 @@ function installMcpConfigUnsafe(
     }
     const write = mergeOpenCodeMcpConfig(configPath, options);
     const result = createMcpInstallResult(ide, 'OpenCode', configPath, write);
-    if (write.changed) {
+    if (write.rewroteJsonc) {
       result.message += '\n  Note: OpenCode config was rewritten as standard JSON.';
     }
     return [result];
   }
 
   if (ide === 'workbuddy') {
-    return installJsonMcpConfigTargets(
-      ide,
-      getWorkBuddyMcpInstallPaths(options.mcpName),
-      'WorkBuddy',
-      options
-    );
+    return installJsonMcpConfigTargets(ide, getWorkBuddyMcpInstallPaths(), 'WorkBuddy', options);
   }
 
   return [{ ide, ok: false, message: `Skipped unknown IDE: ${ide}` }];
@@ -1691,7 +1687,7 @@ function getDefaultMcpInstallIdes(): string[] {
   if (fs.existsSync(getOpenCodeMcpConfigPath())) {
     ides.push('opencode');
   }
-  if (getWorkBuddyMcpInstallPaths(DEFAULT_MCP_NAME).length > 0) {
+  if (getWorkBuddyMcpInstallPaths().length > 0) {
     ides.push('workbuddy');
   }
   return ides;
@@ -1772,7 +1768,7 @@ function getOpenCodeMcpConfigPath(): string {
   return path.join(os.homedir(), '.config', 'opencode', 'opencode.jsonc');
 }
 
-function getWorkBuddyMcpInstallPaths(_mcpName: string): string[] {
+function getWorkBuddyMcpInstallPaths(): string[] {
   const primary = path.join(os.homedir(), '.workbuddy', 'mcp.json');
   const runtime = path.join(os.homedir(), '.workbuddy', '.mcp.json');
   const preferred = process.platform === 'win32' ? primary : runtime;
@@ -1806,6 +1802,8 @@ function mergeOpenCodeMcpConfig(
   configPath: string,
   options: { env: MakerEnvironment; pkg: string; mcpName: string; cwd?: string }
 ): ConfigWriteResult {
+  const rawContent = fs.readFileSync(configPath, 'utf8');
+  const rewroteJsonc = normalizeJsonConfigContent(rawContent, { jsonc: true }) !== rawContent;
   const existing = readJsonObject(configPath, { jsonc: true });
   const mcp = asObject(existing.mcp);
   mcp[options.mcpName] = createOpenCodeMcpServerConfig(options);
@@ -1825,11 +1823,12 @@ function mergeOpenCodeMcpConfig(
     existing.$schema = 'https://opencode.ai/config.json';
   }
 
-  return writeConfigWithTapTapBackupIfChanged(
+  const write = writeConfigWithTapTapBackupIfChanged(
     configPath,
     `${JSON.stringify(existing, null, 2)}\n`,
     (updated) => validateOpenCodeMcpConfig(updated, options)
   );
+  return { ...write, rewroteJsonc: write.changed && rewroteJsonc };
 }
 
 function mergeCodexMcpConfig(


### PR DESCRIPTION
## 需求

- Maker MCP 默认安装从仅支持 Claude / Codex / Cursor，扩展到 Trae、WorkBuddy、OpenCode。
- 新增编辑器只在本机检测到对应配置或 Trae Solo User 目录时安装，避免无端创建无效配置。
- 写入 MCP 配置时要避免重复安装、破坏 JSON/JSONC 结构，写后需要做配置校验。

## 改动内容

- Trae：支持 Solo / Solo CN 优先安装，兼容 Trae / Trae CN 候选路径；Solo 在 User 目录存在时创建或合并 mcp.json，普通 Trae 只更新已存在的 mcp.json。
- WorkBuddy：按平台适配配置路径，Windows 写 ~/.workbuddy/mcp.json，macOS 优先写 ~/.workbuddy/.mcp.json。
- OpenCode：使用官方顶层 mcp schema，command 数组不写 env，并提示 JSONC 会被重写为标准 JSON。
- 通用 JSON MCP 配置：仅作为 README / 文档片段提供给其它编辑器识别后自行合并，不在 CLI 中额外生成通用配置文件。
- 配置安全：新增写入前备份、重复安装覆盖、JSON/JSONC 校验、写后校验和 per-path 容错。
- 兼容修复：支持已有 MCP JSON/JSONC 配置文件带 UTF-8 BOM，避免 Unexpected token BOM。

## Beta 验证

- 已从 beta 分支发布 @taptap/maker@0.0.21-beta.3 验证新增编辑器安装能力。
- 发现 BOM 兼容问题后，已修复并重新发布 @taptap/maker@0.0.21-beta.4。
- GitHub Actions 发布链路 lint / test / build / pack / publish 均通过。

## 本地验证

- npm test -- --runInBand src/__tests__/makerCliCommands.test.ts
- npm run lint
- npm run build
- npm run format:check
