### PR TITLE
ci(maker): use npm trusted publishing

### DIFF
--- a/.github/workflows/publish-maker.yml
+++ b/.github/workflows/publish-maker.yml
@@ -115,6 +115,12 @@ jobs:
         env:
           MAKER_PACKAGE_VERSION: ${{ needs.resolve-version.outputs.version }}
 
+      - name: Upgrade npm for trusted publishing
+        run: |
+          npm install -g npm@11.5.1
+          node --version
+          npm --version
+
       - name: Verify version is still unpublished before npm publish
         run: |
           set -euo pipefail
@@ -131,13 +137,11 @@ jobs:
         run: |
           set -euo pipefail
           tarball="./packages/maker/taptap-maker-${MAKER_PACKAGE_VERSION}.tgz"
-          npm publish "$tarball" --access public --tag "$NPM_TAG" --provenance \
-            || npm publish "$tarball" --access public --tag "$NPM_TAG"
+          npm publish "$tarball" --access public --tag "$NPM_TAG" --provenance
           echo "Published @taptap/maker@$MAKER_PACKAGE_VERSION"
         env:
           MAKER_PACKAGE_VERSION: ${{ needs.resolve-version.outputs.version }}
           NPM_TAG: ${{ inputs.tag }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Update Maker version policy
         id: version-policy


### PR DESCRIPTION
## Summary

- upgrade npm to 11.5.1 before publishing @taptap/maker
- publish through the trusted publishing/provenance path only
- remove the NPM_TOKEN fallback that can mask OIDC publishing failures

## Why

The failed Maker publish run used npm 10.9.8. npm trusted publishing requires a newer npm CLI, so the publish step could sign provenance but still fail at registry publish time.

## Validation

- ruby -ryaml parsed .github/workflows/publish-maker.yml
- git diff --check
- git diff --staged --check