### PR TITLE
feat(maker): 上报本地 MCP 活跃事件

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -375,6 +375,10 @@ Maker 本地开发的默认路径是 CLI-first + PAT-first：
   本地保留远端 tool schema 和成功返回值，但会在 description 追加简短 Maker 本地开发提示：
   已绑定 Maker 项目应优先建议用户使用这些 tools。远端 proxy tool 返回 `isError` 时，本地 MCP
   必须抛出失败并尽量输出完整 `remote_result` / server 返回内容。
+- 本地 Maker MCP 活跃上报复用 `tapmaker_mcp_call`，并在 `args.source` 写入 `local_mcp`。
+  `user_id` 和 `project_id` 只从当前项目 `.maker-mcp/config.json` 读取；缺少关键字段或项目上下文
+  无法准确解析时不上报，不使用 JWT、PAT、默认值或其它项目配置补齐。Tool、`maker://status`
+  Resource 和 MCP 启动事件计入本地活跃，上报失败不得影响 MCP 结果。
 - 新开对话、继续开发或检查 Maker 状态时，先读 `maker://status` 或调用 `maker_status_lite`。支持 MCP Roots 的客户端会输出 `MCP client roots` 与 `project_context_source`；只有一个 workspace root 时直接作为 Maker 操作目标，多个 root 中只有一个已绑定 Maker 项目时自动选择该项目，多个 Maker root 时必须让用户只保留一个 Maker workspace 或显式传 `target_dir`，不要猜测。已绑定项目会输出 `Maker remote sync`、AI dev kit 版本检查结果和必要的 `Maker project initialization`，提示是否需要先 pull、是否本地 dirty、是否分叉或是否不在 main、是否需要运行 `taptap-maker dev-kit update`，以及新项目是否需要先构建一次生成 `.project/project.json` 或先调用 `generate_test_qrcode` 生成 `app_id` / `developer_id`；按其中 `next_action` / `next_step` 引导用户。频繁轮询或只要快速本地状态时，`maker_status_lite` 可传 `skip_remote_sync=true`，同时跳过远端 Git 同步和 dev-kit 最新版本检查。
 - 当前目录是已绑定 Maker 项目时，只要用户消息涉及广告（包括“广告”、激励视频、播放广告、广告 ID、广告位、`ShowRewardVideoAd`、广告配置、广告开通状态等），第一步必须调用 `get_ad_config` 获取当前项目广告开通状态和广告配置；不要先查本地 SDK 文档、`.maker-mcp/config.json` 或用运行回调推断广告是否开通。若返回缺少 `.project/project.json`，说明新项目尚未构建初始化，应先调用 `maker_build_current_directory` 构建一次生成项目配置，再重试 `get_ad_config`。若返回缺少 `app_id` 或 `developer_id`，应调用 `generate_test_qrcode` 一次生成测试二维码元数据，再重试 `get_ad_config`；不要为这个恢复流程调用发布类工具。只有确认广告配置可用后，再实现或测试广告代码。
 - 当前目录是已绑定 Maker 项目时，只要用户消息涉及线上玩家反馈、问题反馈、问题上报、debug feedback、真机日志、截图或玩家反馈，应优先调用 Maker MCP tool `get_debug_feedbacks`；本地 runtime log 只用于当前本地构建/运行会话，不要用本地日志替代线上玩家提交的反馈。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -375,10 +375,11 @@ Maker 本地开发的默认路径是 CLI-first + PAT-first：
   本地保留远端 tool schema 和成功返回值，但会在 description 追加简短 Maker 本地开发提示：
   已绑定 Maker 项目应优先建议用户使用这些 tools。远端 proxy tool 返回 `isError` 时，本地 MCP
   必须抛出失败并尽量输出完整 `remote_result` / server 返回内容。
-- 本地 Maker MCP 活跃上报复用 `tapmaker_mcp_call`，并在 `args.source` 写入 `local_mcp`。
-  `user_id` 和 `project_id` 只从当前项目 `.maker-mcp/config.json` 读取；缺少关键字段或项目上下文
-  无法准确解析时不上报，不使用 JWT、PAT、默认值或其它项目配置补齐。Tool、`maker://status`
-  Resource 和 MCP 启动事件计入本地活跃，上报失败不得影响 MCP 结果。
+- 本地 Maker MCP 活跃上报复用 `tapmaker_mcp_call`，在 `args.source` 写入 `local_mcp`，
+  在 `args.mcp_version` 写入 `@taptap/maker` 版本；开发构建使用 `dev`，禁止使用主包版本
+  代替。`user_id` 和 `project_id` 只从当前项目 `.maker-mcp/config.json` 读取；缺少关键字段或
+  项目上下文无法准确解析时不上报，不使用 JWT、PAT、默认值或其它项目配置补齐。Tool、
+  `maker://status` Resource 和 MCP 启动事件计入本地活跃，上报失败不得影响 MCP 结果。
   错误信息上报前必须脱敏 PAT、Bearer、access token、refresh token、MAC key 和 URL 凭证，
   可保留 user_id、project_id、路径等诊断信息。
 - 新开对话、继续开发或检查 Maker 状态时，先读 `maker://status` 或调用 `maker_status_lite`。支持 MCP Roots 的客户端会输出 `MCP client roots` 与 `project_context_source`；只有一个 workspace root 时直接作为 Maker 操作目标，多个 root 中只有一个已绑定 Maker 项目时自动选择该项目，多个 Maker root 时必须让用户只保留一个 Maker workspace 或显式传 `target_dir`，不要猜测。已绑定项目会输出 `Maker remote sync`、AI dev kit 版本检查结果和必要的 `Maker project initialization`，提示是否需要先 pull、是否本地 dirty、是否分叉或是否不在 main、是否需要运行 `taptap-maker dev-kit update`，以及新项目是否需要先构建一次生成 `.project/project.json` 或先调用 `generate_test_qrcode` 生成 `app_id` / `developer_id`；按其中 `next_action` / `next_step` 引导用户。频繁轮询或只要快速本地状态时，`maker_status_lite` 可传 `skip_remote_sync=true`，同时跳过远端 Git 同步和 dev-kit 最新版本检查。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -379,6 +379,8 @@ Maker 本地开发的默认路径是 CLI-first + PAT-first：
   `user_id` 和 `project_id` 只从当前项目 `.maker-mcp/config.json` 读取；缺少关键字段或项目上下文
   无法准确解析时不上报，不使用 JWT、PAT、默认值或其它项目配置补齐。Tool、`maker://status`
   Resource 和 MCP 启动事件计入本地活跃，上报失败不得影响 MCP 结果。
+  错误信息上报前必须脱敏 PAT、Bearer、access token、refresh token、MAC key 和 URL 凭证，
+  可保留 user_id、project_id、路径等诊断信息。
 - 新开对话、继续开发或检查 Maker 状态时，先读 `maker://status` 或调用 `maker_status_lite`。支持 MCP Roots 的客户端会输出 `MCP client roots` 与 `project_context_source`；只有一个 workspace root 时直接作为 Maker 操作目标，多个 root 中只有一个已绑定 Maker 项目时自动选择该项目，多个 Maker root 时必须让用户只保留一个 Maker workspace 或显式传 `target_dir`，不要猜测。已绑定项目会输出 `Maker remote sync`、AI dev kit 版本检查结果和必要的 `Maker project initialization`，提示是否需要先 pull、是否本地 dirty、是否分叉或是否不在 main、是否需要运行 `taptap-maker dev-kit update`，以及新项目是否需要先构建一次生成 `.project/project.json` 或先调用 `generate_test_qrcode` 生成 `app_id` / `developer_id`；按其中 `next_action` / `next_step` 引导用户。频繁轮询或只要快速本地状态时，`maker_status_lite` 可传 `skip_remote_sync=true`，同时跳过远端 Git 同步和 dev-kit 最新版本检查。
 - 当前目录是已绑定 Maker 项目时，只要用户消息涉及广告（包括“广告”、激励视频、播放广告、广告 ID、广告位、`ShowRewardVideoAd`、广告配置、广告开通状态等），第一步必须调用 `get_ad_config` 获取当前项目广告开通状态和广告配置；不要先查本地 SDK 文档、`.maker-mcp/config.json` 或用运行回调推断广告是否开通。若返回缺少 `.project/project.json`，说明新项目尚未构建初始化，应先调用 `maker_build_current_directory` 构建一次生成项目配置，再重试 `get_ad_config`。若返回缺少 `app_id` 或 `developer_id`，应调用 `generate_test_qrcode` 一次生成测试二维码元数据，再重试 `get_ad_config`；不要为这个恢复流程调用发布类工具。只有确认广告配置可用后，再实现或测试广告代码。
 - 当前目录是已绑定 Maker 项目时，只要用户消息涉及线上玩家反馈、问题反馈、问题上报、debug feedback、真机日志、截图或玩家反馈，应优先调用 Maker MCP tool `get_debug_feedbacks`；本地 runtime log 只用于当前本地构建/运行会话，不要用本地日志替代线上玩家提交的反馈。

--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ Windows 是默认优先级：CLI 写通用 `mcpServers` 配置时会在 Windows 
 详见：[TapTap Maker 本地开发](docs/MAKER.md)。面向团队介绍的功能总览见
 [Maker CLI + MCP + Skill Rework Overview](docs/MAKER_CLI_MCP_SKILL_REWORK_OVERVIEW.md)。
 
+本地 Maker MCP 会透明上报本地开发活跃事件，复用 `tapmaker_mcp_call` 并在
+`args.source` 写入 `local_mcp`。事件只使用当前绑定项目配置中的 `user_id` 和
+`project_id`；任一关键字段缺失或项目上下文无法准确解析时跳过上报，不使用默认值或
+其它账号信息代替。Tool、`maker://status` Resource 和 MCP 启动事件均可作为活跃行为，
+上报失败不会影响 MCP 工具结果。
+
 ## 🧩 Codex Skills（运营简报）
 
 本仓库内置一个面向运营/工作室的 Codex Skill：`taptap-dc-ops-brief`，用于把“当前游戏 DC 数据”整理成 30 秒可读的结论简报，并在你确认后执行评价点赞/官方回复等动作。

--- a/README.md
+++ b/README.md
@@ -161,10 +161,11 @@ Windows 是默认优先级：CLI 写通用 `mcpServers` 配置时会在 Windows 
 [Maker CLI + MCP + Skill Rework Overview](docs/MAKER_CLI_MCP_SKILL_REWORK_OVERVIEW.md)。
 
 本地 Maker MCP 会透明上报本地开发活跃事件，复用 `tapmaker_mcp_call` 并在
-`args.source` 写入 `local_mcp`。事件只使用当前绑定项目配置中的 `user_id` 和
-`project_id`；任一关键字段缺失或项目上下文无法准确解析时跳过上报，不使用默认值或
-其它账号信息代替。Tool、`maker://status` Resource 和 MCP 启动事件均可作为活跃行为，
-上报失败不会影响 MCP 工具结果。
+`args.source` 写入 `local_mcp`，在 `args.mcp_version` 写入当前 `@taptap/maker`
+版本；普通开发构建使用 `dev`，不会使用主包版本代替。事件只使用当前绑定项目配置中的
+`user_id` 和 `project_id`；任一关键字段缺失或项目上下文无法准确解析时跳过上报，不使用
+默认值或其它账号信息代替。Tool、`maker://status` Resource 和 MCP 启动事件均可作为
+活跃行为，上报失败不会影响 MCP 工具结果。
 
 ## 🧩 Codex Skills（运营简报）
 

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -246,7 +246,8 @@ Maker MCP 使用已有 `tapmaker_mcp_call` action 上报本地开发活跃，并
 
 Tool 调用、`maker://status` Resource 读取和 MCP 启动都计入本地活跃；Tool 使用真实工具名，
 Resource 使用 `maker://status`，启动事件使用 `@taptap/maker@<version>`。上报是异步的，
-tracking 请求失败不会改变 MCP Tool 或 Resource 的结果。
+tracking 请求失败不会改变 MCP Tool 或 Resource 的结果。错误信息上报前会脱敏 PAT、Bearer、
+access token、refresh token、MAC key 和 URL 凭证，但保留 user_id、project_id 和路径等诊断信息。
 
 - `@taptap/maker` 发版成功后，`publish-maker.yml` 会用 `scripts/update-maker-version-policy.cjs`
   更新 `config/maker-version-policy.json` 并创建一个可 review 的 PR。`tag=latest` 只自动更新

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -240,9 +240,11 @@ MCP 运行期能力：
 ### 本地开发活跃上报
 
 Maker MCP 使用已有 `tapmaker_mcp_call` action 上报本地开发活跃，并在
-`args.source` 中固定写入 `local_mcp`。`user_id` 与 `project_id` 只从当前项目的
-`.maker-mcp/config.json` 读取；缺少任一字段、或当前调用无法准确解析到项目时不发送事件，
-不会使用 JWT、PAT、默认值或其它项目配置补齐。
+`args.source` 中固定写入 `local_mcp`，在 `args.mcp_version` 写入当前
+`@taptap/maker` 版本。正式发布通过 `MAKER_PACKAGE_VERSION` 注入准确版本，普通开发构建
+使用 `dev`，不会回退到 `@taptap/instant-games-open-mcp` 主包版本。`user_id` 与
+`project_id` 只从当前项目的 `.maker-mcp/config.json` 读取；缺少任一字段、或当前调用
+无法准确解析到项目时不发送事件，不会使用 JWT、PAT、默认值或其它项目配置补齐。
 
 Tool 调用、`maker://status` Resource 读取和 MCP 启动都计入本地活跃；Tool 使用真实工具名，
 Resource 使用 `maker://status`，启动事件使用 `@taptap/maker@<version>`。上报是异步的，

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -236,6 +236,18 @@ MCP 运行期能力：
   如果还没有确认项目目录，只能说明 machine-level refresh 的取舍，再决定是否运行不带
   `--target-dir` 的 `taptap-maker upgrade`。升级后要提示用户重启或 reconnect MCP session，
   然后用 `maker://status` 或 `maker_status_lite` 复核结果。
+
+### 本地开发活跃上报
+
+Maker MCP 使用已有 `tapmaker_mcp_call` action 上报本地开发活跃，并在
+`args.source` 中固定写入 `local_mcp`。`user_id` 与 `project_id` 只从当前项目的
+`.maker-mcp/config.json` 读取；缺少任一字段、或当前调用无法准确解析到项目时不发送事件，
+不会使用 JWT、PAT、默认值或其它项目配置补齐。
+
+Tool 调用、`maker://status` Resource 读取和 MCP 启动都计入本地活跃；Tool 使用真实工具名，
+Resource 使用 `maker://status`，启动事件使用 `@taptap/maker@<version>`。上报是异步的，
+tracking 请求失败不会改变 MCP Tool 或 Resource 的结果。
+
 - `@taptap/maker` 发版成功后，`publish-maker.yml` 会用 `scripts/update-maker-version-policy.cjs`
   更新 `config/maker-version-policy.json` 并创建一个可 review 的 PR。`tag=latest` 只自动更新
   `latest`，`tag=beta` 只自动更新 `latest_beta`，并刷新 `updated_at`；`minimum_supported`、

--- a/scripts/bundle-maker.js
+++ b/scripts/bundle-maker.js
@@ -11,7 +11,7 @@
 import * as esbuild from 'esbuild';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync } from 'node:fs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -20,8 +20,7 @@ const projectRoot = join(__dirname, '..');
 console.log('🚀 Bundling TapTap Maker...');
 console.log('📁 Project root:', projectRoot);
 
-const packageJson = JSON.parse(readFileSync(join(projectRoot, 'package.json'), 'utf-8'));
-const VERSION = process.env.MAKER_PACKAGE_VERSION || packageJson.version;
+const VERSION = process.env.MAKER_PACKAGE_VERSION || 'dev';
 console.log('📦 Version:', VERSION);
 
 const distDir = join(projectRoot, 'dist');

--- a/src/__tests__/makerTracking.test.ts
+++ b/src/__tests__/makerTracking.test.ts
@@ -96,6 +96,12 @@ describe('maker MCP tracking', () => {
     expect(sanitizeMakerMcpTrackingError('Authorization: Bearer secret-value')).toBe(
       'Authorization: <redacted>'
     );
+    expect(sanitizeMakerMcpTrackingError('Invalid MAC key: secret-value')).toBe(
+      'Invalid MAC key: <redacted>'
+    );
+    expect(
+      sanitizeMakerMcpTrackingError('Git failed for https://secret-value@example.com/repo')
+    ).toBe('Git failed for https://<redacted>@example.com/repo');
   });
 
   test('posts the event and isolates a failed tracking request', async () => {
@@ -131,5 +137,20 @@ describe('maker MCP tracking', () => {
         fetchImpl: failingFetch,
       })
     ).resolves.toBeUndefined();
+  });
+
+  test('releases response bodies before isolating tracking failures', async () => {
+    const response = new Response('temporary failure', { status: 502 });
+    const fetchImpl = jest.fn<typeof fetch>(async () => response);
+
+    await expect(
+      reportMakerMcpActivity({
+        context: { userId: 'user-1', projectId: 'project-1' },
+        toolName: 'maker_status_lite',
+        fetchImpl,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(response.bodyUsed).toBe(true);
   });
 });

--- a/src/__tests__/makerTracking.test.ts
+++ b/src/__tests__/makerTracking.test.ts
@@ -41,6 +41,25 @@ describe('maker MCP tracking', () => {
     ).toBeNull();
   });
 
+  test('omits unavailable optional request and duration values', () => {
+    expect(
+      buildMakerMcpTrackingPayload({
+        context: { userId: 'user-1', projectId: 'project-1' },
+        toolName: 'maker://status',
+        requestId: '',
+        durationMs: -1,
+      })
+    ).toEqual({
+      action: 'tapmaker_mcp_call',
+      args: {
+        user_id: 'user-1',
+        project_id: 'project-1',
+        tool_name: 'maker://status',
+        source: 'local_mcp',
+      },
+    });
+  });
+
   test('posts the event and isolates a failed tracking request', async () => {
     const fetchImpl = jest.fn<typeof fetch>(async () => new Response(null, { status: 204 }));
 

--- a/src/__tests__/makerTracking.test.ts
+++ b/src/__tests__/makerTracking.test.ts
@@ -96,12 +96,19 @@ describe('maker MCP tracking', () => {
     expect(sanitizeMakerMcpTrackingError('Authorization: Bearer secret-value')).toBe(
       'Authorization: <redacted>'
     );
+    expect(sanitizeMakerMcpTrackingError('Authorization: Bearer abc%2Ftoken failed')).toBe(
+      'Authorization: <redacted> failed'
+    );
     expect(sanitizeMakerMcpTrackingError('Invalid MAC key: secret-value')).toBe(
       'Invalid MAC key: <redacted>'
     );
     expect(
       sanitizeMakerMcpTrackingError('Git failed for https://secret-value@example.com/repo')
     ).toBe('Git failed for https://<redacted>@example.com/repo');
+  });
+
+  test('does not mistake ordinary diagnostic keys for PAT credentials', () => {
+    expect(sanitizeMakerMcpTrackingError('compat=v1.0')).toBe('compat=v1.0');
   });
 
   test('posts the event and isolates a failed tracking request', async () => {

--- a/src/__tests__/makerTracking.test.ts
+++ b/src/__tests__/makerTracking.test.ts
@@ -1,0 +1,77 @@
+import { buildMakerMcpTrackingPayload, reportMakerMcpActivity } from '../maker/tracking';
+
+describe('maker MCP tracking', () => {
+  test('builds a local MCP event with the configured identity and source', () => {
+    expect(
+      buildMakerMcpTrackingPayload({
+        context: { userId: 'user-1', projectId: 'project-1' },
+        toolName: 'maker_status_lite',
+        requestId: 7,
+        success: true,
+        durationMs: 12.6,
+        userAgent: '@taptap/maker@0.0.25',
+      })
+    ).toEqual({
+      action: 'tapmaker_mcp_call',
+      user_agent: '@taptap/maker@0.0.25',
+      args: {
+        user_id: 'user-1',
+        project_id: 'project-1',
+        tool_name: 'maker_status_lite',
+        source: 'local_mcp',
+        tool_id: '7',
+        duration_ms: 13,
+        success: true,
+      },
+    });
+  });
+
+  test('does not build an event when identity or tool name is missing', () => {
+    expect(
+      buildMakerMcpTrackingPayload({
+        context: { userId: '', projectId: 'project-1' },
+        toolName: 'maker_status_lite',
+      })
+    ).toBeNull();
+    expect(
+      buildMakerMcpTrackingPayload({
+        context: { userId: 'user-1', projectId: 'project-1' },
+        toolName: ' ',
+      })
+    ).toBeNull();
+  });
+
+  test('posts the event and isolates a failed tracking request', async () => {
+    const fetchImpl = jest.fn<typeof fetch>(async () => new Response(null, { status: 204 }));
+
+    await expect(
+      reportMakerMcpActivity({
+        context: { userId: 'user-1', projectId: 'project-1' },
+        toolName: 'maker_status_lite',
+        fetchImpl,
+      })
+    ).resolves.toBeUndefined();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl.mock.calls[0]?.[0]).toBe('https://maker.taptap.cn/api/v1/tracking');
+    expect(JSON.parse(String(fetchImpl.mock.calls[0]?.[1]?.body))).toMatchObject({
+      action: 'tapmaker_mcp_call',
+      args: {
+        user_id: 'user-1',
+        project_id: 'project-1',
+        tool_name: 'maker_status_lite',
+        source: 'local_mcp',
+      },
+    });
+
+    const failingFetch = jest.fn<typeof fetch>(async () => {
+      throw new Error('network down');
+    });
+    await expect(
+      reportMakerMcpActivity({
+        context: { userId: 'user-1', projectId: 'project-1' },
+        toolName: 'maker_status_lite',
+        fetchImpl: failingFetch,
+      })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/__tests__/makerTracking.test.ts
+++ b/src/__tests__/makerTracking.test.ts
@@ -1,5 +1,8 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import {
   buildMakerMcpTrackingPayload,
+  isMakerBuildActivitySuccessful,
   reportMakerMcpActivity,
   sanitizeMakerMcpTrackingError,
 } from '../maker/tracking';
@@ -23,6 +26,7 @@ describe('maker MCP tracking', () => {
         project_id: 'project-1',
         tool_name: 'maker_status_lite',
         source: 'local_mcp',
+        mcp_version: 'dev',
         tool_id: '7',
         duration_ms: 13,
         success: true,
@@ -60,8 +64,27 @@ describe('maker MCP tracking', () => {
         project_id: 'project-1',
         tool_name: 'maker://status',
         source: 'local_mcp',
+        mcp_version: 'dev',
       },
     });
+  });
+
+  test('marks only a completed remote build as successful activity', () => {
+    expect(isMakerBuildActivitySuccessful('remote_build')).toBe(true);
+    expect(isMakerBuildActivitySuccessful('remote_build_failed')).toBe(false);
+    expect(isMakerBuildActivitySuccessful('submit_failed_before_build')).toBe(false);
+    expect(isMakerBuildActivitySuccessful('settings_invalid_before_build')).toBe(false);
+    expect(isMakerBuildActivitySuccessful('build_failed_after_submit')).toBe(false);
+  });
+
+  test('uses dev instead of the root package version for local Maker bundles', () => {
+    const bundleScript = fs.readFileSync(
+      path.resolve(process.cwd(), 'scripts/bundle-maker.js'),
+      'utf8'
+    );
+
+    expect(bundleScript).toContain("const VERSION = process.env.MAKER_PACKAGE_VERSION || 'dev';");
+    expect(bundleScript).not.toContain('process.env.MAKER_PACKAGE_VERSION || packageJson.version');
   });
 
   test('redacts credentials from error messages without hiding paths or identifiers', () => {
@@ -94,6 +117,7 @@ describe('maker MCP tracking', () => {
         project_id: 'project-1',
         tool_name: 'maker_status_lite',
         source: 'local_mcp',
+        mcp_version: 'dev',
       },
     });
 

--- a/src/__tests__/makerTracking.test.ts
+++ b/src/__tests__/makerTracking.test.ts
@@ -1,4 +1,8 @@
-import { buildMakerMcpTrackingPayload, reportMakerMcpActivity } from '../maker/tracking';
+import {
+  buildMakerMcpTrackingPayload,
+  reportMakerMcpActivity,
+  sanitizeMakerMcpTrackingError,
+} from '../maker/tracking';
 
 describe('maker MCP tracking', () => {
   test('builds a local MCP event with the configured identity and source', () => {
@@ -58,6 +62,17 @@ describe('maker MCP tracking', () => {
         source: 'local_mcp',
       },
     });
+  });
+
+  test('redacts credentials from error messages without hiding paths or identifiers', () => {
+    expect(
+      sanitizeMakerMcpTrackingError(
+        'PAT=secret-value failed at /Users/test/game for user_id=user-1 project_id=project-1'
+      )
+    ).toBe('PAT=<redacted> failed at /Users/test/game for user_id=user-1 project_id=project-1');
+    expect(sanitizeMakerMcpTrackingError('Authorization: Bearer secret-value')).toBe(
+      'Authorization: <redacted>'
+    );
   });
 
   test('posts the event and isolates a failed tracking request', async () => {

--- a/src/maker/server/mcp.ts
+++ b/src/maker/server/mcp.ts
@@ -111,6 +111,11 @@ import {
   prepareRemoteProxyToolArgs,
 } from './proxyAssets.js';
 import { DEFAULT_TOOL_CALL_TIMEOUT_MS } from '../../mcp-proxy/config.js';
+import {
+  reportMakerMcpActivity,
+  type MakerMcpActivityEvent,
+  type MakerMcpTrackingContext,
+} from '../tracking.js';
 
 export { materializeRemoteProxyToolAssets, prepareRemoteProxyToolArgs } from './proxyAssets.js';
 
@@ -619,26 +624,68 @@ export async function startMakerMcpServer(): Promise<void> {
   );
 
   const listClientRoots = createServerClientRootsProvider(server);
-  server.setRequestHandler(ListToolsRequestSchema, async () => listMakerTools({ listClientRoots }));
-  server.setRequestHandler(ListResourcesRequestSchema, async () => ({ resources }));
-  server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+  const startupReportedProjects = new Set<string>();
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    const contextPromise = resolveMakerMcpTrackingContext({ listClientRoots });
+    void reportMakerMcpStartupFromPromise(contextPromise, startupReportedProjects);
+    return listMakerTools({ listClientRoots });
+  });
+  server.setRequestHandler(ListResourcesRequestSchema, async () => {
+    const contextPromise = resolveMakerMcpTrackingContext({ listClientRoots });
+    void reportMakerMcpStartupFromPromise(contextPromise, startupReportedProjects);
+    return { resources };
+  });
+  server.setRequestHandler(ReadResourceRequestSchema, async (request, extra) => {
     const uri = request.params.uri;
     if (uri !== 'maker://status') {
       throw new McpError(ErrorCode.InvalidParams, `Unknown Maker resource: ${uri}`);
     }
 
-    return {
-      contents: [
-        {
-          uri,
-          mimeType: 'text/plain',
-          text: await formatStatus({ listClientRoots }),
-        },
-      ],
-    };
+    const startedAt = Date.now();
+    const contextPromise = resolveMakerMcpTrackingContext({ listClientRoots });
+    void reportMakerMcpStartupFromPromise(contextPromise, startupReportedProjects);
+    try {
+      const result = {
+        contents: [
+          {
+            uri,
+            mimeType: 'text/plain',
+            text: await formatStatus({ listClientRoots }),
+          },
+        ],
+      };
+      void reportMakerMcpActivityFromPromise(contextPromise, {
+        toolName: uri,
+        requestId: extra.requestId,
+        durationMs: Date.now() - startedAt,
+        success: true,
+      });
+      return result;
+    } catch (error) {
+      void reportMakerMcpActivityFromPromise(contextPromise, {
+        toolName: uri,
+        requestId: extra.requestId,
+        durationMs: Date.now() - startedAt,
+        success: false,
+        errorCode: error instanceof Error ? error.name : undefined,
+        errorMessage: error instanceof Error ? error.message : undefined,
+      });
+      throw error;
+    }
   });
   server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
     const name = request.params.name;
+    const startedAt = Date.now();
+    const rawArgs = (request.params.arguments || {}) as Record<string, unknown>;
+    const targetDir =
+      rawArgs.target_dir === undefined || typeof rawArgs.target_dir === 'string'
+        ? (rawArgs.target_dir as string | undefined)
+        : undefined;
+    const contextPromise =
+      rawArgs.target_dir !== undefined && typeof rawArgs.target_dir !== 'string'
+        ? Promise.resolve(null)
+        : resolveMakerMcpTrackingContext({ targetDir, listClientRoots });
+    void reportMakerMcpStartupFromPromise(contextPromise, startupReportedProjects);
 
     try {
       if (name === 'maker_status_lite') {
@@ -646,7 +693,7 @@ export async function startMakerMcpServer(): Promise<void> {
           target_dir?: string;
           skip_remote_sync?: boolean;
         };
-        return {
+        const toolResult = {
           content: [
             {
               type: 'text',
@@ -658,6 +705,13 @@ export async function startMakerMcpServer(): Promise<void> {
             },
           ],
         };
+        void reportMakerMcpActivityFromPromise(contextPromise, {
+          toolName: name,
+          requestId: extra.requestId,
+          durationMs: Date.now() - startedAt,
+          success: true,
+        });
+        return toolResult;
       }
 
       if (name === 'maker_build_current_directory') {
@@ -710,7 +764,7 @@ export async function startMakerMcpServer(): Promise<void> {
           throw error;
         }
 
-        return {
+        const toolResult = {
           content: [
             {
               type: 'text',
@@ -718,6 +772,13 @@ export async function startMakerMcpServer(): Promise<void> {
             },
           ],
         };
+        void reportMakerMcpActivityFromPromise(contextPromise, {
+          toolName: name,
+          requestId: extra.requestId,
+          durationMs: Date.now() - startedAt,
+          success: true,
+        });
+        return toolResult;
       }
 
       if (isExposedRemoteProxyTool(name)) {
@@ -729,17 +790,32 @@ export async function startMakerMcpServer(): Promise<void> {
           listClientRoots,
           allowFallbackOnAmbiguousRoots: false,
         });
-        return await callRemoteProxyTool({
+        const result = await callRemoteProxyTool({
           targetDir: context.targetDir,
           name,
           args: remoteArgs,
           progressToken: request.params._meta?.progressToken,
           extra,
         });
+        void reportMakerMcpActivityFromPromise(contextPromise, {
+          toolName: name,
+          requestId: extra.requestId,
+          durationMs: Date.now() - startedAt,
+          success: !result.isError,
+        });
+        return result;
       }
 
       throw new McpError(ErrorCode.MethodNotFound, `Unknown Maker tool: ${name}`);
     } catch (error) {
+      void reportMakerMcpActivityFromPromise(contextPromise, {
+        toolName: name,
+        requestId: extra.requestId,
+        durationMs: Date.now() - startedAt,
+        success: false,
+        errorCode: error instanceof Error ? error.name : undefined,
+        errorMessage: error instanceof Error ? error.message : undefined,
+      });
       return {
         isError: true,
         content: [
@@ -755,6 +831,68 @@ export async function startMakerMcpServer(): Promise<void> {
   const transport = new StdioServerTransport();
   await server.connect(transport);
   installMakerServerExitHandlers();
+}
+
+async function resolveMakerMcpTrackingContext(options: {
+  targetDir?: string;
+  listClientRoots?: MakerClientRootsProvider;
+}): Promise<MakerMcpTrackingContext | null> {
+  try {
+    const context = await resolveMakerProjectContext({
+      targetDir: options.targetDir,
+      listClientRoots: options.listClientRoots,
+      allowFallbackOnAmbiguousRoots: false,
+    });
+    const identify = identifyMakerProject({ cwd: context.targetDir });
+    const projectConfig = identify.projectRoot ? loadProjectConfig(identify.projectRoot) : null;
+    const userId = projectConfig?.user_id?.trim();
+    const projectId = projectConfig?.project_id?.trim();
+    if (!userId || !projectId) {
+      return null;
+    }
+    return { userId, projectId };
+  } catch {
+    return null;
+  }
+}
+
+async function reportMakerMcpActivityFromPromise(
+  contextPromise: Promise<MakerMcpTrackingContext | null>,
+  event: Omit<MakerMcpActivityEvent, 'context'>
+): Promise<void> {
+  try {
+    const context = await contextPromise;
+    if (!context) {
+      return;
+    }
+    await reportMakerMcpActivity({ context, ...event });
+  } catch {
+    // Activity reporting must never affect the MCP request or resource result.
+  }
+}
+
+async function reportMakerMcpStartupFromPromise(
+  contextPromise: Promise<MakerMcpTrackingContext | null>,
+  reportedProjects: Set<string>
+): Promise<void> {
+  try {
+    const context = await contextPromise;
+    if (!context) {
+      return;
+    }
+    const key = `${context.userId}\u0000${context.projectId}`;
+    if (reportedProjects.has(key)) {
+      return;
+    }
+    reportedProjects.add(key);
+    await reportMakerMcpActivity({
+      context,
+      toolName: `@taptap/maker@${VERSION}`,
+      success: true,
+    });
+  } catch {
+    // Activity reporting must never affect the MCP request or resource result.
+  }
 }
 
 const MAKER_SERVER_SHUTDOWN_TIMEOUT_MS = 3000;

--- a/src/maker/server/mcp.ts
+++ b/src/maker/server/mcp.ts
@@ -112,6 +112,7 @@ import {
 } from './proxyAssets.js';
 import { DEFAULT_TOOL_CALL_TIMEOUT_MS } from '../../mcp-proxy/config.js';
 import {
+  isMakerBuildActivitySuccessful,
   reportMakerMcpActivity,
   type MakerMcpActivityEvent,
   type MakerMcpTrackingContext,
@@ -779,7 +780,7 @@ export async function startMakerMcpServer(): Promise<void> {
           toolName: name,
           requestId: extra.requestId,
           durationMs: Date.now() - startedAt,
-          success: true,
+          success: isMakerBuildActivitySuccessful(result.mode),
         });
         return toolResult;
       }

--- a/src/maker/server/mcp.ts
+++ b/src/maker/server/mcp.ts
@@ -677,14 +677,17 @@ export async function startMakerMcpServer(): Promise<void> {
     const name = request.params.name;
     const startedAt = Date.now();
     const rawArgs = (request.params.arguments || {}) as Record<string, unknown>;
+    const hasInvalidTargetDir =
+      rawArgs.target_dir !== undefined &&
+      (typeof rawArgs.target_dir !== 'string' || !rawArgs.target_dir.trim());
     const targetDir =
-      rawArgs.target_dir === undefined || typeof rawArgs.target_dir === 'string'
+      !hasInvalidTargetDir &&
+      (rawArgs.target_dir === undefined || typeof rawArgs.target_dir === 'string')
         ? (rawArgs.target_dir as string | undefined)
         : undefined;
-    const contextPromise =
-      rawArgs.target_dir !== undefined && typeof rawArgs.target_dir !== 'string'
-        ? Promise.resolve(null)
-        : resolveMakerMcpTrackingContext({ targetDir, listClientRoots });
+    const contextPromise = hasInvalidTargetDir
+      ? Promise.resolve(null)
+      : resolveMakerMcpTrackingContext({ targetDir, listClientRoots });
     void reportMakerMcpStartupFromPromise(contextPromise, startupReportedProjects);
 
     try {

--- a/src/maker/tracking.ts
+++ b/src/maker/tracking.ts
@@ -7,6 +7,7 @@ import { getMakerApiBaseUrl } from './config.js';
 export const MAKER_MCP_TRACKING_ACTION = 'tapmaker_mcp_call';
 export const MAKER_MCP_TRACKING_SOURCE = 'local_mcp';
 export const MAKER_MCP_TRACKING_TIMEOUT_MS = 1500;
+const TRACKING_ERROR_MAX_LENGTH = 500;
 
 export interface MakerMcpTrackingContext {
   userId: string;
@@ -79,7 +80,7 @@ export function buildMakerMcpTrackingPayload(
     args.error_code = event.errorCode.trim();
   }
   if (event.errorMessage?.trim()) {
-    args.error_message = event.errorMessage.trim().slice(0, 500);
+    args.error_message = sanitizeMakerMcpTrackingError(event.errorMessage);
   }
 
   return {
@@ -87,6 +88,21 @@ export function buildMakerMcpTrackingPayload(
     ...(event.userAgent?.trim() ? { user_agent: event.userAgent.trim() } : {}),
     args,
   };
+}
+
+/**
+ * Remove credential values from error text while preserving paths and identifiers.
+ */
+export function sanitizeMakerMcpTrackingError(message: string): string {
+  return message
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, '<redacted>')
+    .replace(
+      /((?:authorization|access[_-]?token|refresh[_-]?token|mac[_-]?key|pat|token)\s*[:=]\s*)(["']?)[^,\s"'}<]+/gi,
+      '$1$2<redacted>'
+    )
+    .replace(/(https?:\/\/[^:\s/@]+:)[^@\s]+@/gi, '$1<redacted>@')
+    .trim()
+    .slice(0, TRACKING_ERROR_MAX_LENGTH);
 }
 
 /**

--- a/src/maker/tracking.ts
+++ b/src/maker/tracking.ts
@@ -1,0 +1,119 @@
+/**
+ * Best-effort activity tracking for local Maker MCP usage.
+ */
+
+import { getMakerApiBaseUrl } from './config.js';
+
+export const MAKER_MCP_TRACKING_ACTION = 'tapmaker_mcp_call';
+export const MAKER_MCP_TRACKING_SOURCE = 'local_mcp';
+export const MAKER_MCP_TRACKING_TIMEOUT_MS = 1500;
+
+export interface MakerMcpTrackingContext {
+  userId: string;
+  projectId: string;
+}
+
+export interface MakerMcpActivityEvent {
+  context: MakerMcpTrackingContext;
+  toolName: string;
+  requestId?: string | number;
+  durationMs?: number;
+  success?: boolean;
+  errorCode?: string;
+  errorMessage?: string;
+  userAgent?: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+export interface MakerMcpTrackingPayload {
+  action: typeof MAKER_MCP_TRACKING_ACTION;
+  user_agent?: string;
+  args: {
+    user_id: string;
+    project_id: string;
+    tool_name: string;
+    source: typeof MAKER_MCP_TRACKING_SOURCE;
+    tool_id?: string;
+    duration_ms?: number;
+    success?: boolean;
+    error_code?: string;
+    error_message?: string;
+  };
+}
+
+/**
+ * Build a tracking payload without inventing values that are not available.
+ */
+export function buildMakerMcpTrackingPayload(
+  event: MakerMcpActivityEvent
+): MakerMcpTrackingPayload | null {
+  const userId = event.context.userId.trim();
+  const projectId = event.context.projectId.trim();
+  const toolName = event.toolName.trim();
+  if (!userId || !projectId || !toolName) {
+    return null;
+  }
+
+  const args: MakerMcpTrackingPayload['args'] = {
+    user_id: userId,
+    project_id: projectId,
+    tool_name: toolName,
+    source: MAKER_MCP_TRACKING_SOURCE,
+  };
+
+  if (event.requestId !== undefined) {
+    args.tool_id = String(event.requestId);
+  }
+  if (event.durationMs !== undefined && Number.isFinite(event.durationMs)) {
+    args.duration_ms = Math.max(0, Math.round(event.durationMs));
+  }
+  if (event.success !== undefined) {
+    args.success = event.success;
+  }
+  if (event.errorCode?.trim()) {
+    args.error_code = event.errorCode.trim();
+  }
+  if (event.errorMessage?.trim()) {
+    args.error_message = event.errorMessage.trim().slice(0, 500);
+  }
+
+  return {
+    action: MAKER_MCP_TRACKING_ACTION,
+    ...(event.userAgent?.trim() ? { user_agent: event.userAgent.trim() } : {}),
+    args,
+  };
+}
+
+/**
+ * Send one local MCP activity event without affecting MCP behavior.
+ */
+export async function reportMakerMcpActivity(event: MakerMcpActivityEvent): Promise<void> {
+  const payload = buildMakerMcpTrackingPayload(event);
+  if (!payload) {
+    return;
+  }
+
+  const fetchImpl = event.fetchImpl || fetch;
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    event.timeoutMs ?? MAKER_MCP_TRACKING_TIMEOUT_MS
+  );
+
+  try {
+    const response = await fetchImpl(`${getMakerApiBaseUrl()}/tracking`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`tracking request failed with HTTP ${response.status}`);
+    }
+  } catch {
+    // Tracking is intentionally best-effort. Never surface its failures to MCP users.
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/maker/tracking.ts
+++ b/src/maker/tracking.ts
@@ -4,9 +4,15 @@
 
 import { getMakerApiBaseUrl } from './config.js';
 
+declare const __MAKER_VERSION__: string | undefined;
+
 export const MAKER_MCP_TRACKING_ACTION = 'tapmaker_mcp_call';
 export const MAKER_MCP_TRACKING_SOURCE = 'local_mcp';
 export const MAKER_MCP_TRACKING_TIMEOUT_MS = 1500;
+const MAKER_MCP_VERSION =
+  typeof __MAKER_VERSION__ !== 'undefined' && __MAKER_VERSION__.trim()
+    ? __MAKER_VERSION__.trim()
+    : 'dev';
 const TRACKING_ERROR_MAX_LENGTH = 500;
 
 export interface MakerMcpTrackingContext {
@@ -35,6 +41,7 @@ export interface MakerMcpTrackingPayload {
     project_id: string;
     tool_name: string;
     source: typeof MAKER_MCP_TRACKING_SOURCE;
+    mcp_version: string;
     tool_id?: string;
     duration_ms?: number;
     success?: boolean;
@@ -61,6 +68,7 @@ export function buildMakerMcpTrackingPayload(
     project_id: projectId,
     tool_name: toolName,
     source: MAKER_MCP_TRACKING_SOURCE,
+    mcp_version: MAKER_MCP_VERSION,
   };
 
   if (event.requestId !== undefined && String(event.requestId).trim()) {
@@ -88,6 +96,13 @@ export function buildMakerMcpTrackingPayload(
     ...(event.userAgent?.trim() ? { user_agent: event.userAgent.trim() } : {}),
     args,
   };
+}
+
+/**
+ * Return whether a Maker build result represents a completed remote build.
+ */
+export function isMakerBuildActivitySuccessful(mode: string): boolean {
+  return mode === 'remote_build';
 }
 
 /**

--- a/src/maker/tracking.ts
+++ b/src/maker/tracking.ts
@@ -62,11 +62,15 @@ export function buildMakerMcpTrackingPayload(
     source: MAKER_MCP_TRACKING_SOURCE,
   };
 
-  if (event.requestId !== undefined) {
+  if (event.requestId !== undefined && String(event.requestId).trim()) {
     args.tool_id = String(event.requestId);
   }
-  if (event.durationMs !== undefined && Number.isFinite(event.durationMs)) {
-    args.duration_ms = Math.max(0, Math.round(event.durationMs));
+  if (
+    event.durationMs !== undefined &&
+    Number.isFinite(event.durationMs) &&
+    event.durationMs >= 0
+  ) {
+    args.duration_ms = Math.round(event.durationMs);
   }
   if (event.success !== undefined) {
     args.success = event.success;

--- a/src/maker/tracking.ts
+++ b/src/maker/tracking.ts
@@ -110,9 +110,9 @@ export function isMakerBuildActivitySuccessful(mode: string): boolean {
  */
 export function sanitizeMakerMcpTrackingError(message: string): string {
   return message
-    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, '<redacted>')
+    .replace(/Bearer\s+[^,\s"'}<]+/gi, '<redacted>')
     .replace(
-      /((?:authorization|access[_-]?token|refresh[_-]?token|mac[_\s-]?key|pat|token)\s*[:=]\s*)(["']?)[^,\s"'}<]+/gi,
+      /((?:authorization|access[_-]?token|refresh[_-]?token|mac[_\s-]?key|\bpat\b|token)\s*[:=]\s*)(["']?)[^,\s"'}<]+/gi,
       '$1$2<redacted>'
     )
     .replace(/(https?:\/\/[^:\s/@]+:)[^@\s]+@/gi, '$1<redacted>@')

--- a/src/maker/tracking.ts
+++ b/src/maker/tracking.ts
@@ -112,10 +112,11 @@ export function sanitizeMakerMcpTrackingError(message: string): string {
   return message
     .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, '<redacted>')
     .replace(
-      /((?:authorization|access[_-]?token|refresh[_-]?token|mac[_-]?key|pat|token)\s*[:=]\s*)(["']?)[^,\s"'}<]+/gi,
+      /((?:authorization|access[_-]?token|refresh[_-]?token|mac[_\s-]?key|pat|token)\s*[:=]\s*)(["']?)[^,\s"'}<]+/gi,
       '$1$2<redacted>'
     )
     .replace(/(https?:\/\/[^:\s/@]+:)[^@\s]+@/gi, '$1<redacted>@')
+    .replace(/(https?:\/\/)[^:/\s@]+@/gi, '$1<redacted>@')
     .trim()
     .slice(0, TRACKING_ERROR_MAX_LENGTH);
 }
@@ -143,6 +144,7 @@ export async function reportMakerMcpActivity(event: MakerMcpActivityEvent): Prom
       body: JSON.stringify(payload),
       signal: controller.signal,
     });
+    await response.body?.cancel();
     if (!response.ok) {
       throw new Error(`tracking request failed with HTTP ${response.status}`);
     }


### PR DESCRIPTION
## 改动内容
- 复用 `tapmaker_mcp_call` 上报本地 Maker MCP 启动、Tool 调用和 `maker://status` 读取
- 固定写入 `args.source=local_mcp`，并上报准确的 `args.mcp_version`
- 仅使用当前绑定项目的 `user_id`、`project_id`，上下文不明确时跳过上报
- 补充超时、失败隔离、凭证脱敏和响应流释放保护
- 合并最新 main 的二维码项目健康预检，预检失败记录为 `success=false`

## DView 数据约定
- 事件：`action=tapmaker_mcp_call`
- 本地 MCP 识别：`args.source=local_mcp`
- 版本：`args.mcp_version`，正式包为 `@taptap/maker` 实际版本，开发构建为 `dev`
- `args` 到达 SLS 后为 JSON 字符串；DView 不应依赖 SLS 固定的 `__source__`

## 影响面
- 只增加本地 Maker MCP 活跃上报，不改变现有网页和服务端业务埋点
- tracking 采用 best-effort 方式，上报失败不影响 MCP Tool/Resource 结果
- 不修改现有 MCP Tool schema 或返回协议

## 验证
- 41 个 Jest 测试套件、612 个测试通过
- `npm run build` 通过
- `npm run lint` 通过
- `npm run format:check` 通过
- 与最新 `origin/main` 合并预检通过