### PR TITLE
fix(maker): 完善 WorkBuddy 异步构建流程

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -372,11 +372,11 @@ Maker 本地开发的默认路径是 CLI-first + PAT-first：
   已绑定 Maker 项目应优先建议用户使用这些 tools。远端 proxy tool 返回 `isError` 时，本地 MCP
   必须抛出失败并尽量输出完整 `remote_result` / server 返回内容。
 - 新开对话、继续开发或检查 Maker 状态时，先读 `maker://status` 或调用 `maker_status_lite`。支持 MCP Roots 的客户端会输出 `MCP client roots` 与 `project_context_source`；只有一个 workspace root 时直接作为 Maker 操作目标，多个 root 中只有一个已绑定 Maker 项目时自动选择该项目，多个 Maker root 时必须让用户只保留一个 Maker workspace 或显式传 `target_dir`，不要猜测。已绑定项目会输出 `Maker remote sync` 和 AI dev kit 版本检查结果，提示是否需要先 pull、是否本地 dirty、是否分叉或是否不在 main，以及是否需要运行 `taptap-maker dev-kit update`；按其中 `next_action` / `next_step` 引导用户。频繁轮询或只要快速本地状态时，`maker_status_lite` 可传 `skip_remote_sync=true`，同时跳过远端 Git 同步和 dev-kit 最新版本检查。
-- 用户说“帮我提交 / 提交代码 / 提交并推送 / push / 构建 / 预览 / 跑一下 / 验证一下 / 看看效果”时，都调用 `maker_build_current_directory`。普通构建会先 push 再远端 build：本地有改动时提交改动，已有 ahead commit 时直接 push，本地干净且无 ahead commit 时创建 `chore: wake maker build server` 空提交来唤醒 Maker 远端服务；push 成功后才远端 build。
+- 当前目录是已绑定 Maker 项目时，用户说“帮我提交 / 提交代码 / 提交并推送 / push / 构建 / 预览 / 跑一下 / 查看结果 / 看看效果 / 验证游戏效果”时，都调用 `maker_build_current_directory`。普通“验证代码 / 跑测试 / lint / 检查实现”不应自动触发 Maker 远端构建，除非用户明确要求构建、运行或预览 Maker 游戏。普通构建会先 push 再远端 build：本地有改动时提交改动，已有 ahead commit 时直接 push，本地干净且无 ahead commit 时创建 `chore: wake maker build server` 空提交来唤醒 Maker 远端服务；push 成功后才远端 build。
 - push 被拒绝、远端有新提交、认证失败或存在冲突时，`maker_build_current_directory` 必须停止在 build 前，并返回 `submit_failed_before_build`、本地 commit/ahead 状态、stderr/stdout 和下一步建议；Agent 必须根据 `classification` 选择恢复路径：`remote_rejected` 才协助 pull/rebase，`branch_not_allowed` 切回 main 并迁移本地 commit，`forbidden_path` 按远端 forbidden pattern 从未推送 commit 移除禁止路径，`auth` 才刷新 PAT。
 - push 遇到 503、HTTP 5xx、超时或连接中断会自动重试；最终失败时要读取 `classification`、`retryable`、`retry_reason` 和 `retry_attempts`，按工具返回的恢复路径继续处理。
 - push 成功但远端 build 失败时，工具返回 `build_failed_after_submit`，必须同时说明代码已经提交到 Maker 远端和具体构建错误。
-- 用户明确说不提交、直接构建云端版本时，才允许调用 `maker_build_current_directory` 并设置 `confirm_remote_build_without_submit=true`；这种模式会先打开并返回 Maker 页面链接，Agent 应把链接发给用户，方便其查看远端项目并降低服务休眠导致构建失败的概率。
+- 用户明确说不提交、直接构建云端版本时，才允许调用 `maker_build_current_directory` 并设置 `confirm_remote_build_without_submit=true`；这种模式只构建 Maker 远端已提交版本，不会自动打开 Maker 页面。
 - 构建时如果用户未指定入口且本地存在 `scripts/main.lua`，本地 Maker MCP 默认传 `scriptsPath="scripts"` 和 `entry="main.lua"`；用户显式传单机入口或多人入口时优先生效。
 - 远端 Maker MCP tools 所需的 TapTap MAC token 通过 PAT 获取。
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -359,8 +359,9 @@ Maker 本地开发的默认路径是 CLI-first + PAT-first：
   只在 `mcp.json` 已存在时更新；
   OpenCode 使用官方 `mcp` schema 和 command 数组，
   不写环境变量；
-  WorkBuddy 按平台写配置，macOS 写 `~/.workbuddy/.mcp.json`，
-  Windows 写 `%USERPROFILE%\.workbuddy\mcp.json`；通用
+  WorkBuddy 在 macOS 和 Windows 都优先写用户目录下的 `.workbuddy/mcp.json`；显式传
+  `--ide workbuddy` 时会创建该官方配置文件；未显式指定 IDE 的自动检测模式下，legacy
+  `.workbuddy/.mcp.json` 仅在官方配置文件不存在且自身已存在时作为 fallback 合并；通用
   `mcpServers` JSON 只作为 README/文档片段引导其它 AI 编辑器识别自己的实际配置文件后合并写入，
   CLI 不生成额外通用配置文件。
 - `taptap-maker mcp verify` 默认验证 `mcp install` 写入配置的 npx 包命令能否启动；本地开发只验证当前 CLI 时使用 `--mode self`。

--- a/README.md
+++ b/README.md
@@ -123,14 +123,16 @@ maker_status_lite               # Resource 不可用时的兼容 tool
 maker_build_current_directory   # commit/push/build 合并入口
 ```
 
-`maker_build_current_directory` 同时覆盖“构建 / 预览 / 跑一下 / 验证一下 / 提交 / 推送”。
+在已绑定 Maker 项目中，`maker_build_current_directory` 同时覆盖“构建 / 预览 / 跑一下 /
+查看结果 / 看看效果 / 验证游戏效果 / 提交 / 推送”。普通“验证代码 / 跑测试 / lint /
+检查实现”不应自动触发 Maker 远端构建，除非用户明确要求构建、运行或预览 Maker 游戏。
 普通构建会先 push 到 Maker 远端再触发远端 build：本地有改动时提交改动，已有未推送 commit 时
 直接 push，本地干净且没有未推送 commit 时创建 `chore: wake maker build server` 空提交来唤醒远端
 服务。push 失败时不会继续 build，会返回本地 commit、ahead 状态、stderr/stdout 和下一步建议，
 交给本地 Agent/skill 处理 pull、rebase 或冲突；push 成功但 build 失败时，会明确说明代码已到
 Maker 远端但构建失败。只有用户明确说“不提交，只构建云端版本”时，才传
-`confirm_remote_build_without_submit=true`；该模式会先打开并返回 Maker 页面链接，方便用户查看远端
-项目并避免服务休眠导致构建失败。
+`confirm_remote_build_without_submit=true`；该模式只构建 Maker 远端已提交版本，不会自动打开
+Maker 页面。
 
 构建成功后，Maker MCP 会刷新 Maker Web 预览，并启动本地 runtime log watcher。后续如果用户询问
 游戏运行结果、Lua 报错或调试问题，本地 AI Agent 应优先读取构建返回中的

--- a/README.md
+++ b/README.md
@@ -86,9 +86,10 @@ taptap-maker dev-kit update
 默认会写入 Codex、Cursor、Claude，并自动检测本机已有的 Trae、OpenCode、WorkBuddy
 配置文件；命中后会合并安装 `taptap-maker`。Trae Solo 是重点支持目标，CLI 会在 Solo
 或 Solo CN 的 `User/` 目录存在时创建或合并 `User/mcp.json`；普通 Trae/Trae CN 仍作为
-候选路径保留，但只有 `mcp.json` 已存在时才合并写入。WorkBuddy 在 macOS 写
-`~/.workbuddy/.mcp.json`，Windows 写 `%USERPROFILE%\.workbuddy\mcp.json`，另一配置文件
-仅在已存在时作为 fallback 合并。OpenCode 只在
+候选路径保留，但只有 `mcp.json` 已存在时才合并写入。WorkBuddy 在 macOS 和 Windows 都优先写
+用户目录下的 `.workbuddy/mcp.json`；显式传 `--ide workbuddy` 时会创建该官方配置文件。
+未显式指定 IDE 的自动检测模式下，legacy `.workbuddy/.mcp.json` 仅在官方配置文件不存在且
+自身已存在时作为 fallback 合并。OpenCode 只在
 `~/.config/opencode/opencode.jsonc` 已存在时写入。
 其它 AI 编辑器可按下面的通用 `mcpServers` 片段，让本地 AI 识别自己的配置文件位置后合并写入：
 

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -258,7 +258,8 @@ MCP 运行期能力：
   `.maker/logs/runtime/runtime.log`，保持 server 日志行格式（`t/topic/level/msg/userId`
   等），但去掉无用的 `id` 字段，也不再补 `time/message` 重复字段；并维护
   `.maker/logs/runtime/state.json` 的 `nextStartTime` 和心跳字段。
-- 构建成功输出会包含 `maker_url`，格式为 `https://maker.taptap.cn/app/<project_id>` 或当前环境对应的 Maker Web URL，可直接打开远端 Maker 页面预览。
+- 构建成功输出会包含 `maker_url`，格式为
+  `https://maker.taptap.cn/app/<project_id>?localDev=1` 或当前环境对应的 Maker Web URL，可直接打开远端 Maker 本地开发预览。
 - 构建成功并收到远端 build 返回后，MCP 会用本地缓存 Maker PAT 调用当前环境
   Maker API：`POST /api/v1/apps/<APP_ID>/preview-refresh`，主动刷新 Maker Web 端预览。
 - 构建成功输出会包含 `runtime_logs.watch_started`、`runtime_logs.watch_pid` 和
@@ -499,8 +500,9 @@ Windows 兼容注意：
   `Trae/User/mcp.json`、`Trae CN/User/mcp.json`，并兼容 `TRAE SOLO CN/User/mcp.json`；
   Windows 常见位置包括 `%APPDATA%\TRAE SOLO\User\mcp.json`、
   `%APPDATA%\Trae\User\mcp.json` 和 `%APPDATA%\Trae CN\User\mcp.json`。
-- WorkBuddy 在 macOS 写 `~/.workbuddy/.mcp.json`，Windows 写
-  `%USERPROFILE%\.workbuddy\mcp.json`，另一配置文件仅在已存在时作为 fallback 合并。
+- WorkBuddy 在 macOS 和 Windows 都优先写用户目录下的 `.workbuddy/mcp.json`；
+  显式传 `--ide workbuddy` 时会创建该官方配置文件。未显式指定 IDE 的自动检测模式下，
+  legacy `.workbuddy/.mcp.json` 仅在官方配置文件不存在且自身已存在时作为 fallback 合并。
 - OpenCode 只在 `~/.config/opencode/opencode.jsonc` 已存在时写入，不主动创建。
 - MCP 配置写入时会在对应 MCP server 进程环境中增加
   `TAPTAP_MCP_CLIENT_IDE=<ide>`，取值为 `codex`、`cursor`、`claude`、`trae`、

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -628,6 +628,8 @@ maker_build_current_directory()
   `maker_build_current_directory` MCP 调用不会立即结束，而是在本地继续轮询远端结果。
 - 本地默认每 5 秒调用远端 `query_build(build_id)`，最多 30 分钟；拿到
   `succeeded` 或 `failed` 后结束本次 MCP 调用，同一 Maker 项目再次触发构建时会取消上一轮轮询。
+- 异步构建拿到 `succeeded` 后，会和同步构建成功路径一样刷新 Maker Web 预览，并启动本地
+  runtime log watcher；拿到 `failed` 时不会执行这些成功后的 side effects。
 - `query_build` 返回 `status`、`progress`、`phase`、`elapsed_seconds` 以及
   `result` / `error`，本地状态文件会原样保留这些字段用于诊断。
 - 轮询状态写入 `.maker/builds/active-build.json` 和 `.maker/builds/<build_id>.json`；

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -251,8 +251,7 @@ MCP 运行期能力：
   本地落后远端、分叉、当前不在 `main` 或无法确认远端同步时，会在创建 commit 前停止。普通构建会先
   push 再远端 build：本地有改动时提交改动，已有 ahead commit 时直接 push，本地干净且无 ahead commit
   时创建 `chore: wake maker build server` 空提交来唤醒 Maker 远端服务。用户明确说“不提交，直接构建云端版本”时才传
-  `confirm_remote_build_without_submit=true`，此时工具会先打开并返回 `maker_page_url`，提示用户打开
-  Maker 远端页面后查看结果。
+  `confirm_remote_build_without_submit=true`；此时工具只构建 Maker 远端已提交版本，不会自动打开 Maker 页面。
 - 运行时日志：不作为本地公开 MCP tool 暴露。构建成功后 `taptap-maker logs watch`
   内部调用远端 `query_runtime_logs`，默认只拉 `engine`、`user_script`（客户端 Lua 脚本）和
   `server_user_script`（服务端 Lua 脚本）。本地只追加写入一份
@@ -503,6 +502,9 @@ Windows 兼容注意：
 - WorkBuddy 在 macOS 写 `~/.workbuddy/.mcp.json`，Windows 写
   `%USERPROFILE%\.workbuddy\mcp.json`，另一配置文件仅在已存在时作为 fallback 合并。
 - OpenCode 只在 `~/.config/opencode/opencode.jsonc` 已存在时写入，不主动创建。
+- MCP 配置写入时会在对应 MCP server 进程环境中增加
+  `TAPTAP_MCP_CLIENT_IDE=<ide>`，取值为 `codex`、`cursor`、`claude`、`trae`、
+  `opencode` 或 `workbuddy`，用于本地 Maker MCP 识别当前请求来源。
 - `taptap-maker init` 默认写入不带项目 `cwd` 的用户级 MCP 配置，避免多个项目或多个 AI
   客户端互相覆盖全局 cwd。支持 MCP Roots 的客户端由当前 workspace root 决定 Maker 项目。
   单独运行 `taptap-maker mcp install --target-dir <PROJECT_DIR>` 时才会显式写入该目录，
@@ -535,10 +537,11 @@ maker_build_current_directory()
 - 普通构建必须先 push 到 Maker 远端再 build；如果本地没有改动且没有 ahead commit，会创建
   `chore: wake maker build server` 空提交并 push，用于唤醒可能已挂起或销毁的远端服务。
 - 如果本地有改动或已经有本地 commit 未 push，默认先 commit/push，再远端 build。
-- 用户说“提交 / push / 构建 / 查看结果 / 预览 / 跑一下 / 验证一下 / 看看效果”时，都使用同一个工具。
+- 当前目录是已绑定 Maker 项目时，用户说“提交 / push / 构建 / 查看结果 / 预览 / 跑一下 /
+  看看效果 / 验证游戏效果”时，都使用同一个工具。普通“验证代码 / 跑测试 / lint /
+  检查实现”不应自动触发 Maker 远端构建，除非用户明确要求构建、运行或预览 Maker 游戏。
 - 用户明确说“不提交 / 直接构建 / 构建云端版本”时，才允许传 `confirm_remote_build_without_submit=true`，
-  这会只构建 Maker 远端已提交版本；工具会先打开 Maker 远端页面，并在结果里返回 `maker_page_url`，
-  如果浏览器没有自动弹出，Agent 应把这个链接发给用户让其手动打开。
+  这会只构建 Maker 远端已提交版本，不会自动打开 Maker 页面。
 - push 被远端拒绝、认证失败、远端有新提交或发生冲突时，工具返回 `mode: submit_failed_before_build`，不会继续远端 build。Agent 应解释 push 失败原因，按 `classification` 使用对应恢复策略，再重试同一个构建工具。
 - 如果 push 成功但远端 build 失败，工具返回 `mode: build_failed_after_submit`，同时保留成功的提交/推送结果和构建错误。
 - 如果 build 成功，工具会启动本地 CLI watcher 并在返回里带出
@@ -609,6 +612,28 @@ maker_build_current_directory()
 - `entry_client` / `entry_server`：用户明确说明是多人游戏或给出入口文件时再传入；传入多人入口后不会自动补单机 `scripts/main.lua`。
 - `multiplayer`：用户未指定且本地不存在 `.project/settings.json` 时，默认传 `{ "enabled": false }`，用于第一次单机项目构建初始化。
 - 如果用户明确说明是多人游戏或给出入口文件，再把对应参数传入。
+
+异步远端构建不新增 MCP tool，通过本地参数和 IDE 默认策略控制：
+
+- `maker_build_current_directory` 暴露本地参数 `async_build`。显式传 `async_build=true` 时，
+  无论当前 IDE 是什么，本地 MCP 都会把 `async: true` 转发给远端 `build` tool；显式传
+  `async_build=false` 时保持同步构建。
+- 未传 `async_build` 时，当前 MCP server 进程环境中 `TAPTAP_MCP_CLIENT_IDE=workbuddy`
+  默认走异步构建；Codex、Cursor、Claude、Trae、OpenCode 等其它 IDE 默认保持同步构建。
+- 远端 server 仅在 `_tag=local` 会话暴露 async build 能力。本地默认转发 `async: true`，
+  并通过本地 proxy 私有参数继续注入 `_tag=local`。如需临时联调其它契约，可用
+  `TAPTAP_MAKER_REMOTE_ASYNC_BUILD_PARAM` 覆盖远端参数名，用
+  `TAPTAP_MAKER_REMOTE_ASYNC_BUILD_VALUE_JSON` 覆盖远端参数值（JSON 格式）。
+- 远端异步 build 返回 JSON 回执后，本地读取 `build_id`，并保留 `reused` 标记；本次
+  `maker_build_current_directory` MCP 调用不会立即结束，而是在本地继续轮询远端结果。
+- 本地默认每 5 秒调用远端 `query_build(build_id)`，最多 30 分钟；拿到
+  `succeeded` 或 `failed` 后结束本次 MCP 调用，同一 Maker 项目再次触发构建时会取消上一轮轮询。
+- `query_build` 返回 `status`、`progress`、`phase`、`elapsed_seconds` 以及
+  `result` / `error`，本地状态文件会原样保留这些字段用于诊断。
+- 轮询状态写入 `.maker/builds/active-build.json` 和 `.maker/builds/<build_id>.json`；
+  `maker://status` / `maker_status_lite` 会显示当前 active async build 摘要。
+- server 侧异步任务不跨进程重启持久化，完成结果保留约 30 分钟；本地 watcher 也只在当前
+  MCP server 进程内有效，重启后的残留 active 文件会在状态中标记为 stale。
 
 ## 提交和推送约束
 

--- a/docs/MAKER_CLI_MCP_SKILL_REWORK_OVERVIEW.md
+++ b/docs/MAKER_CLI_MCP_SKILL_REWORK_OVERVIEW.md
@@ -70,8 +70,10 @@ CLI 负责所有与本机环境、账号、项目绑定相关的低频动作：
 - Windows 下生成通用 `mcpServers` 配置时通过 `cmd.exe` 包装 `npx.cmd`，兼容无 shell 的 MCP 启动器。
 - OpenCode 使用官方 `mcp` schema 和 command 数组，不写环境变量，且只写已存在配置文件；
   Trae Solo/Solo CN 优先支持，按 `User/` 目录创建或合并 `User/mcp.json`，普通 Trae
-  只在 `mcp.json` 已存在时更新；WorkBuddy 按平台写配置，macOS 写
-  `~/.workbuddy/.mcp.json`，Windows 写 `%USERPROFILE%\.workbuddy\mcp.json`。
+  只在 `mcp.json` 已存在时更新；WorkBuddy 在 macOS 和 Windows 都优先写用户目录下的
+  `.workbuddy/mcp.json`，显式传 `--ide workbuddy` 时会创建该官方配置文件。未显式指定 IDE
+  的自动检测模式下，legacy `.workbuddy/.mcp.json` 仅在官方配置文件不存在且自身已存在时作为
+  fallback 合并。
 - 初始化失败时保留现场，返回可重试状态，不自动删除用户文件。
 - 用户选择 app 后立即写入 `.maker-mcp/config.json`；clone/fetch 失败后重复执行
   `taptap-maker init` 会复用这个选择继续，后续缺失状态交给 `taptap-maker doctor` 判断。

--- a/skills/taptap-maker-dev-kit-guide/SKILL.md
+++ b/skills/taptap-maker-dev-kit-guide/SKILL.md
@@ -43,13 +43,17 @@ asks and understands they are local environment files.
 
 Keep validation simple for Maker users. 用户可以直接说“提交”或“构建”:
 
-- If the user says “提交”, “推送”, “构建”, “预览”, or “跑一下”, use
+- If the current workspace is a bound Maker project and the user says “提交”, “推送”, “构建”,
+  “预览”, “跑一下”, “查看结果”, “看看效果”, or “验证游戏效果”, use
   `maker_build_current_directory`. The tool commits when needed, pushes to Maker remote, and then
   runs the remote build.
+- Do not treat generic code checks like “验证代码”, “跑测试”, “lint”, or “检查实现” as Maker
+  remote build unless the user explicitly asks to build, run, or preview the Maker game.
 - If push fails, do not start a separate build or generic Git push. Explain the returned recovery
   details, follow the returned classification-specific recovery (`remote_rejected`,
   `branch_not_allowed`, `forbidden_path`, or `auth`), then retry `maker_build_current_directory`.
-- After submit or build finishes, tell the user to open the TapMaker 网页端查看结果.
+- After submit or build finishes, report the returned Maker URL, build status, and runtime log file
+  path when available. Do not auto-open TapMaker pages.
 
 Do not create local-only test scripts just to verify Maker changes. The expected validation path is
-chat request -> Maker MCP submit/build tool -> TapMaker web result check.
+chat request -> Maker MCP submit/build tool -> returned build result, Maker URL, and runtime logs.

--- a/skills/taptap-maker-local/SKILL.md
+++ b/skills/taptap-maker-local/SKILL.md
@@ -52,7 +52,8 @@ exists.
 | submit / commit / push to Maker                           | Inspect local Git state, summarize changed files, then call `maker_build_current_directory` unless blocked.                                     |
 | pull / update from remote                                 | Inspect local changes first; if dirty, explain options before pulling.                                                                          |
 | conflict / merge failed                                   | Explain why the conflict happened, list conflict files, inspect conflict hunks, propose a resolution plan, and ask before editing.              |
-| build / preview / run / verify                            | Use `maker_build_current_directory`; it starts the local runtime log watcher after a successful remote build result.                            |
+| build / preview / run / check game result                 | Use `maker_build_current_directory`; it starts the local runtime log watcher after a successful remote build result.                            |
+| generic code validation / tests / lint                    | Do not use Maker remote build unless the user explicitly asks to build, run, or preview the Maker game.                                         |
 
 ## Create New Maker Project Intent
 
@@ -97,7 +98,10 @@ This policy overrides generic local Git skills and generic Git workflows wheneve
 directory is a Maker project, which means `.maker-mcp/config.json` exists in the project or one of
 its parents.
 
-Use `maker_build_current_directory` for submit, push, build, preview, run, and verify requests.
+Use `maker_build_current_directory` for submit, push, build, preview, run, and game result
+verification requests in a bound Maker project.
+Do not treat generic code checks like "验证代码", "跑测试", "lint", or "检查实现" as Maker
+remote build unless the user explicitly asks to build, run, or preview the Maker game.
 Do not create feature branches, task branches, PR/MR. Do not create task-id based Git flows for
 Maker project submit/build work. Do not run generic Git commit/push helpers as a replacement for
 the Maker MCP tool.
@@ -515,7 +519,7 @@ unless the user asks. Summaries should be understandable to non-programmers:
 - why these files are being submitted
 - whether any generated or suspicious files are included
 
-For normal build/preview/verify requests, a clean workspace still goes through
+For normal build/preview/game-result verification requests, a clean workspace still goes through
 `maker_build_current_directory`; Maker MCP creates and pushes an empty
 `chore: wake maker build server` commit before remote build to wake the Maker server.
 Only skip submit/push when the user explicitly asks to build the committed remote version.
@@ -578,8 +582,7 @@ them before build.
 
 If the user explicitly asks "不提交", "直接构建", or "构建云端版本", call
 `maker_build_current_directory` with `confirm_remote_build_without_submit=true`. In that mode, Maker
-MCP opens the Maker app page before remote build and returns `maker_page_url`; show that URL to the
-user if the browser did not open automatically.
+MCP builds the committed remote version only and does not auto-open Maker pages.
 
 For push failures, use the returned `classification`, `retryable`, `retry_reason`, and
 `retry_attempts` fields. Temporary 5xx/network/timeout failures may be retried with the Maker build

--- a/src/__tests__/makerBuildLocalChanges.test.ts
+++ b/src/__tests__/makerBuildLocalChanges.test.ts
@@ -11,6 +11,7 @@ import { pathToFileURL } from 'node:url';
 import {
   buildCurrentDirectory,
   createBuildArgs,
+  createRemoteBuildCallResult,
   createRemoteProxyCallToolOptions,
   listMakerTools,
   MAKER_REMOTE_PROXY_EXPOSED_TOOL_NAMES,
@@ -19,6 +20,8 @@ import {
   createRemoteProxyContext,
   createRemoteProxyProgressHandler,
   createRemoteRuntimeLogClient,
+  startAsyncBuildResultWatcher,
+  stopExistingAsyncBuildResultWatcher,
   refreshMakerPreview,
   formatBuildResult,
   formatAiDevKitStatus,
@@ -52,6 +55,8 @@ describe('maker build local-change guard', () => {
   const originalGitBase = process.env.TAPTAP_MAKER_GIT_BASE;
   const originalPat = process.env.PAT;
   const originalEnv = process.env.TAPTAP_MCP_ENV;
+  const originalRemoteAsyncBuildParam = process.env.TAPTAP_MAKER_REMOTE_ASYNC_BUILD_PARAM;
+  const originalRemoteAsyncBuildValueJson = process.env.TAPTAP_MAKER_REMOTE_ASYNC_BUILD_VALUE_JSON;
 
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'maker-build-local-changes-'));
@@ -92,6 +97,16 @@ describe('maker build local-change guard', () => {
     } else {
       process.env.TAPTAP_MCP_ENV = originalEnv;
     }
+    if (originalRemoteAsyncBuildParam === undefined) {
+      delete process.env.TAPTAP_MAKER_REMOTE_ASYNC_BUILD_PARAM;
+    } else {
+      process.env.TAPTAP_MAKER_REMOTE_ASYNC_BUILD_PARAM = originalRemoteAsyncBuildParam;
+    }
+    if (originalRemoteAsyncBuildValueJson === undefined) {
+      delete process.env.TAPTAP_MAKER_REMOTE_ASYNC_BUILD_VALUE_JSON;
+    } else {
+      process.env.TAPTAP_MAKER_REMOTE_ASYNC_BUILD_VALUE_JSON = originalRemoteAsyncBuildValueJson;
+    }
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -119,6 +134,270 @@ describe('maker build local-change guard', () => {
 
     expect(changes.hasChanges).toBe(true);
     expect(changes.files).toContain(fileName);
+  });
+
+  test('resolves async build preference from explicit argument and WorkBuddy default', () => {
+    const originalClientIde = process.env.TAPTAP_MCP_CLIENT_IDE;
+    try {
+      expect(
+        createBuildArgs(tempDir, {
+          clientIde: 'workbuddy',
+        })
+      ).toEqual({
+        entry: 'main.lua',
+        scriptsPath: 'scripts',
+        multiplayer: { enabled: false },
+        async: true,
+      });
+
+      expect(
+        createBuildArgs(tempDir, {
+          asyncBuild: true,
+          clientIde: 'codex',
+        })
+      ).toEqual({
+        entry: 'main.lua',
+        scriptsPath: 'scripts',
+        multiplayer: { enabled: false },
+        async: true,
+      });
+
+      expect(
+        createBuildArgs(tempDir, {
+          asyncBuild: false,
+          clientIde: 'workbuddy',
+        })
+      ).toEqual({
+        entry: 'main.lua',
+        scriptsPath: 'scripts',
+        multiplayer: { enabled: false },
+      });
+
+      process.env.TAPTAP_MCP_CLIENT_IDE = 'workbuddy';
+      expect(createBuildArgs(tempDir, {})).toEqual({
+        entry: 'main.lua',
+        scriptsPath: 'scripts',
+        multiplayer: { enabled: false },
+        async: true,
+      });
+    } finally {
+      if (originalClientIde === undefined) {
+        delete process.env.TAPTAP_MCP_CLIENT_IDE;
+      } else {
+        process.env.TAPTAP_MCP_CLIENT_IDE = originalClientIde;
+      }
+    }
+  });
+
+  test('supports configurable remote async build argument contract', () => {
+    process.env.TAPTAP_MAKER_REMOTE_ASYNC_BUILD_PARAM = 'build_mode';
+    process.env.TAPTAP_MAKER_REMOTE_ASYNC_BUILD_VALUE_JSON = '{"mode":"async"}';
+
+    expect(
+      createBuildArgs(tempDir, {
+        asyncBuild: true,
+        clientIde: 'workbuddy',
+      })
+    ).toEqual({
+      entry: 'main.lua',
+      scriptsPath: 'scripts',
+      multiplayer: { enabled: false },
+      build_mode: { mode: 'async' },
+    });
+  });
+
+  test('parses server async build receipt from build_id and reused fields', () => {
+    const result = createRemoteBuildCallResult({
+      projectRoot: tempDir,
+      projectId: 'app-1',
+      projectPath: 'app-1/workspace',
+      serverUrl: 'https://maker.example.test/mcp',
+      env: 'rnd',
+      timeoutMs: 600000,
+      buildArgs: { async: true },
+      resultText: '{"build_id":"build-accepted","status":"running","reused":true}',
+      asyncBuild: true,
+    });
+
+    expect(result.mode).toBe('remote_build_async_started');
+    expect(result.buildArgs).toEqual({ async: true });
+    expect('taskId' in result ? result.taskId : undefined).toBe('build-accepted');
+    expect('reused' in result ? result.reused : undefined).toBe(true);
+  });
+
+  test('async build watcher polls every 5 seconds and stops after success', async () => {
+    jest.useFakeTimers();
+    const statuses: string[] = [];
+    const watcher = startAsyncBuildResultWatcher({
+      projectRoot: tempDir,
+      projectId: 'app-1',
+      projectPath: 'app-1/workspace',
+      serverUrl: 'https://maker.example.test/mcp',
+      env: 'rnd',
+      taskId: 'build-1',
+      reused: false,
+      queryBuildResult: async () => {
+        statuses.push('poll');
+        return statuses.length === 1
+          ? { status: 'running' }
+          : { status: 'succeeded', resultText: 'build ok' };
+      },
+      refreshPreview: async () => ({ ok: true, status: 200, url: 'https://maker.example.test' }),
+      startRuntimeLogWatch: async () => ({
+        started: true,
+        command: 'watch',
+        runtimeLog: path.join(tempDir, '.maker', 'logs', 'runtime', 'runtime.log'),
+      }),
+    });
+
+    expect(watcher.started).toBe(true);
+    expect(statuses).toEqual([]);
+
+    await jest.advanceTimersByTimeAsync(5000);
+    expect(statuses).toHaveLength(1);
+    expect(JSON.parse(fs.readFileSync(watcher.stateFile, 'utf8')).status).toBe('running');
+
+    await jest.advanceTimersByTimeAsync(5000);
+    expect(statuses).toHaveLength(2);
+    const finalState = JSON.parse(fs.readFileSync(watcher.stateFile, 'utf8'));
+    expect(finalState.status).toBe('succeeded');
+    expect(finalState.reused).toBe(false);
+    expect(finalState.previewRefresh.ok).toBe(true);
+    expect(finalState.runtimeLogWatch.started).toBe(true);
+
+    await jest.advanceTimersByTimeAsync(5000);
+    expect(statuses).toHaveLength(2);
+    jest.useRealTimers();
+  });
+
+  test('async build watcher stops when query reports expired build id', async () => {
+    jest.useFakeTimers();
+    let polls = 0;
+    const watcher = startAsyncBuildResultWatcher({
+      projectRoot: tempDir,
+      projectId: 'app-1',
+      projectPath: 'app-1/workspace',
+      serverUrl: 'https://maker.example.test/mcp',
+      env: 'rnd',
+      taskId: 'build-expired',
+      queryBuildResult: async () => {
+        polls += 1;
+        throw new Error('未找到 build_id=build-expired 的构建任务（可能已过期或服务重启）');
+      },
+    });
+
+    await jest.advanceTimersByTimeAsync(5000);
+
+    expect(polls).toBe(1);
+    const state = JSON.parse(fs.readFileSync(watcher.stateFile, 'utf8'));
+    expect(state.status).toBe('expired');
+    expect(state.lastPollError).toContain('未找到');
+    expect(fs.existsSync(watcher.activeFile)).toBe(false);
+
+    await jest.advanceTimersByTimeAsync(5000);
+    expect(polls).toBe(1);
+    jest.useRealTimers();
+  });
+
+  test('async build watcher stops after success even when success side effects fail', async () => {
+    jest.useFakeTimers();
+    let polls = 0;
+    const watcher = startAsyncBuildResultWatcher({
+      projectRoot: tempDir,
+      projectId: 'app-1',
+      projectPath: 'app-1/workspace',
+      serverUrl: 'https://maker.example.test/mcp',
+      env: 'rnd',
+      taskId: 'build-side-effect-fail',
+      queryBuildResult: async () => {
+        polls += 1;
+        return { status: 'succeeded', resultText: 'build ok' };
+      },
+      refreshPreview: async () => {
+        throw new Error('preview unavailable');
+      },
+      startRuntimeLogWatch: async () => {
+        throw new Error('watcher unavailable');
+      },
+    });
+
+    await jest.advanceTimersByTimeAsync(5000);
+
+    expect(polls).toBe(1);
+    const state = JSON.parse(fs.readFileSync(watcher.stateFile, 'utf8'));
+    expect(state.status).toBe('succeeded');
+    expect(state.previewRefresh.error).toBe('preview unavailable');
+    expect(state.runtimeLogWatch.error).toBe('watcher unavailable');
+    expect(fs.existsSync(watcher.activeFile)).toBe(false);
+
+    await jest.advanceTimersByTimeAsync(5000);
+    expect(polls).toBe(1);
+    jest.useRealTimers();
+  });
+
+  test('async build watcher times out after 30 minutes', async () => {
+    jest.useFakeTimers();
+    let polls = 0;
+    const watcher = startAsyncBuildResultWatcher({
+      projectRoot: tempDir,
+      projectId: 'app-1',
+      projectPath: 'app-1/workspace',
+      serverUrl: 'https://maker.example.test/mcp',
+      env: 'rnd',
+      taskId: 'build-timeout',
+      queryBuildResult: async () => {
+        polls += 1;
+        return { status: 'running' };
+      },
+    });
+
+    await jest.advanceTimersByTimeAsync(30 * 60 * 1000);
+
+    expect(polls).toBe(360);
+    expect(JSON.parse(fs.readFileSync(watcher.stateFile, 'utf8')).status).toBe('timeout');
+    jest.useRealTimers();
+  });
+
+  test('starting a new async build watcher cancels the previous watcher for the same project', async () => {
+    jest.useFakeTimers();
+    let firstPolls = 0;
+    let firstStopped = 0;
+    const first = startAsyncBuildResultWatcher({
+      projectRoot: tempDir,
+      projectId: 'app-1',
+      projectPath: 'app-1/workspace',
+      serverUrl: 'https://maker.example.test/mcp',
+      env: 'rnd',
+      taskId: 'build-old',
+      queryBuildResult: async () => {
+        firstPolls += 1;
+        return { status: 'running' };
+      },
+      onStop: () => {
+        firstStopped += 1;
+      },
+    });
+
+    const second = startAsyncBuildResultWatcher({
+      projectRoot: tempDir,
+      projectId: 'app-1',
+      projectPath: 'app-1/workspace',
+      serverUrl: 'https://maker.example.test/mcp',
+      env: 'rnd',
+      taskId: 'build-new',
+      queryBuildResult: async () => ({ status: 'running' }),
+    });
+
+    expect(JSON.parse(fs.readFileSync(first.stateFile, 'utf8')).status).toBe(
+      'cancelled_by_new_build'
+    );
+    expect(firstStopped).toBe(1);
+    expect(JSON.parse(fs.readFileSync(second.activeFile, 'utf8')).taskId).toBe('build-new');
+
+    await jest.advanceTimersByTimeAsync(30000);
+    expect(firstPolls).toBe(0);
+    stopExistingAsyncBuildResultWatcher(tempDir, 'cancelled');
+    jest.useRealTimers();
   });
 
   test('remote proxy context uses project local rnd environment config', () => {
@@ -604,6 +883,74 @@ describe('maker build local-change guard', () => {
     ]);
   });
 
+  test('workbuddy default async build waits for query result before returning', async () => {
+    const originalClientIde = process.env.TAPTAP_MCP_CLIENT_IDE;
+    process.env.TAPTAP_MCP_CLIENT_IDE = 'workbuddy';
+    try {
+      let queryCount = 0;
+      const progressMessages: string[] = [];
+      const resultPromise = buildCurrentDirectory({
+        targetDir: tempDir,
+        submitLocalChanges: async () => ({
+          branch: 'main',
+          committed: true,
+          commitHash: 'abc1234',
+          message: 'chore: update maker project',
+          pushed: true,
+          status: 'pushed',
+        }),
+        callRemoteBuild: async () => ({
+          mode: 'remote_build_async_started',
+          projectRoot: fs.realpathSync(tempDir),
+          projectId: 'app-1',
+          projectPath: 'app-1/workspace',
+          serverUrl: 'https://maker.example.test/mcp',
+          env: 'rnd',
+          timeoutMs: 600000,
+          buildArgs: { async: true },
+          taskId: 'build-flow',
+          reused: true,
+          resultText: '{"build_id":"build-flow","status":"running","reused":true}',
+        }),
+        queryAsyncBuildResult: async () => {
+          queryCount += 1;
+          return {
+            status: 'succeeded',
+            resultText: 'build ok',
+            result: { status: 'succeeded', progress: 100, phase: 'pack', elapsed_seconds: 12 },
+          };
+        },
+        refreshPreview: async () => ({ ok: true, status: 200, url: 'https://maker.example.test' }),
+        startRuntimeLogWatch: async () => ({
+          started: true,
+          command: 'watch',
+          runtimeLog: path.join(tempDir, '.maker', 'logs', 'runtime', 'runtime.log'),
+        }),
+        asyncBuildPollIntervalMs: 1,
+        onProgress: (progress) => {
+          progressMessages.push(`${progress.phase}:${progress.message}`);
+        },
+      });
+
+      const result = await resultPromise;
+
+      expect(queryCount).toBe(1);
+      expect(progressMessages).toContain(
+        'async_build_poll:build_id=build-flow status=succeeded phase=pack elapsed=12s'
+      );
+      expect(result.mode).toBe('remote_build');
+      expect('submitResult' in result ? result.submitResult.pushed : undefined).toBe(true);
+      expect('resultText' in result ? result.resultText : undefined).toBe('build ok');
+      expect('buildArgs' in result ? result.buildArgs : undefined).toEqual({ async: true });
+    } finally {
+      if (originalClientIde === undefined) {
+        delete process.env.TAPTAP_MCP_CLIENT_IDE;
+      } else {
+        process.env.TAPTAP_MCP_CLIENT_IDE = originalClientIde;
+      }
+    }
+  });
+
   test('syncs local changes from a Maker project subdirectory', async () => {
     fs.writeFileSync(path.join(tempDir, 'scripts', 'main.lua'), '-- changed\n', 'utf8');
     const submitCwds: string[] = [];
@@ -700,18 +1047,13 @@ describe('maker build local-change guard', () => {
     ]);
   });
 
-  test('build request opens Maker page when user confirms building committed remote version', async () => {
+  test('build request does not open Maker page when building committed remote version', async () => {
     fs.writeFileSync(path.join(tempDir, 'scripts', 'main.lua'), '-- changed\n', 'utf8');
     const remoteBuildTargetDirs: string[] = [];
-    const openedUrls: string[] = [];
 
     const result = await buildCurrentDirectory({
       targetDir: tempDir,
       confirmRemoteBuildWithoutSubmit: true,
-      openMakerPage: (url) => {
-        openedUrls.push(url);
-        return { ok: true, url };
-      },
       callRemoteBuild: async (targetDir) => {
         remoteBuildTargetDirs.push(targetDir);
         return {
@@ -730,11 +1072,7 @@ describe('maker build local-change guard', () => {
 
     expect(result.mode).toBe('remote_build');
     expect('submitResult' in result ? result.submitResult : undefined).toBeUndefined();
-    expect('makerPageOpen' in result ? result.makerPageOpen : undefined).toMatchObject({
-      ok: true,
-      url: 'https://maker.taptap.cn/app/app-1',
-    });
-    expect(openedUrls).toEqual(['https://maker.taptap.cn/app/app-1']);
+    expect('makerPageOpen' in result).toBe(false);
     expect(remoteBuildTargetDirs).toEqual([tempDir]);
   });
 
@@ -776,10 +1114,14 @@ describe('maker build local-change guard', () => {
     const buildTool = tools.find((item) => item.name === 'maker_build_current_directory');
 
     expect(buildTool?.description).toContain('always pushes before remote Maker build');
+    expect(buildTool?.description).toContain('bound Maker project');
+    expect(buildTool?.description).toContain('验证游戏效果');
+    expect(buildTool?.description).toContain('Do not treat generic code validation requests');
     expect(buildTool?.description).toContain('empty wake-up commit');
     expect(buildTool?.description).toContain('remote Maker build');
     expect(buildTool?.description).toContain('If push fails, build is not started');
-    expect(buildTool?.description).toContain('maker_page_url');
+    expect(buildTool?.description).toContain('does not auto-open Maker pages');
+    expect(buildTool?.description).not.toContain('maker_page_url');
     expect(buildTool?.description).toContain('runtime_logs.local_file');
     expect(buildTool?.description).toContain('runtime_logs.state_file');
     expect(buildTool?.description).not.toContain('maker_submit_current_directory');
@@ -2127,12 +2469,16 @@ describe('maker build local-change guard', () => {
     expect(buildTool?.description).toContain('must not block the remote build flow');
   });
 
-  test('build tool schema exposes sync inputs without build preference parameter', () => {
+  test('build tool schema exposes async build preference parameter', () => {
     const buildTool = tools.find((item) => item.name === 'maker_build_current_directory');
 
     expect(buildTool?.inputSchema.properties).toHaveProperty('message');
     expect(buildTool?.inputSchema.properties).toHaveProperty('files');
     expect(buildTool?.inputSchema.properties).toHaveProperty('confirm_remote_build_without_submit');
+    expect(buildTool?.inputSchema.properties).toHaveProperty('async_build');
+    expect(buildTool?.inputSchema.properties.async_build.description).toContain(
+      'WorkBuddy defaults to async'
+    );
     expect(buildTool?.inputSchema.properties).not.toHaveProperty(
       'remember_build_submit_preference'
     );
@@ -2327,7 +2673,7 @@ describe('maker build local-change guard', () => {
     );
   });
 
-  test('formats remote-only build with Maker page open guidance', () => {
+  test('formats remote-only build without Maker page open guidance', () => {
     const output = formatBuildResult(
       {
         mode: 'remote_build',
@@ -2339,10 +2685,6 @@ describe('maker build local-change guard', () => {
         timeoutMs: 600000,
         buildArgs: { scriptsPath: 'scripts', entry: 'main.lua' },
         resultText: 'build ok',
-        makerPageOpen: {
-          ok: true,
-          url: 'https://maker.taptap.cn/app/app-1',
-        },
       },
       {
         elapsedMs: 1000,
@@ -2351,9 +2693,10 @@ describe('maker build local-change guard', () => {
       }
     );
 
-    expect(output).toContain('- maker_page_open: ok');
-    expect(output).toContain('- maker_page_url: https://maker.taptap.cn/app/app-1');
-    expect(output).toContain('如果没有自动弹出，请手动打开 maker_page_url');
+    expect(output).toContain('- maker_url: https://maker.taptap.cn/app/app-1');
+    expect(output).not.toContain('maker_page_open');
+    expect(output).not.toContain('maker_page_url');
+    expect(output).not.toContain('自动弹出');
   });
 
   test('submit tool pushes and then runs remote build', async () => {
@@ -2566,6 +2909,45 @@ describe('maker build local-change guard', () => {
     );
   });
 
+  test('formats remote build server error diagnostic fields for client output', async () => {
+    const output = formatBuildResult(
+      {
+        mode: 'build_failed_after_submit',
+        projectRoot: tempDir,
+        projectId: 'app-1',
+        submitResult: {
+          branch: 'main',
+          committed: true,
+          commitHash: 'def5678',
+          message: 'chore: update maker project',
+          pushed: true,
+          status: 'pushed',
+        },
+        buildFailure: {
+          name: 'McpError',
+          message: 'MCP error -32603: Remote build failed',
+          code: -32603,
+          data: {
+            remote_result: {
+              error: 'BUILD FAILED: lua syntax error',
+              token: 'secret-token',
+            },
+          },
+        },
+      },
+      {
+        elapsedMs: 1000,
+        elapsed: '1s',
+        progressEvents: 1,
+      }
+    );
+
+    expect(output).toContain('error_details:');
+    expect(output).toContain('BUILD FAILED: lua syntax error');
+    expect(output).toContain('"token": "<redacted>"');
+    expect(output).not.toContain('secret-token');
+  });
+
   test('remote build refreshes Maker web preview after a build result is returned', async () => {
     const refreshedProjects: string[] = [];
 
@@ -2744,7 +3126,6 @@ describe('maker build local-change guard', () => {
     const result = await buildCurrentDirectory({
       targetDir: tempDir,
       confirmRemoteBuildWithoutSubmit: true,
-      openMakerPage: (url) => ({ ok: true, url }),
       callRemoteBuild: async () => ({
         mode: 'remote_build',
         projectRoot: tempDir,

--- a/src/__tests__/makerBuildLocalChanges.test.ts
+++ b/src/__tests__/makerBuildLocalChanges.test.ts
@@ -951,6 +951,165 @@ describe('maker build local-change guard', () => {
     }
   });
 
+  test('async build success runs default preview refresh and runtime log watcher with original build args', async () => {
+    process.env.TAPTAP_MAKER_HOME = path.join(tempDir, 'maker-home-async-side-effects');
+    process.env.TAPTAP_MCP_ENV = 'rnd';
+    savePat({ token: 'rnd-pat' });
+    delete process.env.TAPTAP_MCP_ENV;
+    const originalFetch = global.fetch;
+    const fetchMock = jest.fn(async () => new Response('ok', { status: 200 }));
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const runtimeBuildArgs: Record<string, unknown>[] = [];
+
+    try {
+      const result = await buildCurrentDirectory({
+        targetDir: tempDir,
+        submitLocalChanges: async () => ({
+          branch: 'main',
+          committed: true,
+          commitHash: 'abc1234',
+          message: 'chore: update maker project',
+          pushed: true,
+          status: 'pushed',
+        }),
+        callRemoteBuild: async () => ({
+          mode: 'remote_build_async_started',
+          projectRoot: fs.realpathSync(tempDir),
+          projectId: 'app-1',
+          projectPath: 'app-1/workspace',
+          serverUrl: 'https://fuping.agnt.xd.com/mcp/v1',
+          env: 'rnd',
+          timeoutMs: 600000,
+          buildArgs: { async: true },
+          taskId: 'build-side-effects',
+          resultText: '{"build_id":"build-side-effects","status":"running"}',
+        }),
+        queryAsyncBuildResult: async () => ({
+          status: 'succeeded',
+          resultText: 'build ok',
+          result: { status: 'succeeded', progress: 100, phase: 'pack' },
+        }),
+        startRuntimeLogWatch: async (buildResult) => {
+          runtimeBuildArgs.push(buildResult.buildArgs);
+          return {
+            started: true,
+            command: 'watch',
+            runtimeLog: path.join(tempDir, '.maker', 'logs', 'runtime', 'runtime.log'),
+          };
+        },
+        asyncBuildPollIntervalMs: 1,
+      });
+
+      expect(result.mode).toBe('remote_build');
+      expect('previewRefresh' in result ? result.previewRefresh?.ok : undefined).toBe(true);
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://fuping.agnt.xd.com/api/v1/apps/app-1/preview-refresh',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer rnd-pat',
+          }),
+        })
+      );
+      expect(runtimeBuildArgs).toEqual([{ async: true }]);
+      expect('runtimeLogWatch' in result ? result.runtimeLogWatch?.started : undefined).toBe(true);
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
+  test('confirmed remote-only async build still runs success side effects', async () => {
+    const refreshedProjects: string[] = [];
+    const watchedProjects: string[] = [];
+
+    const result = await buildCurrentDirectory({
+      targetDir: tempDir,
+      confirmRemoteBuildWithoutSubmit: true,
+      callRemoteBuild: async () => ({
+        mode: 'remote_build_async_started',
+        projectRoot: fs.realpathSync(tempDir),
+        projectId: 'app-remote-only',
+        projectPath: 'app-remote-only/workspace',
+        serverUrl: 'https://maker.example.test/mcp',
+        env: 'rnd',
+        timeoutMs: 600000,
+        buildArgs: { async: true },
+        taskId: 'build-remote-only',
+        resultText: '{"build_id":"build-remote-only","status":"running"}',
+      }),
+      queryAsyncBuildResult: async () => ({
+        status: 'succeeded',
+        resultText: 'build ok',
+        result: { status: 'succeeded', progress: 100, phase: 'pack' },
+      }),
+      refreshPreview: async (buildResult) => {
+        refreshedProjects.push(buildResult.projectId);
+        return { ok: true, status: 200, url: 'https://maker.example.test/preview-refresh' };
+      },
+      startRuntimeLogWatch: async (buildResult) => {
+        watchedProjects.push(buildResult.projectId);
+        return { started: true, command: 'watch', runtimeLog: 'runtime.log' };
+      },
+      asyncBuildPollIntervalMs: 1,
+    });
+
+    expect(result.mode).toBe('remote_build');
+    expect('submitResult' in result ? result.submitResult : undefined).toBeUndefined();
+    expect(refreshedProjects).toEqual(['app-remote-only']);
+    expect(watchedProjects).toEqual(['app-remote-only']);
+    expect('previewRefresh' in result ? result.previewRefresh?.ok : undefined).toBe(true);
+    expect('runtimeLogWatch' in result ? result.runtimeLogWatch?.started : undefined).toBe(true);
+  });
+
+  test('async build failure after submit does not run success side effects', async () => {
+    const refreshedProjects: string[] = [];
+    const watchedProjects: string[] = [];
+
+    const result = await buildCurrentDirectory({
+      targetDir: tempDir,
+      submitLocalChanges: async () => ({
+        branch: 'main',
+        committed: true,
+        commitHash: 'abc1234',
+        message: 'chore: update maker project',
+        pushed: true,
+        status: 'pushed',
+      }),
+      callRemoteBuild: async () => ({
+        mode: 'remote_build_async_started',
+        projectRoot: fs.realpathSync(tempDir),
+        projectId: 'app-async-fail',
+        projectPath: 'app-async-fail/workspace',
+        serverUrl: 'https://maker.example.test/mcp',
+        env: 'rnd',
+        timeoutMs: 600000,
+        buildArgs: { async: true },
+        taskId: 'build-async-fail',
+        resultText: '{"build_id":"build-async-fail","status":"running"}',
+      }),
+      queryAsyncBuildResult: async () => ({
+        status: 'failed',
+        resultText: 'BUILD FAILED: lua syntax error',
+        result: { status: 'failed', error: 'lua syntax error' },
+        error: 'lua syntax error',
+      }),
+      refreshPreview: async (buildResult) => {
+        refreshedProjects.push(buildResult.projectId);
+        return { ok: true, status: 200, url: 'preview-refresh' };
+      },
+      startRuntimeLogWatch: async (buildResult) => {
+        watchedProjects.push(buildResult.projectId);
+        return { started: true, command: 'watch', runtimeLog: 'runtime.log' };
+      },
+      asyncBuildPollIntervalMs: 1,
+    });
+
+    expect(result.mode).toBe('build_failed_after_submit');
+    expect('submitResult' in result ? result.submitResult.pushed : undefined).toBe(true);
+    expect('buildFailure' in result ? result.buildFailure.message : '').toContain('BUILD FAILED');
+    expect(refreshedProjects).toEqual([]);
+    expect(watchedProjects).toEqual([]);
+  });
+
   test('syncs local changes from a Maker project subdirectory', async () => {
     fs.writeFileSync(path.join(tempDir, 'scripts', 'main.lua'), '-- changed\n', 'utf8');
     const submitCwds: string[] = [];

--- a/src/__tests__/makerBuildLocalChanges.test.ts
+++ b/src/__tests__/makerBuildLocalChanges.test.ts
@@ -232,6 +232,48 @@ describe('maker build local-change guard', () => {
     expect('reused' in result ? result.reused : undefined).toBe(true);
   });
 
+  test('parses async build receipt from multiline remote text', () => {
+    const result = createRemoteBuildCallResult({
+      projectRoot: tempDir,
+      projectId: 'app-1',
+      projectPath: 'app-1/workspace',
+      serverUrl: 'https://maker.example.test/mcp',
+      env: 'rnd',
+      timeoutMs: 600000,
+      buildArgs: { async: true },
+      resultText:
+        'Maker build accepted\n{"build_id":"build-multiline","status":"running","reused":false}',
+      asyncBuild: true,
+    });
+
+    expect(result.mode).toBe('remote_build_async_started');
+    expect('taskId' in result ? result.taskId : undefined).toBe('build-multiline');
+    expect('reused' in result ? result.reused : undefined).toBe(false);
+  });
+
+  test('parses async build receipt from fenced json remote text', () => {
+    const result = createRemoteBuildCallResult({
+      projectRoot: tempDir,
+      projectId: 'app-1',
+      projectPath: 'app-1/workspace',
+      serverUrl: 'https://maker.example.test/mcp',
+      env: 'rnd',
+      timeoutMs: 600000,
+      buildArgs: { async: true },
+      resultText: [
+        'Maker build accepted',
+        '```json',
+        '{"build_id":"build-fenced","status":"running","reused":true}',
+        '```',
+      ].join('\n'),
+      asyncBuild: true,
+    });
+
+    expect(result.mode).toBe('remote_build_async_started');
+    expect('taskId' in result ? result.taskId : undefined).toBe('build-fenced');
+    expect('reused' in result ? result.reused : undefined).toBe(true);
+  });
+
   test('async build watcher polls every 5 seconds and stops after success', async () => {
     jest.useFakeTimers();
     const statuses: string[] = [];

--- a/src/__tests__/makerBuildLocalChanges.test.ts
+++ b/src/__tests__/makerBuildLocalChanges.test.ts
@@ -55,6 +55,7 @@ describe('maker build local-change guard', () => {
   const originalGitBase = process.env.TAPTAP_MAKER_GIT_BASE;
   const originalPat = process.env.PAT;
   const originalEnv = process.env.TAPTAP_MCP_ENV;
+  const originalMakerWebUrl = process.env.TAPTAP_MAKER_WEB_URL;
   const originalRemoteAsyncBuildParam = process.env.TAPTAP_MAKER_REMOTE_ASYNC_BUILD_PARAM;
   const originalRemoteAsyncBuildValueJson = process.env.TAPTAP_MAKER_REMOTE_ASYNC_BUILD_VALUE_JSON;
 
@@ -96,6 +97,11 @@ describe('maker build local-change guard', () => {
       delete process.env.TAPTAP_MCP_ENV;
     } else {
       process.env.TAPTAP_MCP_ENV = originalEnv;
+    }
+    if (originalMakerWebUrl === undefined) {
+      delete process.env.TAPTAP_MAKER_WEB_URL;
+    } else {
+      process.env.TAPTAP_MAKER_WEB_URL = originalMakerWebUrl;
     }
     if (originalRemoteAsyncBuildParam === undefined) {
       delete process.env.TAPTAP_MAKER_REMOTE_ASYNC_BUILD_PARAM;
@@ -2816,7 +2822,7 @@ describe('maker build local-change guard', () => {
     );
 
     expect(output).toContain(
-      '- maker_url: https://maker.taptap.cn/app/a161a4e5-a226-4133-908f-c28c228b7ea5'
+      '- maker_url: https://maker.taptap.cn/app/a161a4e5-a226-4133-908f-c28c228b7ea5?localDev=1'
     );
     expect(output).toContain('runtime_logs:');
     expect(output).toContain('- watch_started: yes');
@@ -2852,10 +2858,37 @@ describe('maker build local-change guard', () => {
       }
     );
 
-    expect(output).toContain('- maker_url: https://maker.taptap.cn/app/app-1');
+    expect(output).toContain('- maker_url: https://maker.taptap.cn/app/app-1?localDev=1');
     expect(output).not.toContain('maker_page_open');
     expect(output).not.toContain('maker_page_url');
     expect(output).not.toContain('自动弹出');
+  });
+
+  test('maker app preview URL keeps custom web URL path and appends localDev', () => {
+    process.env.TAPTAP_MAKER_WEB_URL = 'https://maker.example.test/tenant/dev';
+
+    const output = formatBuildResult(
+      {
+        mode: 'remote_build',
+        projectRoot: tempDir,
+        projectId: 'app-1',
+        projectPath: 'app-1/workspace',
+        serverUrl: 'https://maker.example.test/tenant/dev/mcp/v1',
+        env: 'rnd',
+        timeoutMs: 600000,
+        buildArgs: { scriptsPath: 'scripts', entry: 'main.lua' },
+        resultText: 'build ok',
+      },
+      {
+        elapsedMs: 1000,
+        elapsed: '1s',
+        progressEvents: 1,
+      }
+    );
+
+    expect(output).toContain(
+      '- maker_url: https://maker.example.test/tenant/dev/app/app-1?localDev=1'
+    );
   });
 
   test('submit tool pushes and then runs remote build', async () => {
@@ -3000,7 +3033,7 @@ describe('maker build local-change guard', () => {
       }
     );
 
-    expect(output).toContain('- maker_url: https://fuping.agnt.xd.com/app/app-rnd');
+    expect(output).toContain('- maker_url: https://fuping.agnt.xd.com/app/app-rnd?localDev=1');
   });
 
   test('push failure output explains Maker retry path without generic git push', () => {

--- a/src/__tests__/makerBuildLocalChanges.test.ts
+++ b/src/__tests__/makerBuildLocalChanges.test.ts
@@ -19,6 +19,7 @@ import {
   prepareRemoteProxyToolArgs,
   createRemoteProxyContext,
   createRemoteProxyProgressHandler,
+  createRemoteAsyncBuildQueryRunner,
   createRemoteRuntimeLogClient,
   startAsyncBuildResultWatcher,
   stopExistingAsyncBuildResultWatcher,
@@ -1064,6 +1065,38 @@ describe('maker build local-change guard', () => {
     expect(watchedProjects).toEqual(['app-remote-only']);
     expect('previewRefresh' in result ? result.previewRefresh?.ok : undefined).toBe(true);
     expect('runtimeLogWatch' in result ? result.runtimeLogWatch?.started : undefined).toBe(true);
+  });
+
+  test('confirmed remote-only async build expired state returns structured failure', async () => {
+    const result = await buildCurrentDirectory({
+      targetDir: tempDir,
+      confirmRemoteBuildWithoutSubmit: true,
+      callRemoteBuild: async () => ({
+        mode: 'remote_build_async_started',
+        projectRoot: fs.realpathSync(tempDir),
+        projectId: 'app-remote-expired',
+        projectPath: 'app-remote-expired/workspace',
+        serverUrl: 'https://maker.example.test/mcp',
+        env: 'rnd',
+        timeoutMs: 600000,
+        buildArgs: { async: true },
+        taskId: 'build-remote-expired',
+        resultText: '{"build_id":"build-remote-expired","status":"running"}',
+      }),
+      queryAsyncBuildResult: async () => {
+        throw new Error('未找到 build_id=build-remote-expired 的构建任务（可能已过期）');
+      },
+      asyncBuildPollIntervalMs: 1,
+    });
+
+    expect(result.mode).toBe('remote_build_failed');
+    expect('buildResult' in result ? result.buildResult.projectId : undefined).toBe(
+      'app-remote-expired'
+    );
+    expect('buildFailure' in result ? result.buildFailure.name : undefined).toBe(
+      'RemoteBuildFailedError'
+    );
+    expect('buildFailure' in result ? result.buildFailure.message : '').toContain('expired');
   });
 
   test('async build failure after submit does not run success side effects', async () => {
@@ -3561,6 +3594,59 @@ describe('maker build local-change guard', () => {
       undefined,
       expect.objectContaining({ timeout: 60 * 60 * 1000 })
     );
+  });
+
+  test('async build query runner reconnects after call failure', async () => {
+    saveTapAuth({ kid: 'rnd-kid', token: 'rnd-token', mac_key: 'rnd-mac-key' });
+    const firstConnect = jest.fn(async () => undefined);
+    const secondConnect = jest.fn(async () => undefined);
+    const firstCallTool = jest.fn(async () => {
+      throw new Error('transport closed');
+    });
+    const secondCallTool = jest.fn(async () => ({
+      content: [{ type: 'text', text: '{"status":"succeeded","progress":100}' }],
+    }));
+    const firstClose = jest.fn(async () => undefined);
+    const secondClose = jest.fn(async () => undefined);
+    const createClient = jest
+      .fn()
+      .mockReturnValueOnce({ connect: firstConnect, callTool: firstCallTool, close: firstClose })
+      .mockReturnValueOnce({
+        connect: secondConnect,
+        callTool: secondCallTool,
+        close: secondClose,
+      });
+    const createTransport = jest.fn(() => ({}) as never);
+
+    const runner = createRemoteAsyncBuildQueryRunner(
+      {
+        mode: 'remote_build_async_started',
+        projectRoot: tempDir,
+        projectId: 'app-1',
+        projectPath: 'app-1/workspace',
+        serverUrl: 'https://maker.example.test/mcp',
+        env: 'rnd',
+        makerUrl: 'https://maker.example.test/app/app-1?localDev=1',
+        timeoutMs: 600000,
+        buildArgs: { async: true },
+        taskId: 'build-reconnect',
+        resultText: '{"build_id":"build-reconnect"}',
+      },
+      { createClient, createTransport }
+    );
+
+    await expect(runner.query('build-reconnect')).rejects.toThrow('transport closed');
+    await expect(runner.query('build-reconnect')).resolves.toEqual(
+      expect.objectContaining({ status: 'succeeded' })
+    );
+    await runner.close();
+
+    expect(createClient).toHaveBeenCalledTimes(2);
+    expect(createTransport).toHaveBeenCalledTimes(2);
+    expect(firstConnect).toHaveBeenCalledTimes(1);
+    expect(secondConnect).toHaveBeenCalledTimes(1);
+    expect(firstClose).toHaveBeenCalledTimes(1);
+    expect(secondClose).toHaveBeenCalledTimes(1);
   });
 
   function runGit(args: string[], cwd = tempDir): void {

--- a/src/__tests__/makerCliCommands.test.ts
+++ b/src/__tests__/makerCliCommands.test.ts
@@ -721,10 +721,7 @@ describe('Maker CLI commands', () => {
   });
 
   test('explicit workbuddy mcp install writes platform config file', async () => {
-    const configPath =
-      process.platform === 'win32'
-        ? path.join(tempDir, '.workbuddy', 'mcp.json')
-        : path.join(tempDir, '.workbuddy', '.mcp.json');
+    const configPath = path.join(tempDir, '.workbuddy', 'mcp.json');
     fs.mkdirSync(path.dirname(configPath), { recursive: true });
     fs.writeFileSync(
       configPath,
@@ -758,11 +755,63 @@ describe('Maker CLI commands', () => {
     });
   });
 
+  test('explicit workbuddy mcp install creates the official config file when missing', async () => {
+    const configPath = path.join(tempDir, '.workbuddy', 'mcp.json');
+
+    await runMakerCli(['mcp', 'install', '--ide', 'workbuddy', '--env', 'rnd', '--json']);
+
+    const payloads = JSON.parse(String(stdoutSpy.mock.calls[0][0]));
+    expect(payloads).toEqual([
+      expect.objectContaining({
+        ide: 'workbuddy',
+        ok: true,
+        path: configPath,
+      }),
+    ]);
+    expect(JSON.parse(fs.readFileSync(configPath, 'utf8')).mcpServers['taptap-maker']).toEqual({
+      command: expectedNpxLaunch.command,
+      args: expectedNpxLaunch.args,
+      env: { TAPTAP_MCP_ENV: 'rnd', TAPTAP_MCP_CLIENT_IDE: 'workbuddy' },
+    });
+  });
+
+  test('workbuddy mcp install prefers official mcp.json over legacy .mcp.json', async () => {
+    const configPath = path.join(tempDir, '.workbuddy', 'mcp.json');
+    const legacyPath = path.join(tempDir, '.workbuddy', '.mcp.json');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({ mcpServers: { official: { command: 'official' } } }, null, 2),
+      'utf8'
+    );
+    fs.writeFileSync(
+      legacyPath,
+      JSON.stringify({ mcpServers: { legacy: { command: 'legacy' } } }, null, 2),
+      'utf8'
+    );
+
+    await runMakerCli(['mcp', 'install', '--ide', 'workbuddy', '--env', 'rnd', '--json']);
+
+    const payloads = JSON.parse(String(stdoutSpy.mock.calls[0][0]));
+    expect(payloads).toEqual([
+      expect.objectContaining({
+        ide: 'workbuddy',
+        ok: true,
+        path: configPath,
+      }),
+    ]);
+    expect(JSON.parse(fs.readFileSync(configPath, 'utf8')).mcpServers['taptap-maker']).toEqual({
+      command: expectedNpxLaunch.command,
+      args: expectedNpxLaunch.args,
+      env: { TAPTAP_MCP_ENV: 'rnd', TAPTAP_MCP_CLIENT_IDE: 'workbuddy' },
+    });
+    expect(JSON.parse(fs.readFileSync(legacyPath, 'utf8')).mcpServers).toEqual({
+      legacy: { command: 'legacy' },
+    });
+  });
+
   test('workbuddy auto install writes existing platform config file', async () => {
-    const workBuddyConfigPath =
-      process.platform === 'win32'
-        ? path.join(tempDir, '.workbuddy', 'mcp.json')
-        : path.join(tempDir, '.workbuddy', '.mcp.json');
+    const workBuddyConfigPath = path.join(tempDir, '.workbuddy', 'mcp.json');
     fs.mkdirSync(path.dirname(workBuddyConfigPath), { recursive: true });
     const runtimeConfig = `${JSON.stringify(
       {

--- a/src/__tests__/makerCliCommands.test.ts
+++ b/src/__tests__/makerCliCommands.test.ts
@@ -279,6 +279,7 @@ describe('Maker CLI commands', () => {
       `args = [${expectedNpxLaunch.args.map((arg) => `"${arg}"`).join(', ')}]`
     );
     expect(text).toContain('TAPTAP_MCP_ENV = "rnd"');
+    expect(text).toContain('TAPTAP_MCP_CLIENT_IDE = "codex"');
     expect(text).toContain('[mcp_servers."other".env]');
     expect(text).toContain('KEEP = "yes"');
   });
@@ -308,6 +309,7 @@ describe('Maker CLI commands', () => {
       args: expectedNpxLaunch.args,
       env: {
         TAPTAP_MCP_ENV: 'rnd',
+        TAPTAP_MCP_CLIENT_IDE: 'cursor',
       },
     });
     if (process.platform === 'win32') {
@@ -329,7 +331,7 @@ describe('Maker CLI commands', () => {
     expect(config.mcpServers['taptap-maker']).toEqual({
       command: expectedNpxLaunch.command,
       args: expectedNpxLaunch.args,
-      env: { TAPTAP_MCP_ENV: 'rnd' },
+      env: { TAPTAP_MCP_ENV: 'rnd', TAPTAP_MCP_CLIENT_IDE: 'cursor' },
     });
   });
 
@@ -356,6 +358,7 @@ describe('Maker CLI commands', () => {
       cwd: projectDir,
       env: {
         TAPTAP_MCP_ENV: 'rnd',
+        TAPTAP_MCP_CLIENT_IDE: 'cursor',
       },
     });
   });
@@ -430,19 +433,34 @@ describe('Maker CLI commands', () => {
     expect(JSON.parse(fs.readFileSync(traePath, 'utf8')).mcpServers['taptap-maker']).toEqual({
       command: expectedNpxLaunch.command,
       args: expectedNpxLaunch.args,
-      env: { TAPTAP_MCP_ENV: 'rnd' },
+      env: { TAPTAP_MCP_ENV: 'rnd', TAPTAP_MCP_CLIENT_IDE: 'trae' },
     });
     expect(JSON.parse(fs.readFileSync(openCodePath, 'utf8')).mcp['taptap-maker']).toEqual({
       type: 'local',
       command: expectedOpenCodeCommand,
+      environment: { TAPTAP_MCP_ENV: 'rnd', TAPTAP_MCP_CLIENT_IDE: 'opencode' },
       enabled: true,
     });
     expect(JSON.parse(fs.readFileSync(workBuddyPath, 'utf8')).mcpServers['taptap-maker']).toEqual({
       command: expectedNpxLaunch.command,
       args: expectedNpxLaunch.args,
-      env: { TAPTAP_MCP_ENV: 'rnd' },
+      env: { TAPTAP_MCP_ENV: 'rnd', TAPTAP_MCP_CLIENT_IDE: 'workbuddy' },
     });
     expect(fs.existsSync(path.join(tempDir, 'maker-home', 'mcp.json'))).toBe(false);
+  });
+
+  test('workbuddy mcp install writes client ide environment marker in production', async () => {
+    const workBuddyPath = path.join(tempDir, '.workbuddy', 'mcp.json');
+    fs.mkdirSync(path.dirname(workBuddyPath), { recursive: true });
+    fs.writeFileSync(workBuddyPath, '{ "mcpServers": {} }\n', 'utf8');
+
+    await runMakerCli(['mcp', 'install', '--ide', 'workbuddy']);
+
+    expect(JSON.parse(fs.readFileSync(workBuddyPath, 'utf8')).mcpServers['taptap-maker']).toEqual({
+      command: expectedNpxLaunch.command,
+      args: expectedNpxLaunch.args,
+      env: { TAPTAP_MCP_CLIENT_IDE: 'workbuddy' },
+    });
   });
 
   test('trae mcp install updates both solo and non-solo configs when both exist', async () => {
@@ -512,7 +530,7 @@ describe('Maker CLI commands', () => {
     expect(JSON.parse(fs.readFileSync(soloConfigPath, 'utf8')).mcpServers['taptap-maker']).toEqual({
       command: expectedNpxLaunch.command,
       args: expectedNpxLaunch.args,
-      env: { TAPTAP_MCP_ENV: 'rnd' },
+      env: { TAPTAP_MCP_ENV: 'rnd', TAPTAP_MCP_CLIENT_IDE: 'trae' },
     });
     expect(fs.readFileSync(invalidConfigPath, 'utf8')).toBe(
       '{ "mcpServers": { "broken": true, }\n'
@@ -555,7 +573,7 @@ describe('Maker CLI commands', () => {
     ).toEqual({
       command: expectedNpxLaunch.command,
       args: expectedNpxLaunch.args,
-      env: { TAPTAP_MCP_ENV: 'rnd' },
+      env: { TAPTAP_MCP_ENV: 'rnd', TAPTAP_MCP_CLIENT_IDE: 'trae' },
     });
   });
 
@@ -580,11 +598,11 @@ describe('Maker CLI commands', () => {
     expect(JSON.parse(fs.readFileSync(traeConfigPath, 'utf8')).mcpServers['taptap-maker']).toEqual({
       command: expectedNpxLaunch.command,
       args: expectedNpxLaunch.args,
-      env: { TAPTAP_MCP_ENV: 'rnd' },
+      env: { TAPTAP_MCP_ENV: 'rnd', TAPTAP_MCP_CLIENT_IDE: 'trae' },
     });
   });
 
-  test('opencode mcp install uses the official mcp schema without environment fields', async () => {
+  test('opencode mcp install uses the official mcp schema with client environment fields', async () => {
     const configPath = path.join(tempDir, '.config', 'opencode', 'opencode.jsonc');
     fs.mkdirSync(path.dirname(configPath), { recursive: true });
     fs.writeFileSync(
@@ -613,10 +631,10 @@ describe('Maker CLI commands', () => {
     expect(config.mcp['taptap-maker']).toEqual({
       type: 'local',
       command: expectedOpenCodeCommand,
+      environment: { TAPTAP_MCP_ENV: 'rnd', TAPTAP_MCP_CLIENT_IDE: 'opencode' },
       enabled: true,
     });
     expect(config.mcp['taptap-maker']).not.toHaveProperty('env');
-    expect(config.mcp['taptap-maker']).not.toHaveProperty('environment');
     expect(config.mcpServers?.['taptap-maker']).toBeUndefined();
   });
 
@@ -664,11 +682,12 @@ describe('Maker CLI commands', () => {
     expect(config.mcp['taptap-maker']).toEqual({
       type: 'local',
       command: expectedOpenCodeCommand,
+      environment: { TAPTAP_MCP_CLIENT_IDE: 'opencode' },
       enabled: true,
     });
   });
 
-  test('opencode mcp install omits production environment by default', async () => {
+  test('opencode mcp install keeps production environment limited to client marker', async () => {
     const configPath = path.join(tempDir, '.config', 'opencode', 'opencode.jsonc');
     fs.mkdirSync(path.dirname(configPath), { recursive: true });
     fs.writeFileSync(configPath, '{ "mcp": {} }\n', 'utf8');
@@ -679,10 +698,10 @@ describe('Maker CLI commands', () => {
     expect(config.mcp['taptap-maker']).toEqual({
       type: 'local',
       command: expectedOpenCodeCommand,
+      environment: { TAPTAP_MCP_CLIENT_IDE: 'opencode' },
       enabled: true,
     });
     expect(config.mcp['taptap-maker']).not.toHaveProperty('env');
-    expect(config.mcp['taptap-maker']).not.toHaveProperty('environment');
   });
 
   test('explicit opencode mcp install does not create a missing config file', async () => {
@@ -735,7 +754,7 @@ describe('Maker CLI commands', () => {
     expect(config.mcpServers['taptap-maker']).toEqual({
       command: expectedNpxLaunch.command,
       args: expectedNpxLaunch.args,
-      env: { TAPTAP_MCP_ENV: 'rnd' },
+      env: { TAPTAP_MCP_ENV: 'rnd', TAPTAP_MCP_CLIENT_IDE: 'workbuddy' },
     });
   });
 
@@ -771,7 +790,7 @@ describe('Maker CLI commands', () => {
     expect(config.mcpServers['taptap-maker']).toEqual({
       command: expectedNpxLaunch.command,
       args: expectedNpxLaunch.args,
-      env: { TAPTAP_MCP_ENV: 'rnd' },
+      env: { TAPTAP_MCP_ENV: 'rnd', TAPTAP_MCP_CLIENT_IDE: 'workbuddy' },
     });
   });
 
@@ -807,6 +826,8 @@ describe('Maker CLI commands', () => {
       'stdio',
       '--env',
       'TAPTAP_MCP_ENV=rnd',
+      '--env',
+      'TAPTAP_MCP_CLIENT_IDE=claude',
       'taptap-maker',
       '--',
       expectedNpxLaunch.command,
@@ -1024,6 +1045,7 @@ describe('Maker CLI commands', () => {
       cwd: tempDir,
       env: {
         TAPTAP_MCP_ENV: 'rnd',
+        TAPTAP_MCP_CLIENT_IDE: 'cursor',
       },
     });
     const agents = fs.readFileSync(agentsPath, 'utf8');
@@ -1051,6 +1073,7 @@ describe('Maker CLI commands', () => {
       args: expectedNpxLaunch.args,
       env: {
         TAPTAP_MCP_ENV: 'rnd',
+        TAPTAP_MCP_CLIENT_IDE: 'cursor',
       },
     });
     expect(config.mcpServers['taptap-maker']).not.toHaveProperty('cwd');
@@ -1187,8 +1210,10 @@ describe('Maker CLI commands', () => {
     expect(config.mcpServers['taptap-maker']).toEqual({
       command: expectedNpxLaunch.command,
       args: expectedNpxLaunch.args,
+      env: {
+        TAPTAP_MCP_CLIENT_IDE: 'cursor',
+      },
     });
-    expect(config.mcpServers['taptap-maker']).not.toHaveProperty('env');
     expect(config.mcpServers['taptap-maker']).not.toHaveProperty('cwd');
   });
 

--- a/src/__tests__/makerSkillInstall.test.ts
+++ b/src/__tests__/makerSkillInstall.test.ts
@@ -85,7 +85,7 @@ describe('Maker bundled workflow skill documents', () => {
     expect(skillText).toContain('committed-but-unpushed local commits');
     expect(skillText).toContain('chore: wake maker build server');
     expect(skillText).toContain('confirm_remote_build_without_submit=true');
-    expect(skillText).toContain('maker_page_url');
+    expect(skillText).not.toContain('maker_page_url');
     expect(skillText).toContain('push_recovery');
     expect(skillText).toContain('Do not ask for permission to run a generic `git push`');
     expect(skillText).toContain('Maker Git Workflow Policy');
@@ -163,7 +163,9 @@ describe('Maker bundled workflow skill documents', () => {
     expect(skillText).toContain('用户可以直接说“提交”或“构建”');
     expect(skillText).toContain('taptap-maker dev-kit update');
     expect(skillText).toContain('maker_build_current_directory');
-    expect(skillText).toContain('TapMaker 网页端查看结果');
+    expect(skillText).toContain('验证游戏效果');
+    expect(skillText).toContain('Do not auto-open TapMaker pages');
+    expect(skillText).not.toContain('TapMaker 网页端查看结果');
     expect(skillText).not.toContain('maker_clone_to_current_directory');
     expect(skillText).not.toContain('maker_status`');
   });

--- a/src/__tests__/mcpProxyLifecycle.test.ts
+++ b/src/__tests__/mcpProxyLifecycle.test.ts
@@ -48,6 +48,19 @@ describe('standalone MCP proxy lifecycle guards', () => {
     expect((proxy as any).isNetworkError(serverBuildError)).toBe(false);
   });
 
+  test('classifies MCP disconnect errors as reconnectable network errors', () => {
+    const proxy = new TapTapMCPProxy(createProxyConfig());
+    const notConnectedError = Object.assign(new Error('MCP error -32000: not connected'), {
+      code: -32000,
+    });
+    const sessionExpiredError = Object.assign(new Error('MCP error -32000: session expired'), {
+      code: -32000,
+    });
+
+    expect((proxy as any).isNetworkError(notConnectedError)).toBe(true);
+    expect((proxy as any).isNetworkError(sessionExpiredError)).toBe(true);
+  });
+
   test('cleans up and exits when stdin closes', () => {
     const stdin = new PassThrough();
     const cleanup = jest.fn();

--- a/src/__tests__/mcpProxyLifecycle.test.ts
+++ b/src/__tests__/mcpProxyLifecycle.test.ts
@@ -31,6 +31,23 @@ describe('standalone MCP proxy lifecycle guards', () => {
     expect(DEFAULT_TOOL_CALL_TIMEOUT_MS).toBe(60 * 60 * 1000);
   });
 
+  test('does not classify MCP server build errors as reconnectable network errors', () => {
+    const proxy = new TapTapMCPProxy(createProxyConfig());
+    const serverBuildError = Object.assign(
+      new Error('MCP error -32603: build failed before timeout window'),
+      {
+        code: -32603,
+        data: {
+          remote_result: {
+            error: 'BUILD FAILED: lua syntax error',
+          },
+        },
+      }
+    );
+
+    expect((proxy as any).isNetworkError(serverBuildError)).toBe(false);
+  });
+
   test('cleans up and exits when stdin closes', () => {
     const stdin = new PassThrough();
     const cleanup = jest.fn();

--- a/src/maker/cli/commands.ts
+++ b/src/maker/cli/commands.ts
@@ -1638,10 +1638,15 @@ function installMcpConfigUnsafe(ide: string, options: McpInstallOptions): McpIns
   }
 
   if (ide === 'workbuddy') {
-    return installJsonMcpConfigTargets(ide, getWorkBuddyMcpInstallPaths(), 'WorkBuddy', {
-      ...options,
-      clientIde: 'workbuddy',
-    });
+    return installJsonMcpConfigTargets(
+      ide,
+      getWorkBuddyMcpInstallPaths({ createPrimary: true }),
+      'WorkBuddy',
+      {
+        ...options,
+        clientIde: 'workbuddy',
+      }
+    );
   }
 
   return [{ ide, ok: false, message: `Skipped unknown IDE: ${ide}` }];
@@ -1783,19 +1788,16 @@ function getOpenCodeMcpConfigPath(): string {
   return path.join(os.homedir(), '.config', 'opencode', 'opencode.jsonc');
 }
 
-function getWorkBuddyMcpInstallPaths(): string[] {
+function getWorkBuddyMcpInstallPaths(options: { createPrimary?: boolean } = {}): string[] {
   const primary = path.join(os.homedir(), '.workbuddy', 'mcp.json');
-  const runtime = path.join(os.homedir(), '.workbuddy', '.mcp.json');
-  const preferred = process.platform === 'win32' ? primary : runtime;
-  const fallback = process.platform === 'win32' ? runtime : primary;
-  const paths: string[] = [];
-  if (fs.existsSync(preferred)) {
-    paths.push(preferred);
+  if (fs.existsSync(primary) || options.createPrimary) {
+    return [primary];
   }
-  if (fs.existsSync(fallback)) {
-    paths.push(fallback);
+  const legacy = path.join(os.homedir(), '.workbuddy', '.mcp.json');
+  if (fs.existsSync(legacy)) {
+    return [legacy];
   }
-  return paths;
+  return [];
 }
 
 function mergeJsonMcpConfig(configPath: string, options: McpInstallOptions): ConfigWriteResult {

--- a/src/maker/cli/commands.ts
+++ b/src/maker/cli/commands.ts
@@ -143,6 +143,14 @@ type McpInstallResult = {
   backupPath?: string;
 };
 
+type McpInstallOptions = {
+  env: MakerEnvironment;
+  pkg: string;
+  mcpName: string;
+  cwd?: string;
+  clientIde?: string;
+};
+
 export async function runMakerCli(argv: string[]): Promise<void> {
   const parsed = parseArgs(argv);
   setMakerEnvironmentOverride(makerEnvOption(parsed));
@@ -1559,10 +1567,7 @@ function installMcpConfigs(options: {
   return uniqueStrings(options.ides).flatMap((ide) => installMcpConfig(ide, options));
 }
 
-function installMcpConfig(
-  ide: string,
-  options: { env: MakerEnvironment; pkg: string; mcpName: string; cwd?: string }
-): McpInstallResult[] {
+function installMcpConfig(ide: string, options: McpInstallOptions): McpInstallResult[] {
   try {
     return installMcpConfigUnsafe(ide, options);
   } catch (error) {
@@ -1578,25 +1583,23 @@ function installMcpConfig(
   }
 }
 
-function installMcpConfigUnsafe(
-  ide: string,
-  options: { env: MakerEnvironment; pkg: string; mcpName: string; cwd?: string }
-): McpInstallResult[] {
+function installMcpConfigUnsafe(ide: string, options: McpInstallOptions): McpInstallResult[] {
   if (ide === 'codex') {
     const configPath = path.join(os.homedir(), '.codex', 'config.toml');
-    const write = mergeCodexMcpConfig(configPath, options);
+    const write = mergeCodexMcpConfig(configPath, withClientIde(options, 'codex'));
     return [createMcpInstallResult(ide, 'Codex', configPath, write)];
   }
 
   if (ide === 'cursor') {
     const configPath = path.join(os.homedir(), '.cursor', 'mcp.json');
-    const write = mergeJsonMcpConfig(configPath, options);
+    const write = mergeJsonMcpConfig(configPath, withClientIde(options, 'cursor'));
     return [createMcpInstallResult(ide, 'Cursor', configPath, write)];
   }
 
   if (ide === 'claude') {
+    const claudeOptions = withClientIde(options, 'claude');
     if (!options.cwd) {
-      const claudeResult = tryClaudeMcpAdd(options);
+      const claudeResult = tryClaudeMcpAdd(claudeOptions);
       if (claudeResult.ok) {
         return [
           {
@@ -1608,12 +1611,17 @@ function installMcpConfigUnsafe(
       }
     }
     const configPath = path.join(os.homedir(), '.claude.json');
-    const write = mergeJsonMcpConfig(configPath, options);
+    const write = mergeJsonMcpConfig(configPath, claudeOptions);
     return [createMcpInstallResult(ide, 'Claude fallback', configPath, write)];
   }
 
   if (ide === 'trae') {
-    return installJsonMcpConfigTargets(ide, getTraeMcpInstallPaths(), 'Trae', options);
+    return installJsonMcpConfigTargets(
+      ide,
+      getTraeMcpInstallPaths(),
+      'Trae',
+      withClientIde(options, 'trae')
+    );
   }
 
   if (ide === 'opencode') {
@@ -1621,7 +1629,7 @@ function installMcpConfigUnsafe(
     if (!fs.existsSync(configPath)) {
       return [{ ide, ok: false, message: 'Skipped OpenCode: no supported config file found' }];
     }
-    const write = mergeOpenCodeMcpConfig(configPath, options);
+    const write = mergeOpenCodeMcpConfig(configPath, withClientIde(options, 'opencode'));
     const result = createMcpInstallResult(ide, 'OpenCode', configPath, write);
     if (write.rewroteJsonc) {
       result.message += '\n  Note: OpenCode config was rewritten as standard JSON.';
@@ -1630,17 +1638,24 @@ function installMcpConfigUnsafe(
   }
 
   if (ide === 'workbuddy') {
-    return installJsonMcpConfigTargets(ide, getWorkBuddyMcpInstallPaths(), 'WorkBuddy', options);
+    return installJsonMcpConfigTargets(ide, getWorkBuddyMcpInstallPaths(), 'WorkBuddy', {
+      ...options,
+      clientIde: 'workbuddy',
+    });
   }
 
   return [{ ide, ok: false, message: `Skipped unknown IDE: ${ide}` }];
+}
+
+function withClientIde(options: McpInstallOptions, clientIde: string): McpInstallOptions {
+  return { ...options, clientIde };
 }
 
 function installJsonMcpConfigTargets(
   ide: string,
   configPaths: string[],
   label: string,
-  options: { env: MakerEnvironment; pkg: string; mcpName: string; cwd?: string }
+  options: McpInstallOptions
 ): McpInstallResult[] {
   if (configPaths.length === 0) {
     return [{ ide, ok: false, message: `Skipped ${label}: no supported config file found` }];
@@ -1783,10 +1798,7 @@ function getWorkBuddyMcpInstallPaths(): string[] {
   return paths;
 }
 
-function mergeJsonMcpConfig(
-  configPath: string,
-  options: { env: MakerEnvironment; pkg: string; mcpName: string; cwd?: string }
-): ConfigWriteResult {
+function mergeJsonMcpConfig(configPath: string, options: McpInstallOptions): ConfigWriteResult {
   const existing = readJsonObject(configPath);
   const mcpServers = asObject(existing.mcpServers);
   mcpServers[options.mcpName] = createJsonMcpServerConfig(options);
@@ -1798,10 +1810,7 @@ function mergeJsonMcpConfig(
   );
 }
 
-function mergeOpenCodeMcpConfig(
-  configPath: string,
-  options: { env: MakerEnvironment; pkg: string; mcpName: string; cwd?: string }
-): ConfigWriteResult {
+function mergeOpenCodeMcpConfig(configPath: string, options: McpInstallOptions): ConfigWriteResult {
   const rawContent = fs.readFileSync(configPath, 'utf8');
   const rewroteJsonc = normalizeJsonConfigContent(rawContent, { jsonc: true }) !== rawContent;
   const existing = readJsonObject(configPath, { jsonc: true });
@@ -1831,18 +1840,20 @@ function mergeOpenCodeMcpConfig(
   return { ...write, rewroteJsonc: write.changed && rewroteJsonc };
 }
 
-function mergeCodexMcpConfig(
-  configPath: string,
-  options: { env: MakerEnvironment; pkg: string; mcpName: string; cwd?: string }
-): ConfigWriteResult {
+function mergeCodexMcpConfig(configPath: string, options: McpInstallOptions): ConfigWriteResult {
   const existing = fs.existsSync(configPath) ? fs.readFileSync(configPath, 'utf8') : '';
   const sectionPattern = createCodexMcpSectionPattern(options.mcpName);
   const withoutOld = existing.replace(sectionPattern, '').trimEnd();
   const launch = getNpxCliCommand(options.pkg);
+  const envValues = createMcpEnvironmentValues(options.env, options.clientIde);
   const envSection =
-    options.env === 'production'
+    Object.keys(envValues).length === 0
       ? []
-      : ['', `[mcp_servers."${options.mcpName}".env]`, `TAPTAP_MCP_ENV = "${options.env}"`];
+      : [
+          '',
+          `[mcp_servers."${options.mcpName}".env]`,
+          ...Object.entries(envValues).map(([key, value]) => `${key} = "${escapeToml(value)}"`),
+        ];
   const section = [
     `[mcp_servers."${options.mcpName}"]`,
     `command = "${escapeToml(launch.command)}"`,
@@ -1911,9 +1922,7 @@ function normalizeCodexMcpTablePath(tablePath: string, mcpName: string): string 
   return `mcp_servers.${mcpName}${match[1] || ''}`;
 }
 
-function tryClaudeMcpAdd(options: { env: MakerEnvironment; pkg: string; mcpName: string }): {
-  ok: boolean;
-} {
+function tryClaudeMcpAdd(options: McpInstallOptions): { ok: boolean } {
   const npxLaunch = getNpxCliCommand(options.pkg);
   const claudeArgs = [
     'mcp',
@@ -1923,6 +1932,7 @@ function tryClaudeMcpAdd(options: { env: MakerEnvironment; pkg: string; mcpName:
     '--transport',
     'stdio',
     ...(options.env === 'production' ? [] : ['--env', `TAPTAP_MCP_ENV=${options.env}`]),
+    ...(options.clientIde ? ['--env', `TAPTAP_MCP_CLIENT_IDE=${options.clientIde}`] : []),
     options.mcpName,
     '--',
     ...npxLaunch.commandAndArgs,
@@ -1936,7 +1946,7 @@ function tryClaudeMcpAdd(options: { env: MakerEnvironment; pkg: string; mcpName:
   return { ok: result.status === 0 };
 }
 
-function createJsonMcpServerConfig(options: { env: MakerEnvironment; pkg: string; cwd?: string }): {
+function createJsonMcpServerConfig(options: McpInstallOptions): {
   command: string;
   args: string[];
   cwd?: string;
@@ -1947,36 +1957,52 @@ function createJsonMcpServerConfig(options: { env: MakerEnvironment; pkg: string
     command: launch.command,
     args: launch.args,
     ...(options.cwd ? { cwd: options.cwd } : {}),
-    ...createOptionalMcpEnvironment(options.env, 'env'),
+    ...createOptionalMcpEnvironment(options.env, 'env', options.clientIde),
   };
 }
 
-function createOpenCodeMcpServerConfig(options: { pkg: string; cwd?: string }): {
+function createOpenCodeMcpServerConfig(options: McpInstallOptions): {
   type: 'local';
   command: string[];
   cwd?: string;
   enabled: true;
+  environment?: Record<string, string>;
 } {
   return {
     type: 'local',
     command: getOpenCodeNpxCliCommand(options.pkg),
     ...(options.cwd ? { cwd: options.cwd } : {}),
+    ...createOptionalMcpEnvironment(options.env, 'environment', options.clientIde),
     enabled: true,
   };
 }
 
 function createOptionalMcpEnvironment<Key extends 'env' | 'environment'>(
   env: MakerEnvironment,
-  key: Key
+  key: Key,
+  clientIde?: string
 ): Record<Key, Record<string, string>> | Record<string, never> {
-  if (env === 'production') {
+  const values = createMcpEnvironmentValues(env, clientIde);
+  if (Object.keys(values).length === 0) {
     return {};
   }
   return {
-    [key]: {
-      TAPTAP_MCP_ENV: env,
-    },
+    [key]: values,
   } as Record<Key, Record<string, string>>;
+}
+
+function createMcpEnvironmentValues(
+  env: MakerEnvironment,
+  clientIde?: string
+): Record<string, string> {
+  const values: Record<string, string> = {};
+  if (env !== 'production') {
+    values.TAPTAP_MCP_ENV = env;
+  }
+  if (clientIde) {
+    values.TAPTAP_MCP_CLIENT_IDE = clientIde;
+  }
+  return values;
 }
 
 function getOpenCodeNpxCliCommand(pkg: string): string[] {

--- a/src/maker/server/mcp.ts
+++ b/src/maker/server/mcp.ts
@@ -2271,14 +2271,68 @@ function parseJsonObjectFromText(text: string): Record<string, unknown> | undefi
   if (!trimmed) {
     return undefined;
   }
-  try {
-    const parsed = JSON.parse(trimmed);
-    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
-      ? (parsed as Record<string, unknown>)
-      : undefined;
-  } catch {
-    return undefined;
+  for (const candidate of extractJsonObjectCandidates(trimmed)) {
+    try {
+      const parsed = JSON.parse(candidate);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Try the next candidate from multi-part MCP text.
+    }
   }
+  return undefined;
+}
+
+function extractJsonObjectCandidates(text: string): string[] {
+  const candidates = new Set<string>([text]);
+  const fencedJsonPattern = /```(?:json)?\s*([\s\S]*?)```/gi;
+  let fencedMatch: RegExpExecArray | null;
+  while ((fencedMatch = fencedJsonPattern.exec(text)) !== null) {
+    const candidate = fencedMatch[1]?.trim();
+    if (candidate) {
+      candidates.add(candidate);
+    }
+  }
+
+  let start = -1;
+  let depth = 0;
+  let inString = false;
+  let escaping = false;
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (inString) {
+      if (escaping) {
+        escaping = false;
+      } else if (char === '\\') {
+        escaping = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (char === '{') {
+      if (depth === 0) {
+        start = index;
+      }
+      depth += 1;
+      continue;
+    }
+    if (char === '}' && depth > 0) {
+      depth -= 1;
+      if (depth === 0 && start >= 0) {
+        candidates.add(text.slice(start, index + 1));
+        start = -1;
+      }
+    }
+  }
+
+  return [...candidates].map((candidate) => candidate.trim()).filter(Boolean);
 }
 
 function attachAsyncBuildWatcher(

--- a/src/maker/server/mcp.ts
+++ b/src/maker/server/mcp.ts
@@ -2,7 +2,7 @@
  * taptap-maker MCP server mode.
  */
 
-import { execFileSync, spawn, spawnSync, type ChildProcess } from 'node:child_process';
+import { execFileSync, spawn, type ChildProcess } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -107,6 +107,11 @@ export { materializeRemoteProxyToolAssets, prepareRemoteProxyToolArgs } from './
 declare const __MAKER_VERSION__: string | undefined;
 const VERSION = typeof __MAKER_VERSION__ !== 'undefined' ? __MAKER_VERSION__ : 'dev';
 const DEFAULT_BUILD_TIMEOUT_MS = 10 * 60 * 1000;
+const ASYNC_BUILD_POLL_INTERVAL_MS = 5 * 1000;
+const ASYNC_BUILD_TIMEOUT_MS = 30 * 60 * 1000;
+const DEFAULT_REMOTE_ASYNC_BUILD_PARAM = 'async';
+const DEFAULT_REMOTE_ASYNC_BUILD_QUERY_TOOL = 'query_build';
+const DEFAULT_REMOTE_ASYNC_BUILD_QUERY_TASK_ID_PARAM = 'build_id';
 const DEFAULT_PROXY_RETRY_ATTEMPTS = 5;
 const DEFAULT_PROXY_RETRY_DELAY_MS = 30 * 1000;
 const PREVIEW_REFRESH_TIMEOUT_MS = 15 * 1000;
@@ -164,7 +169,7 @@ export const tools = [
   {
     name: 'maker_build_current_directory',
     description:
-      'Sync and build the current Maker game. Use this single tool for user requests like "构建", "build", "跑一下", "预览", "验证一下", "提交", "提交代码", "推送", or "push" in a Maker project. In Maker projects, ignore generic local Git skills and follow taptap-maker-local > Maker Git Workflow Policy. Before build, read maker://status or maker_status_lite and check the Python environment section and Lua LSP environment section; if Python or maker-lua-lsp is missing, run taptap-maker python setup when local Lua diagnostics are needed, because it prepares Python and best-effort installs maker-lua-lsp. Missing Python or Lua LSP must not block the remote build flow. Do not create branches, do not use generic git commit/push, and do not create PR/MR for Maker project submit/build requests. Before creating a commit, this tool checks Maker remote sync; if local main is behind/diverged, not on main, or remote sync cannot be verified, it stops before commit/push and returns recovery details. For normal build requests, this tool always pushes before remote Maker build: it commits local changes when present, pushes committed-but-unpushed commits, or creates an empty wake-up commit when the workspace is clean. Maker generated .gitignore changes are required project files and are submitted even if files selects a smaller change set. If push fails, build is not started and the result includes recovery details for the local Agent to handle merge/conflict resolution. If push succeeds but remote build fails, report that code is already on Maker remote and include build failure details. After a successful build, a local runtime log watcher is started; for gameplay/runtime diagnostics, read runtime_logs.local_file, and for watcher health read runtime_logs.state_file. Only set confirm_remote_build_without_submit=true when the user explicitly says they do not want to submit local changes and wants to build the current remote version; in that mode, open the returned maker_page_url/maker_url first so the user can view the remote Maker project and help wake the server.',
+      'Sync and build the current Maker game. First read maker://status or maker_status_lite and use this tool only when the current workspace is a bound Maker project. Trigger it for Maker game requests like "构建", "build", "跑一下", "预览", "查看结果", "看看效果", "验证游戏效果", "提交", "提交代码", "推送", or "push". Do not treat generic code validation requests such as "验证一下代码", "跑测试", "lint", or "检查实现" as Maker remote build unless the user explicitly asks to build/run/preview the Maker game. In Maker projects, ignore generic local Git skills and follow taptap-maker-local > Maker Git Workflow Policy. Before build, check the Python environment section and Lua LSP environment section; if Python or maker-lua-lsp is missing, run taptap-maker python setup when local Lua diagnostics are needed, because it prepares Python and best-effort installs maker-lua-lsp. Missing Python or Lua LSP must not block the remote build flow. Do not create branches, do not use generic git commit/push, and do not create PR/MR for Maker project submit/build requests. Before creating a commit, this tool checks Maker remote sync; if local main is behind/diverged, not on main, or remote sync cannot be verified, it stops before commit/push and returns recovery details. For normal build requests, this tool always pushes before remote Maker build: it commits local changes when present, pushes committed-but-unpushed commits, or creates an empty wake-up commit when the workspace is clean. Maker generated .gitignore changes are required project files and are submitted even if files selects a smaller change set. If push fails, build is not started and the result includes recovery details for the local Agent to handle merge/conflict resolution. If push succeeds but remote build fails, report that code is already on Maker remote and include build failure details. After a successful build, a local runtime log watcher is started; for gameplay/runtime diagnostics, read runtime_logs.local_file, and for watcher health read runtime_logs.state_file. Only set confirm_remote_build_without_submit=true when the user explicitly says they do not want to submit local changes and wants to build the current remote version; this mode does not submit local changes and does not auto-open Maker pages.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -213,6 +218,11 @@ export const tools = [
           description:
             'Optional remote build timeout in milliseconds. Defaults to 10 minutes. If timed out, do not retry blindly; inspect remote build logs first.',
         },
+        async_build: {
+          type: 'boolean',
+          description:
+            'Async remote build preference. If true, Maker MCP forwards remote build async:true in any IDE. If false, it keeps synchronous remote build. If omitted, WorkBuddy defaults to async and other IDEs default to sync. For async builds, this tool keeps the current MCP call open, polls query_build(build_id) every 5 seconds, and returns only after success, failure, replacement by a newer build, or 30 minutes.',
+        },
         message: {
           type: 'string',
           description:
@@ -227,7 +237,7 @@ export const tools = [
         confirm_remote_build_without_submit: {
           type: 'boolean',
           description:
-            'Set true only after the user explicitly confirms they do not want to submit local changes and want to build the current Maker remote committed version. This mode opens and returns the Maker app page URL before remote build.',
+            'Set true only after the user explicitly confirms they do not want to submit local changes and want to build the current Maker remote committed version. This mode does not submit local changes and does not auto-open Maker pages.',
         },
       },
     },
@@ -581,6 +591,7 @@ export async function startMakerMcpServer(): Promise<void> {
           server_url?: string;
           env?: 'rnd' | 'production';
           timeout_ms?: number;
+          async_build?: boolean;
           message?: string;
           files?: string[];
           confirm_remote_build_without_submit?: boolean;
@@ -609,6 +620,7 @@ export async function startMakerMcpServer(): Promise<void> {
             serverUrl: args.server_url,
             env: args.env,
             timeoutMs: args.timeout_ms,
+            asyncBuild: args.async_build,
             message: args.message,
             files: args.files,
             confirmRemoteBuildWithoutSubmit: args.confirm_remote_build_without_submit,
@@ -808,6 +820,8 @@ async function formatStatus(
     '',
     remoteSyncText,
     '',
+    identify.projectRoot ? formatAsyncBuildStatus(identify.projectRoot) : '',
+    '',
     identify.projectRoot
       ? await formatMakerProxyToolsStatusSafely({ targetDir: identify.projectRoot })
       : '',
@@ -828,6 +842,38 @@ async function formatStatus(
     formatMakerSkillStatus({ projectRoot: identify.projectRoot || targetDir }),
     '',
     projectSection,
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+function formatAsyncBuildStatus(projectRoot: string): string {
+  const active = readJsonFile(getAsyncBuildWatcherPaths(projectRoot, 'unused').activeFile) as
+    | { taskId?: string; stateFile?: string; deadlineAt?: string; pid?: number; reused?: boolean }
+    | undefined;
+  if (!active?.taskId) {
+    return ['Maker async build', '', '- status: inactive'].join('\n');
+  }
+  const stale = active.pid !== undefined && active.pid !== process.pid;
+  const state = active.stateFile
+    ? (readJsonFile(active.stateFile) as AsyncBuildWatcherState)
+    : undefined;
+  return [
+    'Maker async build',
+    '',
+    `- status: ${stale ? 'stale' : 'active'}`,
+    `- build_id: ${active.taskId}`,
+    active.reused !== undefined ? `- reused: ${active.reused ? 'yes' : 'no'}` : '',
+    active.pid ? `- watcher_pid: ${active.pid}` : '',
+    stale
+      ? '- note: active marker belongs to a previous MCP process; polling is not durable after restart'
+      : '',
+    active.stateFile ? `- state_file: ${active.stateFile}` : '',
+    active.deadlineAt ? `- deadline_at: ${active.deadlineAt}` : '',
+    state?.status ? `- last_status: ${state.status}` : '',
+    state?.updatedAt ? `- updated_at: ${state.updatedAt}` : '',
+    `- poll_interval_ms: ${ASYNC_BUILD_POLL_INTERVAL_MS}`,
+    `- timeout_ms: ${ASYNC_BUILD_TIMEOUT_MS}`,
   ]
     .filter(Boolean)
     .join('\n');
@@ -1748,16 +1794,16 @@ type SubmitLocalChangesForBuild = (
 ) => Promise<PushMakerProjectResult>;
 
 type RemoteBuildResult = Extract<BuildCurrentDirectoryResult, { mode: 'remote_build' }>;
-type MakerPageOpenResult = {
-  ok: boolean;
-  url: string;
-  error?: string;
-};
-type OpenMakerPage = (url: string) => MakerPageOpenResult;
+type RemoteBuildAsyncStartedResult = Extract<
+  BuildCurrentDirectoryResult,
+  { mode: 'remote_build_async_started' }
+>;
+type RemoteBuildCallResult = RemoteBuildResult | RemoteBuildAsyncStartedResult;
 type MakerBuildFailure = {
   name: string;
   message: string;
   stack?: string;
+  [key: string]: unknown;
 };
 type PreviewRefreshResult = {
   ok: boolean;
@@ -1786,6 +1832,64 @@ type RuntimeLogWatcherPidState = {
   startedAt?: string;
   legacy?: boolean;
 };
+type AsyncBuildQueryStatus = 'queued' | 'running' | 'succeeded' | 'failed';
+type AsyncBuildQueryResult = {
+  status: AsyncBuildQueryStatus;
+  resultText?: string;
+  result?: unknown;
+  error?: unknown;
+};
+type AsyncBuildWatcherStateStatus =
+  | AsyncBuildQueryStatus
+  | 'timeout'
+  | 'expired'
+  | 'cancelled'
+  | 'cancelled_by_new_build'
+  | 'poll_failed';
+type AsyncBuildWatcherState = {
+  mode: 'remote_build_async';
+  taskId: string;
+  reused?: boolean;
+  projectId: string;
+  projectPath: string;
+  projectRoot: string;
+  serverUrl: string;
+  env: string;
+  status: AsyncBuildWatcherStateStatus;
+  startedAt: string;
+  updatedAt: string;
+  deadlineAt: string;
+  pollIntervalMs: number;
+  resultText?: string;
+  result?: unknown;
+  error?: unknown;
+  lastPollError?: string;
+  sideEffectError?: string;
+  previewRefresh?: PreviewRefreshResult;
+  runtimeLogWatch?: RuntimeLogWatchStartResult;
+};
+type AsyncBuildWatcherStartResult = {
+  started: boolean;
+  taskId: string;
+  reused?: boolean;
+  activeFile: string;
+  stateFile: string;
+  pollIntervalMs: number;
+  timeoutMs: number;
+  previousTaskId?: string;
+  previousStopped?: boolean;
+  error?: string;
+};
+type ActiveAsyncBuildWatcher = {
+  timer?: NodeJS.Timeout;
+  stopped?: boolean;
+  state: AsyncBuildWatcherState;
+  activeFile: string;
+  stateFile: string;
+  onStop?: () => Promise<void> | void;
+  completion?: Promise<AsyncBuildWatcherState>;
+  complete?: (state: AsyncBuildWatcherState) => void;
+};
 type StopRuntimeLogWatcherOptions = {
   getProcessCommand?: (pid: number) => string | undefined;
   waitForExit?: (pid: number, timeoutMs: number) => boolean;
@@ -1796,48 +1900,11 @@ type RemoteRuntimeLogClient = {
   call: (args: RuntimeLogQueryArgs) => Promise<RuntimeLogQueryResult>;
   close: () => Promise<void>;
 };
+const activeAsyncBuildWatchers = new Map<string, ActiveAsyncBuildWatcher>();
 
 function formatMakerAppWebUrl(projectId: string, env: string): string {
   const makerEnv = env === 'rnd' || env === 'production' ? env : undefined;
   return `${getMakerWebUrl(makerEnv)}/app/${encodeURIComponent(projectId)}`;
-}
-
-function openRemoteBuildMakerPage(options: {
-  targetDir: string;
-  env?: 'rnd' | 'production';
-  openMakerPage?: OpenMakerPage;
-}): MakerPageOpenResult {
-  const identify = identifyMakerProject({ cwd: options.targetDir });
-  if (!identify.projectRoot || !identify.projectId) {
-    throw new Error(
-      `${options.targetDir} is not bound to a Maker project. Run taptap-maker init first.`
-    );
-  }
-  const projectConfig = loadProjectConfig(identify.projectRoot);
-  const projectId = projectConfig?.project_id || identify.projectId;
-  const env = getMakerEnvironment(options.env, identify.projectRoot);
-  const url = formatMakerAppWebUrl(projectId, env);
-  return (options.openMakerPage || openMakerPageInBrowser)(url);
-}
-
-function openMakerPageInBrowser(url: string): MakerPageOpenResult {
-  const command =
-    process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'cmd' : 'xdg-open';
-  const args = process.platform === 'win32' ? ['/c', 'start', '', url] : [url];
-  const result = spawnSync(command, args, {
-    stdio: 'ignore',
-    windowsHide: true,
-    timeout: 5000,
-  });
-  if (result.error || result.status !== 0) {
-    return {
-      ok: false,
-      url,
-      error:
-        result.error?.message || `open command exited with status ${result.status ?? 'unknown'}`,
-    };
-  }
-  return { ok: true, url };
 }
 
 type BuildCurrentDirectoryResult =
@@ -1855,7 +1922,22 @@ type BuildCurrentDirectoryResult =
       previewRefresh?: PreviewRefreshResult;
       runtimeLogWatch?: RuntimeLogWatchStartResult;
       submitResult?: PushMakerProjectResult;
-      makerPageOpen?: MakerPageOpenResult;
+    }
+  | {
+      mode: 'remote_build_async_started';
+      projectRoot: string;
+      projectId: string;
+      projectPath: string;
+      serverUrl: string;
+      env: string;
+      makerUrl?: string;
+      timeoutMs: number;
+      buildArgs: Record<string, unknown>;
+      taskId: string;
+      reused?: boolean;
+      resultText: string;
+      asyncBuildWatch?: AsyncBuildWatcherStartResult;
+      submitResult?: PushMakerProjectResult;
     }
   | {
       mode: 'remote_build_failed';
@@ -1863,7 +1945,6 @@ type BuildCurrentDirectoryResult =
       projectId: string;
       buildResult: RemoteBuildResult;
       buildFailure: MakerBuildFailure;
-      makerPageOpen?: MakerPageOpenResult;
     }
   | {
       mode: 'submit_failed_before_build';
@@ -1899,14 +1980,16 @@ export async function buildCurrentDirectory(options: {
   serverUrl?: string;
   env?: 'rnd' | 'production';
   timeoutMs?: number;
+  asyncBuild?: boolean;
   message?: string;
   files?: string[];
   confirmRemoteBuildWithoutSubmit?: boolean;
   submitLocalChanges?: SubmitLocalChangesForBuild;
-  callRemoteBuild?: (targetDir: string) => Promise<RemoteBuildResult>;
-  openMakerPage?: OpenMakerPage;
+  callRemoteBuild?: (targetDir: string) => Promise<RemoteBuildCallResult>;
+  queryAsyncBuildResult?: (taskId: string) => Promise<AsyncBuildQueryResult>;
   refreshPreview?: RefreshMakerPreview;
   startRuntimeLogWatch?: StartRuntimeLogWatch;
+  asyncBuildPollIntervalMs?: number;
   onProgress?: MakerProjectProgressHandler;
 }): Promise<BuildCurrentDirectoryResult> {
   const localChanges = await readMakerProjectLocalChanges(options.targetDir);
@@ -1937,7 +2020,7 @@ export async function buildCurrentDirectory(options: {
         submitResult,
       };
     }
-    let buildResult: RemoteBuildResult;
+    let buildResult: RemoteBuildCallResult;
     try {
       buildResult = await runRemoteBuildCurrentDirectory(options, localChanges.projectRoot);
     } catch (error) {
@@ -1949,18 +2032,34 @@ export async function buildCurrentDirectory(options: {
         buildFailure: toMakerBuildFailure(error),
       };
     }
+    if (buildResult.mode === 'remote_build_async_started') {
+      try {
+        return {
+          ...(await attachAndWaitAsyncBuildResult(buildResult, options)),
+          submitResult,
+        };
+      } catch (error) {
+        return {
+          mode: 'build_failed_after_submit',
+          projectRoot: localChanges.projectRoot,
+          projectId: config?.project_id || 'unknown',
+          submitResult,
+          buildFailure: toMakerBuildFailure(error),
+        };
+      }
+    }
     return {
       ...buildResult,
       submitResult,
     };
   }
 
-  const makerPageOpen = openRemoteBuildMakerPage(options);
   try {
-    return {
-      ...(await runRemoteBuildCurrentDirectory(options, options.targetDir)),
-      makerPageOpen,
-    };
+    const buildResult = await runRemoteBuildCurrentDirectory(options, options.targetDir);
+    if (buildResult.mode === 'remote_build_async_started') {
+      return await attachAndWaitAsyncBuildResult(buildResult, options);
+    }
+    return buildResult;
   } catch (error) {
     if (error instanceof RemoteBuildFailedError) {
       return {
@@ -1969,7 +2068,6 @@ export async function buildCurrentDirectory(options: {
         projectId: error.buildResult.projectId,
         buildResult: error.buildResult,
         buildFailure: toMakerBuildFailure(error),
-        makerPageOpen,
       };
     }
     throw error;
@@ -1987,17 +2085,22 @@ async function runRemoteBuildCurrentDirectory(
     serverUrl?: string;
     env?: 'rnd' | 'production';
     timeoutMs?: number;
-    callRemoteBuild?: (
-      targetDir: string
-    ) => Promise<Extract<BuildCurrentDirectoryResult, { mode: 'remote_build' }>>;
+    asyncBuild?: boolean;
+    callRemoteBuild?: (targetDir: string) => Promise<RemoteBuildCallResult>;
+    queryAsyncBuildResult?: (taskId: string) => Promise<AsyncBuildQueryResult>;
     refreshPreview?: RefreshMakerPreview;
     startRuntimeLogWatch?: StartRuntimeLogWatch;
+    asyncBuildPollIntervalMs?: number;
     onProgress?: MakerProjectProgressHandler;
   },
   targetDir: string
-): Promise<RemoteBuildResult> {
+): Promise<RemoteBuildCallResult> {
   if (options.callRemoteBuild) {
-    return attachBuildSuccessSideEffects(await options.callRemoteBuild(targetDir), {
+    const injectedResult = await options.callRemoteBuild(targetDir);
+    if (injectedResult.mode === 'remote_build_async_started') {
+      return injectedResult;
+    }
+    return attachBuildSuccessSideEffects(injectedResult, {
       refreshPreview: options.refreshPreview || skipPreviewRefresh,
       startRuntimeLogWatch: options.startRuntimeLogWatch,
     });
@@ -2009,6 +2112,7 @@ async function runRemoteBuildCurrentDirectory(
     env: options.env,
   });
   const buildArgs = createBuildArgs(proxy.projectRoot, options);
+  const asyncBuildForwarded = shouldForwardAsyncBuild(options.asyncBuild);
   const timeoutMs = options.timeoutMs || DEFAULT_BUILD_TIMEOUT_MS;
 
   const result = await retryMakerProxyOperation(
@@ -2071,24 +2175,288 @@ async function runRemoteBuildCurrentDirectory(
     throw new Error(formatRemoteToolResult(result));
   }
 
-  return attachBuildSuccessSideEffects(
-    {
-      mode: 'remote_build',
-      projectRoot: proxy.projectRoot,
-      projectId: proxy.projectId,
-      projectPath: proxy.projectPath,
-      serverUrl: proxy.serverUrl,
-      env: proxy.env,
-      makerUrl: formatMakerAppWebUrl(proxy.projectId, proxy.env),
-      timeoutMs,
-      buildArgs,
-      resultText: formatRemoteToolResult(result),
-    },
-    {
+  const resultText = formatRemoteToolResult(result);
+  const buildCallResult = createRemoteBuildCallResult({
+    projectRoot: proxy.projectRoot,
+    projectId: proxy.projectId,
+    projectPath: proxy.projectPath,
+    serverUrl: proxy.serverUrl,
+    env: proxy.env,
+    timeoutMs,
+    buildArgs,
+    resultText,
+    asyncBuild: asyncBuildForwarded,
+  });
+  if (buildCallResult.mode === 'remote_build_async_started') {
+    return buildCallResult;
+  }
+
+  return attachBuildSuccessSideEffects(buildCallResult, {
+    refreshPreview: options.refreshPreview,
+    startRuntimeLogWatch: options.startRuntimeLogWatch || startRuntimeLogWatch,
+  });
+}
+
+export function createRemoteBuildCallResult(options: {
+  projectRoot: string;
+  projectId: string;
+  projectPath: string;
+  serverUrl: string;
+  env: string;
+  timeoutMs: number;
+  buildArgs: Record<string, unknown>;
+  resultText: string;
+  asyncBuild?: boolean;
+}): RemoteBuildCallResult {
+  const asyncReceipt = options.asyncBuild
+    ? extractAsyncBuildReceipt(options.resultText)
+    : undefined;
+  const taskId = asyncReceipt?.taskId;
+  if (taskId) {
+    return {
+      mode: 'remote_build_async_started',
+      projectRoot: options.projectRoot,
+      projectId: options.projectId,
+      projectPath: options.projectPath,
+      serverUrl: options.serverUrl,
+      env: options.env,
+      makerUrl: formatMakerAppWebUrl(options.projectId, options.env),
+      timeoutMs: options.timeoutMs,
+      buildArgs: options.buildArgs,
+      taskId,
+      reused: asyncReceipt.reused,
+      resultText: options.resultText,
+    };
+  }
+  return {
+    mode: 'remote_build',
+    projectRoot: options.projectRoot,
+    projectId: options.projectId,
+    projectPath: options.projectPath,
+    serverUrl: options.serverUrl,
+    env: options.env,
+    makerUrl: formatMakerAppWebUrl(options.projectId, options.env),
+    timeoutMs: options.timeoutMs,
+    buildArgs: options.buildArgs,
+    resultText: options.resultText,
+  };
+}
+
+function extractAsyncBuildReceipt(
+  resultText: string
+): { taskId: string; reused?: boolean } | undefined {
+  const parsed = parseJsonObjectFromText(resultText);
+  const taskId =
+    parsed?.build_id ||
+    parsed?.buildId ||
+    parsed?.task_id ||
+    parsed?.taskId ||
+    parsed?.build_task_id ||
+    parsed?.buildTaskId;
+  if (typeof taskId !== 'string' || !taskId.trim()) {
+    return undefined;
+  }
+  return {
+    taskId: taskId.trim(),
+    ...(typeof parsed?.reused === 'boolean' ? { reused: parsed.reused } : {}),
+  };
+}
+
+function parseJsonObjectFromText(text: string): Record<string, unknown> | undefined {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(trimmed);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function attachAsyncBuildWatcher(
+  buildResult: RemoteBuildAsyncStartedResult,
+  options: {
+    queryAsyncBuildResult?: (taskId: string) => Promise<AsyncBuildQueryResult>;
+    refreshPreview?: RefreshMakerPreview;
+    startRuntimeLogWatch?: StartRuntimeLogWatch;
+    asyncBuildPollIntervalMs?: number;
+    onProgress?: MakerProjectProgressHandler;
+  }
+): RemoteBuildAsyncStartedResult {
+  const remoteQueryRunner = options.queryAsyncBuildResult
+    ? undefined
+    : createRemoteAsyncBuildQueryRunner(buildResult);
+  const queryBuildResult =
+    options.queryAsyncBuildResult ||
+    ((taskId: string): Promise<AsyncBuildQueryResult> =>
+      remoteQueryRunner?.query(taskId) ||
+      Promise.reject(new Error('Async build query runner is not available')));
+  return {
+    ...buildResult,
+    asyncBuildWatch: startAsyncBuildResultWatcher({
+      projectRoot: buildResult.projectRoot,
+      projectId: buildResult.projectId,
+      projectPath: buildResult.projectPath,
+      serverUrl: buildResult.serverUrl,
+      env: buildResult.env,
+      taskId: buildResult.taskId,
+      reused: buildResult.reused,
+      queryBuildResult: () => queryBuildResult(buildResult.taskId),
       refreshPreview: options.refreshPreview,
       startRuntimeLogWatch: options.startRuntimeLogWatch || startRuntimeLogWatch,
+      pollIntervalMs: options.asyncBuildPollIntervalMs,
+      onProgress: options.onProgress,
+      onStop: () => remoteQueryRunner?.close(),
+    }),
+  };
+}
+
+async function attachAndWaitAsyncBuildResult(
+  buildResult: RemoteBuildAsyncStartedResult,
+  options: {
+    queryAsyncBuildResult?: (taskId: string) => Promise<AsyncBuildQueryResult>;
+    refreshPreview?: RefreshMakerPreview;
+    startRuntimeLogWatch?: StartRuntimeLogWatch;
+    asyncBuildPollIntervalMs?: number;
+    onProgress?: MakerProjectProgressHandler;
+  }
+): Promise<RemoteBuildResult> {
+  const watched = attachAsyncBuildWatcher(buildResult, options);
+  const activeFile = watched.asyncBuildWatch?.activeFile;
+  const completion = activeFile ? activeAsyncBuildWatchers.get(activeFile)?.completion : undefined;
+  if (!completion) {
+    throw new Error('Async build watcher did not start');
+  }
+  const finalState = await completion;
+  const finalResult = asyncWatcherStateToRemoteBuildResult(finalState, buildResult);
+  if (finalState.status === 'succeeded') {
+    return finalResult;
+  }
+  if (finalState.status === 'failed') {
+    throw new RemoteBuildFailedError(finalResult);
+  }
+  throw new Error(
+    `Async Maker build did not finish successfully: ${finalState.status}${
+      finalState.error ? `: ${formatAsyncBuildDiagnostic(finalState.error)}` : ''
+    }`
+  );
+}
+
+function formatAsyncBuildDiagnostic(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function createRemoteAsyncBuildQueryRunner(buildResult: RemoteBuildAsyncStartedResult): {
+  query: (taskId: string) => Promise<AsyncBuildQueryResult>;
+  close: () => Promise<void>;
+} {
+  const proxy = createRemoteProxyContext({
+    targetDir: buildResult.projectRoot,
+    serverUrl: buildResult.serverUrl,
+    env:
+      buildResult.env === 'rnd' || buildResult.env === 'production' ? buildResult.env : undefined,
+  });
+  const queryToolName =
+    process.env.TAPTAP_MAKER_REMOTE_ASYNC_BUILD_QUERY_TOOL?.trim() ||
+    DEFAULT_REMOTE_ASYNC_BUILD_QUERY_TOOL;
+  const taskIdParam =
+    process.env.TAPTAP_MAKER_REMOTE_ASYNC_BUILD_QUERY_TASK_ID_PARAM?.trim() ||
+    DEFAULT_REMOTE_ASYNC_BUILD_QUERY_TASK_ID_PARAM;
+  const transport = trackMakerChildTransport(
+    new HiddenStdioClientTransport({
+      command: proxy.command,
+      args: proxy.args,
+      env: mergeStringEnv(process.env, proxy.envVars),
+      stderr: 'pipe',
+    })
+  );
+  const client = new Client(
+    {
+      name: 'taptap-maker-async-build-query-forwarder',
+      version: VERSION,
+    },
+    {
+      capabilities: {},
     }
   );
+  let connectPromise: Promise<void> | undefined;
+  const ensureConnected = async (): Promise<void> => {
+    if (!connectPromise) {
+      connectPromise = client.connect(transport);
+    }
+    await connectPromise;
+  };
+
+  return {
+    query: async (taskId: string): Promise<AsyncBuildQueryResult> => {
+      await ensureConnected();
+      const result = await client.callTool(
+        {
+          name: queryToolName,
+          arguments: { [taskIdParam]: taskId },
+        },
+        undefined,
+        {
+          timeout: DEFAULT_BUILD_TIMEOUT_MS,
+        }
+      );
+      return normalizeAsyncBuildQueryResult(result);
+    },
+    close: async (): Promise<void> => {
+      await client.close().catch(() => {});
+    },
+  };
+}
+
+function normalizeAsyncBuildQueryResult(result: unknown): AsyncBuildQueryResult {
+  const resultText = formatRemoteToolResult(result);
+  const parsed = parseJsonObjectFromText(resultText);
+  const status = normalizeAsyncBuildStatus(parsed?.status || parsed?.state || parsed?.phase);
+  if (status) {
+    return {
+      status,
+      resultText,
+      result: parsed,
+      error: parsed?.error,
+    };
+  }
+  return {
+    status: isRemoteToolError(result) ? 'failed' : 'running',
+    resultText,
+    result: parsed || result,
+    ...(isRemoteToolError(result) ? { error: resultText } : {}),
+  };
+}
+
+function normalizeAsyncBuildStatus(status: unknown): AsyncBuildQueryStatus | undefined {
+  if (typeof status !== 'string') {
+    return undefined;
+  }
+  const normalized = status.trim().toLowerCase();
+  if (['queued', 'pending', 'created'].includes(normalized)) {
+    return 'queued';
+  }
+  if (['running', 'building', 'in_progress', 'processing'].includes(normalized)) {
+    return 'running';
+  }
+  if (['succeeded', 'success', 'done', 'completed', 'finished'].includes(normalized)) {
+    return 'succeeded';
+  }
+  if (['failed', 'failure', 'error', 'cancelled', 'canceled'].includes(normalized)) {
+    return 'failed';
+  }
+  return undefined;
 }
 
 async function attachBuildSuccessSideEffects(
@@ -2250,6 +2618,368 @@ async function startRuntimeLogWatch(
   } finally {
     fs.closeSync(outFd);
     fs.closeSync(errFd);
+  }
+}
+
+export function startAsyncBuildResultWatcher(options: {
+  projectRoot: string;
+  projectId: string;
+  projectPath: string;
+  serverUrl: string;
+  env: string;
+  taskId: string;
+  reused?: boolean;
+  queryBuildResult: () => Promise<AsyncBuildQueryResult>;
+  refreshPreview?: RefreshMakerPreview;
+  startRuntimeLogWatch?: StartRuntimeLogWatch;
+  onProgress?: MakerProjectProgressHandler;
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+  onStop?: () => Promise<void> | void;
+}): AsyncBuildWatcherStartResult {
+  const pollIntervalMs = options.pollIntervalMs || ASYNC_BUILD_POLL_INTERVAL_MS;
+  const timeoutMs = options.timeoutMs || ASYNC_BUILD_TIMEOUT_MS;
+  const paths = getAsyncBuildWatcherPaths(options.projectRoot, options.taskId);
+  const previous = stopExistingAsyncBuildResultWatcher(
+    options.projectRoot,
+    'cancelled_by_new_build'
+  );
+  const now = new Date();
+  const state: AsyncBuildWatcherState = {
+    mode: 'remote_build_async',
+    taskId: options.taskId,
+    reused: options.reused,
+    projectId: options.projectId,
+    projectPath: options.projectPath,
+    projectRoot: options.projectRoot,
+    serverUrl: options.serverUrl,
+    env: options.env,
+    status: 'queued',
+    startedAt: now.toISOString(),
+    updatedAt: now.toISOString(),
+    deadlineAt: new Date(now.getTime() + timeoutMs).toISOString(),
+    pollIntervalMs,
+  };
+  let completeWatcher: (state: AsyncBuildWatcherState) => void = () => {};
+  const completion = new Promise<AsyncBuildWatcherState>((resolve) => {
+    completeWatcher = resolve;
+  });
+  const watcher: ActiveAsyncBuildWatcher = {
+    state,
+    activeFile: paths.activeFile,
+    stateFile: paths.stateFile,
+    onStop: options.onStop,
+    completion,
+    complete: completeWatcher,
+  };
+  fs.mkdirSync(path.dirname(paths.activeFile), { recursive: true });
+  writeJsonFile(paths.stateFile, state);
+  writeJsonFile(paths.activeFile, {
+    taskId: options.taskId,
+    reused: options.reused,
+    projectId: options.projectId,
+    pid: process.pid,
+    startedAt: state.startedAt,
+    deadlineAt: state.deadlineAt,
+    stateFile: paths.stateFile,
+  });
+  activeAsyncBuildWatchers.set(paths.activeFile, watcher);
+
+  const poll = async (): Promise<void> => {
+    if (!activeAsyncBuildWatchers.has(paths.activeFile)) {
+      return;
+    }
+    try {
+      const result = await options.queryBuildResult();
+      updateAsyncBuildWatcherState(watcher, {
+        status: result.status,
+        resultText: result.resultText,
+        result: result.result,
+        error: result.error,
+        lastPollError: undefined,
+      });
+      emitAsyncBuildPollProgress(watcher, result, options.onProgress);
+      if (result.status === 'succeeded' || result.status === 'failed') {
+        if (result.status === 'succeeded') {
+          await finishAsyncBuildSuccessSideEffects(watcher, options);
+        }
+        stopAsyncBuildWatcherRuntime(watcher);
+        watcher.complete?.(watcher.state);
+        return;
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (isAsyncBuildExpiredErrorMessage(message)) {
+        updateAsyncBuildWatcherState(watcher, {
+          status: 'expired',
+          error: message,
+          lastPollError: message,
+        });
+        stopAsyncBuildWatcherRuntime(watcher);
+        watcher.complete?.(watcher.state);
+        return;
+      }
+      const nextStatus: AsyncBuildQueryStatus = 'running';
+      updateAsyncBuildWatcherState(watcher, {
+        status: nextStatus,
+        lastPollError: message,
+      });
+      emitAsyncBuildPollProgress(
+        watcher,
+        { status: nextStatus, error: message },
+        options.onProgress
+      );
+    }
+
+    if (Date.now() >= Date.parse(watcher.state.deadlineAt)) {
+      updateAsyncBuildWatcherState(watcher, { status: 'timeout' });
+      stopAsyncBuildWatcherRuntime(watcher);
+      watcher.complete?.(watcher.state);
+      return;
+    }
+    watcher.timer = setTimeout(() => {
+      void poll();
+    }, pollIntervalMs);
+  };
+
+  watcher.timer = setTimeout(() => {
+    void poll();
+  }, pollIntervalMs);
+
+  return {
+    started: true,
+    taskId: options.taskId,
+    reused: options.reused,
+    activeFile: paths.activeFile,
+    stateFile: paths.stateFile,
+    pollIntervalMs,
+    timeoutMs,
+    previousTaskId: previous.previousTaskId,
+    previousStopped: previous.previousStopped,
+  };
+}
+
+function stopAsyncBuildWatcherRuntime(watcher: ActiveAsyncBuildWatcher): void {
+  if (watcher.stopped) {
+    return;
+  }
+  watcher.stopped = true;
+  if (watcher.timer) {
+    clearTimeout(watcher.timer);
+    watcher.timer = undefined;
+  }
+  activeAsyncBuildWatchers.delete(watcher.activeFile);
+  fs.rmSync(watcher.activeFile, { force: true });
+  void Promise.resolve(watcher.onStop?.()).catch((error) => {
+    updateAsyncBuildWatcherState(watcher, {
+      sideEffectError: `async query runner close failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    });
+  });
+}
+
+function isAsyncBuildExpiredErrorMessage(message: string): boolean {
+  const normalized = message.trim().toLowerCase();
+  return [
+    'not found',
+    'not_found',
+    'not exist',
+    'unknown build',
+    'unknown build_id',
+    'expired',
+    'restart',
+    'restarted',
+    '未找到',
+    '不存在',
+    '过期',
+    '服务重启',
+  ].some((pattern) => normalized.includes(pattern));
+}
+
+function emitAsyncBuildPollProgress(
+  watcher: ActiveAsyncBuildWatcher,
+  result: Pick<AsyncBuildQueryResult, 'status' | 'result' | 'error'>,
+  onProgress?: MakerProjectProgressHandler
+): void {
+  if (!onProgress) {
+    return;
+  }
+  const payload =
+    result.result && typeof result.result === 'object' && !Array.isArray(result.result)
+      ? (result.result as Record<string, unknown>)
+      : {};
+  const remoteProgress = typeof payload.progress === 'number' ? payload.progress : undefined;
+  const remotePhase =
+    typeof payload.phase === 'string' && payload.phase.trim() ? payload.phase.trim() : undefined;
+  const elapsedSeconds =
+    typeof payload.elapsed_seconds === 'number' ? payload.elapsed_seconds : undefined;
+  onProgress({
+    progress: remoteProgress,
+    total: remoteProgress === undefined ? undefined : 100,
+    phase: 'async_build_poll',
+    message: [
+      `build_id=${watcher.state.taskId}`,
+      `status=${result.status}`,
+      remotePhase ? `phase=${remotePhase}` : '',
+      elapsedSeconds !== undefined ? `elapsed=${elapsedSeconds}s` : '',
+      result.error ? `error=${formatAsyncBuildDiagnostic(result.error)}` : '',
+    ]
+      .filter(Boolean)
+      .join(' '),
+  });
+}
+
+export function stopExistingAsyncBuildResultWatcher(
+  projectRoot: string,
+  reason: Extract<
+    AsyncBuildWatcherStateStatus,
+    'cancelled' | 'cancelled_by_new_build'
+  > = 'cancelled'
+): { previousTaskId?: string; previousStopped?: boolean } {
+  const activeFile = getAsyncBuildWatcherPaths(projectRoot, 'unused').activeFile;
+  const active = readJsonFile(activeFile) as { taskId?: string; stateFile?: string } | undefined;
+  const watcher = activeAsyncBuildWatchers.get(activeFile);
+  if (!active && !watcher) {
+    return {};
+  }
+  const stateFile = active?.stateFile || watcher?.stateFile;
+  const taskId = active?.taskId || watcher?.state.taskId;
+  if (stateFile && fs.existsSync(stateFile)) {
+    const existing = (readJsonFile(stateFile) || {}) as Partial<AsyncBuildWatcherState>;
+    writeJsonFile(stateFile, {
+      ...existing,
+      status: reason,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+  if (watcher) {
+    updateAsyncBuildWatcherState(watcher, {
+      status: reason,
+      updatedAt: new Date().toISOString(),
+    });
+    stopAsyncBuildWatcherRuntime(watcher);
+    watcher.complete?.(watcher.state);
+  } else {
+    fs.rmSync(activeFile, { force: true });
+  }
+  return {
+    previousTaskId: taskId,
+    previousStopped: Boolean(taskId),
+  };
+}
+
+async function finishAsyncBuildSuccessSideEffects(
+  watcher: ActiveAsyncBuildWatcher,
+  options: {
+    refreshPreview?: RefreshMakerPreview;
+    startRuntimeLogWatch?: StartRuntimeLogWatch;
+  }
+): Promise<void> {
+  const buildResult = asyncWatcherStateToRemoteBuildResult(watcher.state);
+  if (options.refreshPreview) {
+    try {
+      updateAsyncBuildWatcherState(watcher, {
+        previewRefresh: await options.refreshPreview(buildResult),
+      });
+    } catch (error) {
+      updateAsyncBuildWatcherState(watcher, {
+        previewRefresh: {
+          ok: false,
+          status: 0,
+          url: '',
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
+    }
+  }
+  if (options.startRuntimeLogWatch) {
+    try {
+      updateAsyncBuildWatcherState(watcher, {
+        runtimeLogWatch: await options.startRuntimeLogWatch(buildResult),
+      });
+    } catch (error) {
+      updateAsyncBuildWatcherState(watcher, {
+        runtimeLogWatch: {
+          started: false,
+          command: '',
+          runtimeLog: '',
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
+    }
+  }
+}
+
+function asyncWatcherStateToRemoteBuildResult(
+  state: AsyncBuildWatcherState,
+  originalBuildResult?: RemoteBuildAsyncStartedResult
+): RemoteBuildResult {
+  return {
+    mode: 'remote_build',
+    projectRoot: state.projectRoot,
+    projectId: state.projectId,
+    projectPath: state.projectPath,
+    serverUrl: state.serverUrl,
+    env: state.env,
+    makerUrl: formatMakerAppWebUrl(state.projectId, state.env),
+    timeoutMs: originalBuildResult?.timeoutMs || DEFAULT_BUILD_TIMEOUT_MS,
+    buildArgs: originalBuildResult?.buildArgs || {},
+    resultText: state.resultText || '',
+    previewRefresh: state.previewRefresh,
+    runtimeLogWatch: state.runtimeLogWatch,
+  };
+}
+
+function updateAsyncBuildWatcherState(
+  watcher: ActiveAsyncBuildWatcher,
+  patch: Partial<AsyncBuildWatcherState>
+): void {
+  watcher.state = {
+    ...watcher.state,
+    ...patch,
+    updatedAt: new Date().toISOString(),
+  };
+  writeJsonFile(watcher.stateFile, watcher.state);
+}
+
+function getAsyncBuildWatcherPaths(
+  projectRoot: string,
+  taskId: string
+): { activeFile: string; stateFile: string } {
+  const normalizedProjectRoot = normalizeExistingProjectPath(projectRoot);
+  const buildDir = path.join(normalizedProjectRoot, '.maker', 'builds');
+  return {
+    activeFile: path.join(buildDir, 'active-build.json'),
+    stateFile: path.join(buildDir, `${sanitizeAsyncBuildTaskId(taskId)}.json`),
+  };
+}
+
+function normalizeExistingProjectPath(projectRoot: string): string {
+  try {
+    return fs.realpathSync(projectRoot);
+  } catch {
+    return path.resolve(projectRoot);
+  }
+}
+
+function sanitizeAsyncBuildTaskId(taskId: string): string {
+  return taskId.replace(/[^A-Za-z0-9_.-]/g, '_') || 'unknown-task';
+}
+
+function writeJsonFile(filePath: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function readJsonFile(filePath: string): unknown | undefined {
+  if (!fs.existsSync(filePath)) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return undefined;
   }
 }
 
@@ -2656,6 +3386,7 @@ function toMakerBuildFailure(error: unknown): MakerBuildFailure {
     name: error instanceof Error ? error.name : typeof error,
     message: error instanceof Error ? error.message : String(error),
     ...(error instanceof Error && error.stack ? { stack: error.stack } : {}),
+    ...(error instanceof Error ? errorOwnDiagnosticFields(error) : {}),
   };
 }
 
@@ -2667,6 +3398,8 @@ export function createBuildArgs(
     entryClient?: string;
     entryServer?: string;
     multiplayer?: Record<string, unknown>;
+    asyncBuild?: boolean;
+    clientIde?: string;
   }
 ): Record<string, unknown> {
   const buildArgs: Record<string, unknown> = {};
@@ -2698,8 +3431,46 @@ export function createBuildArgs(
   } else if (!fs.existsSync(path.join(projectRoot, '.project', 'settings.json'))) {
     buildArgs.multiplayer = { enabled: false };
   }
+  if (shouldForwardAsyncBuild(options.asyncBuild, options.clientIde)) {
+    buildArgs[getRemoteAsyncBuildParamName()] = getRemoteAsyncBuildParamValue();
+  }
 
   return buildArgs;
+}
+
+function shouldForwardAsyncBuild(asyncBuild?: boolean, clientIde?: string): boolean {
+  if (asyncBuild === true) {
+    return true;
+  }
+  if (asyncBuild === false) {
+    return false;
+  }
+  return normalizeClientIde(clientIde || process.env.TAPTAP_MCP_CLIENT_IDE) === 'workbuddy';
+}
+
+function normalizeClientIde(clientIde?: string): string {
+  return (clientIde || '').trim().toLowerCase();
+}
+
+function getRemoteAsyncBuildParamName(): string {
+  const paramName = process.env.TAPTAP_MAKER_REMOTE_ASYNC_BUILD_PARAM?.trim();
+  return paramName || DEFAULT_REMOTE_ASYNC_BUILD_PARAM;
+}
+
+function getRemoteAsyncBuildParamValue(): unknown {
+  const rawValue = process.env.TAPTAP_MAKER_REMOTE_ASYNC_BUILD_VALUE_JSON;
+  if (!rawValue) {
+    return true;
+  }
+  try {
+    return JSON.parse(rawValue);
+  } catch (error) {
+    throw new Error(
+      `Invalid TAPTAP_MAKER_REMOTE_ASYNC_BUILD_VALUE_JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
 }
 
 function mergeStringEnv(
@@ -2749,7 +3520,6 @@ export function formatBuildResult(
       '',
       `- project_root: ${result.projectRoot}`,
       `- project_id: ${result.projectId}`,
-      ...formatMakerPageOpenLines(result.makerPageOpen),
       `- maker_url: ${
         result.buildResult.makerUrl ||
         formatMakerAppWebUrl(result.buildResult.projectId, result.buildResult.env)
@@ -2830,6 +3600,50 @@ export function formatBuildResult(
       .join('\n');
   }
 
+  if (result.mode === 'remote_build_async_started') {
+    return [
+      result.submitResult
+        ? '✓ Maker project submitted, then remote Maker async build started'
+        : '✓ Remote Maker async build started',
+      '',
+      `- project_root: ${result.projectRoot}`,
+      `- project_id: ${result.projectId}`,
+      `- maker_url: ${result.makerUrl || formatMakerAppWebUrl(result.projectId, result.env)}`,
+      `- project_path: ${result.projectPath}`,
+      `- server_url: ${result.serverUrl}`,
+      `- env: ${result.env}`,
+      `- build_id: ${result.taskId}`,
+      result.reused !== undefined ? `- reused: ${result.reused ? 'yes' : 'no'}` : '',
+      `- timeout_ms: ${result.timeoutMs}`,
+      `- build_args: ${JSON.stringify(result.buildArgs)}`,
+      result.asyncBuildWatch
+        ? `- async_watch_started: ${result.asyncBuildWatch.started ? 'yes' : 'no'}`
+        : '',
+      result.asyncBuildWatch ? `- async_watch_state_file: ${result.asyncBuildWatch.stateFile}` : '',
+      result.asyncBuildWatch
+        ? `- async_watch_active_file: ${result.asyncBuildWatch.activeFile}`
+        : '',
+      result.asyncBuildWatch
+        ? `- async_watch_poll_interval_ms: ${result.asyncBuildWatch.pollIntervalMs}`
+        : '',
+      result.asyncBuildWatch ? `- async_watch_timeout_ms: ${result.asyncBuildWatch.timeoutMs}` : '',
+      result.asyncBuildWatch?.previousTaskId
+        ? `- previous_async_build_id: ${result.asyncBuildWatch.previousTaskId}`
+        : '',
+      result.asyncBuildWatch?.previousStopped !== undefined
+        ? `- previous_async_watch_stopped: ${result.asyncBuildWatch.previousStopped ? 'yes' : 'no'}`
+        : '',
+      ...formatProgressSummary(progressSummary),
+      '',
+      'note: 远端异步构建已启动；本地每 5 秒查询一次结果，最多轮询 30 分钟。',
+      'note: 如果同一 Maker 项目再次触发构建，上一轮异步轮询会被取消。',
+      'remote_result:',
+      indent(result.resultText),
+    ]
+      .filter(Boolean)
+      .join('\n');
+  }
+
   const submitLines = result.submitResult
     ? [
         'submit_result:',
@@ -2854,7 +3668,6 @@ export function formatBuildResult(
     `- project_root: ${result.projectRoot}`,
     `- project_id: ${result.projectId}`,
     `- maker_url: ${result.makerUrl || formatMakerAppWebUrl(result.projectId, result.env)}`,
-    ...formatMakerPageOpenLines(result.makerPageOpen),
     `- project_path: ${result.projectPath}`,
     `- server_url: ${result.serverUrl}`,
     `- env: ${result.env}`,
@@ -2975,19 +3788,6 @@ function formatPreviewRefreshLines(result?: PreviewRefreshResult): string[] {
   ].filter(Boolean);
 }
 
-function formatMakerPageOpenLines(result?: MakerPageOpenResult): string[] {
-  if (!result) {
-    return [];
-  }
-
-  return [
-    `- maker_page_open: ${result.ok ? 'ok' : 'failed'}`,
-    `- maker_page_url: ${result.url}`,
-    result.error ? `- maker_page_error: ${result.error}` : '',
-    '- next_action: 已按“不提交，只构建云端版本”打开 Maker 远端页面；如果没有自动弹出，请手动打开 maker_page_url 后再查看构建结果。',
-  ].filter(Boolean);
-}
-
 function formatRuntimeLogWatchNextActionLines(result: RemoteBuildResult): string[] {
   const command = formatLocalShellCommand([
     'taptap-maker',
@@ -3071,12 +3871,27 @@ function pushRecoveryUserMessage(failure?: MakerGitFailure): string {
 }
 
 function formatMakerBuildFailureLines(failure: MakerBuildFailure): string[] {
+  const details = buildFailureDiagnosticFields(failure);
   return [
     'build_failure:',
     `- error_name: ${failure.name}`,
     `- message: ${failure.message}`,
+    Object.keys(details).length > 0
+      ? `- error_details:\n${indent(formatDiagnosticJson(details))}`
+      : '',
     failure.stack ? `- stack:\n${indent(failure.stack)}` : '',
   ].filter(Boolean);
+}
+
+function buildFailureDiagnosticFields(failure: MakerBuildFailure): Record<string, unknown> {
+  const details: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(failure)) {
+    if (key === 'name' || key === 'message' || key === 'stack') {
+      continue;
+    }
+    details[key] = sanitizeDiagnosticValue(value);
+  }
+  return details;
 }
 
 function formatMakerFailureLines(failure: MakerGitFailure): string[] {

--- a/src/maker/server/mcp.ts
+++ b/src/maker/server/mcp.ts
@@ -848,7 +848,7 @@ async function formatStatus(
 }
 
 function formatAsyncBuildStatus(projectRoot: string): string {
-  const active = readJsonFile(getAsyncBuildWatcherPaths(projectRoot, 'unused').activeFile) as
+  const active = readJsonFile(getAsyncBuildActiveFilePath(projectRoot)) as
     | { taskId?: string; stateFile?: string; deadlineAt?: string; pid?: number; reused?: boolean }
     | undefined;
   if (!active?.taskId) {
@@ -1897,6 +1897,7 @@ type StopRuntimeLogWatcherOptions = {
 };
 type StartRuntimeLogWatch = (buildResult: RemoteBuildResult) => Promise<RuntimeLogWatchStartResult>;
 type RuntimeLogMcpClient = Pick<Client, 'connect' | 'callTool' | 'close'>;
+type AsyncBuildMcpClient = Pick<Client, 'connect' | 'callTool' | 'close'>;
 type RemoteRuntimeLogClient = {
   call: (args: RuntimeLogQueryArgs) => Promise<RuntimeLogQueryResult>;
   close: () => Promise<void>;
@@ -2343,11 +2344,14 @@ async function attachAndWaitAsyncBuildResult(
   if (finalState.status === 'failed') {
     throw new RemoteBuildFailedError(finalResult);
   }
-  throw new Error(
-    `Async Maker build did not finish successfully: ${finalState.status}${
-      finalState.error ? `: ${formatAsyncBuildDiagnostic(finalState.error)}` : ''
-    }`
-  );
+  throw new RemoteBuildFailedError({
+    ...finalResult,
+    resultText:
+      finalResult.resultText ||
+      `Async Maker build did not finish successfully: ${finalState.status}${
+        finalState.error ? `: ${formatAsyncBuildDiagnostic(finalState.error)}` : ''
+      }`,
+  });
 }
 
 function formatAsyncBuildDiagnostic(value: unknown): string {
@@ -2361,7 +2365,13 @@ function formatAsyncBuildDiagnostic(value: unknown): string {
   }
 }
 
-function createRemoteAsyncBuildQueryRunner(buildResult: RemoteBuildAsyncStartedResult): {
+export function createRemoteAsyncBuildQueryRunner(
+  buildResult: RemoteBuildAsyncStartedResult,
+  options: {
+    createTransport?: () => Transport;
+    createClient?: () => AsyncBuildMcpClient;
+  } = {}
+): {
   query: (taskId: string) => Promise<AsyncBuildQueryResult>;
   close: () => Promise<void>;
 } {
@@ -2377,48 +2387,72 @@ function createRemoteAsyncBuildQueryRunner(buildResult: RemoteBuildAsyncStartedR
   const taskIdParam =
     process.env.TAPTAP_MAKER_REMOTE_ASYNC_BUILD_QUERY_TASK_ID_PARAM?.trim() ||
     DEFAULT_REMOTE_ASYNC_BUILD_QUERY_TASK_ID_PARAM;
-  const transport = trackMakerChildTransport(
-    new HiddenStdioClientTransport({
-      command: proxy.command,
-      args: proxy.args,
-      env: mergeStringEnv(process.env, proxy.envVars),
-      stderr: 'pipe',
-    })
-  );
-  const client = new Client(
-    {
-      name: 'taptap-maker-async-build-query-forwarder',
-      version: VERSION,
-    },
-    {
-      capabilities: {},
+  let client: AsyncBuildMcpClient | undefined;
+  const createTransport =
+    options.createTransport ||
+    (() =>
+      trackMakerChildTransport(
+        new HiddenStdioClientTransport({
+          command: proxy.command,
+          args: proxy.args,
+          env: mergeStringEnv(process.env, proxy.envVars),
+          stderr: 'pipe',
+        })
+      ));
+  const createClient =
+    options.createClient ||
+    (() =>
+      new Client(
+        {
+          name: 'taptap-maker-async-build-query-forwarder',
+          version: VERSION,
+        },
+        {
+          capabilities: {},
+        }
+      ));
+
+  const ensureClient = async (): Promise<AsyncBuildMcpClient> => {
+    if (client) {
+      return client;
     }
-  );
-  let connectPromise: Promise<void> | undefined;
-  const ensureConnected = async (): Promise<void> => {
-    if (!connectPromise) {
-      connectPromise = client.connect(transport);
+    const nextClient = createClient();
+    await nextClient.connect(createTransport());
+    client = nextClient;
+    return nextClient;
+  };
+
+  const close = async (): Promise<void> => {
+    const activeClient = client;
+    client = undefined;
+    if (activeClient) {
+      await activeClient.close();
     }
-    await connectPromise;
   };
 
   return {
     query: async (taskId: string): Promise<AsyncBuildQueryResult> => {
-      await ensureConnected();
-      const result = await client.callTool(
-        {
-          name: queryToolName,
-          arguments: { [taskIdParam]: taskId },
-        },
-        undefined,
-        {
-          timeout: DEFAULT_BUILD_TIMEOUT_MS,
-        }
-      );
+      const activeClient = await ensureClient();
+      let result: unknown;
+      try {
+        result = await activeClient.callTool(
+          {
+            name: queryToolName,
+            arguments: { [taskIdParam]: taskId },
+          },
+          undefined,
+          {
+            timeout: DEFAULT_BUILD_TIMEOUT_MS,
+          }
+        );
+      } catch (error) {
+        await close().catch(() => {});
+        throw error;
+      }
       return normalizeAsyncBuildQueryResult(result);
     },
     close: async (): Promise<void> => {
-      await client.close().catch(() => {});
+      await close().catch(() => {});
     },
   };
 }
@@ -2843,7 +2877,7 @@ export function stopExistingAsyncBuildResultWatcher(
     'cancelled' | 'cancelled_by_new_build'
   > = 'cancelled'
 ): { previousTaskId?: string; previousStopped?: boolean } {
-  const activeFile = getAsyncBuildWatcherPaths(projectRoot, 'unused').activeFile;
+  const activeFile = getAsyncBuildActiveFilePath(projectRoot);
   const active = readJsonFile(activeFile) as { taskId?: string; stateFile?: string } | undefined;
   const watcher = activeAsyncBuildWatchers.get(activeFile);
   if (!active && !watcher) {
@@ -2959,9 +2993,14 @@ function getAsyncBuildWatcherPaths(
   const normalizedProjectRoot = normalizeExistingProjectPath(projectRoot);
   const buildDir = path.join(normalizedProjectRoot, '.maker', 'builds');
   return {
-    activeFile: path.join(buildDir, 'active-build.json'),
+    activeFile: getAsyncBuildActiveFilePath(projectRoot),
     stateFile: path.join(buildDir, `${sanitizeAsyncBuildTaskId(taskId)}.json`),
   };
+}
+
+function getAsyncBuildActiveFilePath(projectRoot: string): string {
+  const normalizedProjectRoot = normalizeExistingProjectPath(projectRoot);
+  return path.join(normalizedProjectRoot, '.maker', 'builds', 'active-build.json');
 }
 
 function normalizeExistingProjectPath(projectRoot: string): string {

--- a/src/maker/server/mcp.ts
+++ b/src/maker/server/mcp.ts
@@ -1884,6 +1884,7 @@ type ActiveAsyncBuildWatcher = {
   timer?: NodeJS.Timeout;
   stopped?: boolean;
   state: AsyncBuildWatcherState;
+  sourceBuildResult?: RemoteBuildAsyncStartedResult;
   activeFile: string;
   stateFile: string;
   onStop?: () => Promise<void> | void;
@@ -2305,8 +2306,9 @@ function attachAsyncBuildWatcher(
       env: buildResult.env,
       taskId: buildResult.taskId,
       reused: buildResult.reused,
+      sourceBuildResult: buildResult,
       queryBuildResult: () => queryBuildResult(buildResult.taskId),
-      refreshPreview: options.refreshPreview,
+      refreshPreview: options.refreshPreview || refreshMakerPreview,
       startRuntimeLogWatch: options.startRuntimeLogWatch || startRuntimeLogWatch,
       pollIntervalMs: options.asyncBuildPollIntervalMs,
       onProgress: options.onProgress,
@@ -2629,6 +2631,7 @@ export function startAsyncBuildResultWatcher(options: {
   env: string;
   taskId: string;
   reused?: boolean;
+  sourceBuildResult?: RemoteBuildAsyncStartedResult;
   queryBuildResult: () => Promise<AsyncBuildQueryResult>;
   refreshPreview?: RefreshMakerPreview;
   startRuntimeLogWatch?: StartRuntimeLogWatch;
@@ -2666,6 +2669,7 @@ export function startAsyncBuildResultWatcher(options: {
   });
   const watcher: ActiveAsyncBuildWatcher = {
     state,
+    sourceBuildResult: options.sourceBuildResult,
     activeFile: paths.activeFile,
     stateFile: paths.stateFile,
     onStop: options.onStop,
@@ -2876,7 +2880,10 @@ async function finishAsyncBuildSuccessSideEffects(
     startRuntimeLogWatch?: StartRuntimeLogWatch;
   }
 ): Promise<void> {
-  const buildResult = asyncWatcherStateToRemoteBuildResult(watcher.state);
+  const buildResult = asyncWatcherStateToRemoteBuildResult(
+    watcher.state,
+    watcher.sourceBuildResult
+  );
   if (options.refreshPreview) {
     try {
       updateAsyncBuildWatcherState(watcher, {

--- a/src/maker/server/mcp.ts
+++ b/src/maker/server/mcp.ts
@@ -1905,7 +1905,9 @@ const activeAsyncBuildWatchers = new Map<string, ActiveAsyncBuildWatcher>();
 
 function formatMakerAppWebUrl(projectId: string, env: string): string {
   const makerEnv = env === 'rnd' || env === 'production' ? env : undefined;
-  return `${getMakerWebUrl(makerEnv)}/app/${encodeURIComponent(projectId)}`;
+  const url = new URL(`${getMakerWebUrl(makerEnv)}/app/${encodeURIComponent(projectId)}`);
+  url.searchParams.set('localDev', '1');
+  return url.toString();
 }
 
 type BuildCurrentDirectoryResult =

--- a/src/mcp-proxy/proxy.ts
+++ b/src/mcp-proxy/proxy.ts
@@ -598,6 +598,10 @@ export class TapTapMCPProxy {
     const errorMsg = error.message.toLowerCase();
     const errorCode = (error as any).code;
 
+    if (this.isMcpApplicationError(error)) {
+      return false;
+    }
+
     // 检查错误码（优先，更可靠）
     const networkErrorCodes = [
       'ECONNREFUSED', // 连接拒绝
@@ -633,6 +637,12 @@ export class TapTapMCPProxy {
     // 🔑 关键：会话无效错误也需要触发重连
     // 这解决了多副本部署时连接到未初始化 Server 副本的问题
     return this.isSessionInvalidError(error);
+  }
+
+  private isMcpApplicationError(error: Error): boolean {
+    const message = error.message.toLowerCase();
+    const code = (error as any).code;
+    return (typeof code === 'number' && code < 0) || /\bmcp error -\d+/.test(message);
   }
 
   /**

--- a/src/mcp-proxy/proxy.ts
+++ b/src/mcp-proxy/proxy.ts
@@ -598,10 +598,6 @@ export class TapTapMCPProxy {
     const errorMsg = error.message.toLowerCase();
     const errorCode = (error as any).code;
 
-    if (this.isMcpApplicationError(error)) {
-      return false;
-    }
-
     // 检查错误码（优先，更可靠）
     const networkErrorCodes = [
       'ECONNREFUSED', // 连接拒绝
@@ -618,6 +614,16 @@ export class TapTapMCPProxy {
       return true;
     }
 
+    // MCP SDK may wrap transport/session failures as McpError with negative codes.
+    // Keep these reconnectable before excluding real MCP application errors below.
+    if (errorMsg.includes('not connected') || this.isSessionInvalidError(error)) {
+      return true;
+    }
+
+    if (this.isMcpApplicationError(error)) {
+      return false;
+    }
+
     // 检查错误消息关键词（备选）
     const networkErrorKeywords = [
       'fetch failed',
@@ -627,7 +633,6 @@ export class TapTapMCPProxy {
       'connection reset',
       'timeout',
       'dns',
-      'not connected', // 连接断开
     ];
 
     if (networkErrorKeywords.some((keyword) => errorMsg.includes(keyword))) {


### PR DESCRIPTION
## 改动内容
- WorkBuddy 默认走异步构建，并在异步完成后执行预览刷新和 runtime log watcher。
- 异步构建本地轮询改为 5s，支持完成、失败、超时和同项目新构建取消旧 watcher。
- WorkBuddy MCP 安装写入 TAPTAP_MCP_CLIENT_IDE，并支持显式安装创建官方 mcp.json。
- 构建成功后的 maker_url 追加 localDev=1，并保留自定义 Maker Web URL path。
- 更新 README、AGENTS、Maker 文档和 bundled skills 说明。

## 影响面
- 影响 Maker MCP 构建工具、WorkBuddy MCP 配置安装、构建结果输出和本地日志 watcher 启动。
- 非 WorkBuddy IDE 默认保持同步构建，显式 async_build 仍可强制异步构建。

## 验证
- npm test -- --runInBand src/__tests__/makerCliCommands.test.ts
- npm test -- --runInBand src/__tests__/makerBuildLocalChanges.test.ts
- npm run lint
- npm run build
- git diff --check