### PR TITLE
fix(ci): publish maker package with oidc only

### DIFF
--- a/.github/workflows/publish-maker.yml
+++ b/.github/workflows/publish-maker.yml
@@ -85,6 +85,11 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
+      - name: Upgrade npm for trusted publishing
+        run: |
+          npm install -g npm@latest
+          npm --version
+
       - name: Install dependencies
         run: npm ci
 
@@ -131,13 +136,11 @@ jobs:
         run: |
           set -euo pipefail
           tarball="./packages/maker/taptap-maker-${MAKER_PACKAGE_VERSION}.tgz"
-          npm publish "$tarball" --access public --tag "$NPM_TAG" --provenance \
-            || npm publish "$tarball" --access public --tag "$NPM_TAG"
+          npm publish "$tarball" --access public --tag "$NPM_TAG" --provenance
           echo "Published @taptap/maker@$MAKER_PACKAGE_VERSION"
         env:
           MAKER_PACKAGE_VERSION: ${{ needs.resolve-version.outputs.version }}
           NPM_TAG: ${{ inputs.tag }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Update Maker version policy
         id: version-policy

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -341,9 +341,11 @@ npx commitlint --from HEAD~1 --to HEAD
 
 **认证方式**：
 
-- 优先使用 npm Trusted Publishing / GitHub OIDC。
+- 只使用 npm Trusted Publishing / GitHub OIDC。
 - workflow 必须保留 `permissions.id-token: write`。
-- `npm publish --provenance` 失败时 fallback 到不带 provenance 的 `npm publish`。
+- publish job 会先升级 npm CLI，确保满足 Trusted Publishing 版本要求。
+- workflow 不再读取 `NPM_TOKEN`，也不再降级到不带 provenance 的 `npm publish`。
+- 如果 OIDC Trusted Publishing 配置失效，发布 job 必须直接失败并停止。
 
 **执行步骤**：
 
@@ -373,7 +375,7 @@ npx commitlint --from HEAD~1 --to HEAD
 - 手动发布如果修改三段版本号里的前两段，CI 会先在 Actions Summary 显示当前
   线上 dist-tag 版本和目标版本，再由人工点击 protected environment 审批按钮继续。
 - 发布 job 在实际 `npm publish` 前会再次检查目标版本是否仍未发布。
-- 如果带 provenance 和不带 provenance 的发布都失败，workflow 必须失败并停止。
+- 如果 `npm publish --provenance` 失败，workflow 必须失败并停止，不能降级发布。
 
 ### 5.5 主包与 Maker 包发布隔离
 


### PR DESCRIPTION
## 改动内容
- Maker package 发布步骤只执行 `npm publish --provenance`。
- 移除 `publish-maker.yml` 中过期的 `NPM_TOKEN` / `NODE_AUTH_TOKEN` 依赖。
- 更新 CI/CD 文档，明确 Maker 发布只使用 npm Trusted Publishing / GitHub OIDC。

## 影响面
- `@taptap/maker` 手动发布 workflow。
- OIDC Trusted Publishing 配置异常时 workflow 会直接失败，不再降级发布。

## 验证
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish-maker.yml"); puts "publish-maker.yml YAML OK"'`\n