### PR TITLE
ci(maker-plugin): 添加独立插件发布流程

### DIFF
--- a/.github/workflows/prepare-maker-plugin-release.yml
+++ b/.github/workflows/prepare-maker-plugin-release.yml
@@ -122,9 +122,9 @@ jobs:
           token: ${{ steps.release-token.outputs.token }}
           branch: chore/maker-plugin-${{ steps.version.outputs.version }}
           delete-branch: true
-          title: 'chore(maker-plugin): prepare ${{ steps.version.outputs.version }}'
+          title: 'chore(maker): prepare plugin ${{ steps.version.outputs.version }}'
           commit-message: |
-            chore(maker-plugin): prepare ${{ steps.version.outputs.version }}
+            chore(maker): prepare plugin ${{ steps.version.outputs.version }}
 
             - Increment the independent Maker client plugin patch version
             - Regenerate Codex and WorkBuddy self-contained plugin packages

--- a/.github/workflows/prepare-maker-plugin-release.yml
+++ b/.github/workflows/prepare-maker-plugin-release.yml
@@ -1,0 +1,82 @@
+name: Prepare Maker Plugin Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: prepare-maker-plugin-release
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Prepare next plugin patch
+    if: github.ref_name == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Resolve next plugin version
+        id: version
+        shell: bash
+        run: |
+          latest_tag="$(git tag --list 'maker-plugin-v*' --sort=-v:refname | head -n 1)"
+          latest_tag="${latest_tag:-none}"
+          result="$(node scripts/resolve-maker-plugin-version.js --latest-tag "$latest_tag" --json)"
+          echo "version=$(node -e 'const value=JSON.parse(process.argv[1]); process.stdout.write(value.version)' "$result")" >> "$GITHUB_OUTPUT"
+          echo "tag=$(node -e 'const value=JSON.parse(process.argv[1]); process.stdout.write(value.tag)' "$result")" >> "$GITHUB_OUTPUT"
+
+      - name: Update version and generated plugins
+        run: |
+          node scripts/update-maker-plugin-version.js --version "${{ steps.version.outputs.version }}"
+          npm run maker:codex-plugin:prepare
+          npm run maker:workbuddy-plugin:prepare
+
+      - name: Verify release candidate
+        run: |
+          npm run lint
+          npm run format:check
+          npm test -- --runInBand
+          npm run maker:plugins:package -- --output-dir "$RUNNER_TEMP/maker-plugins"
+
+      - name: Generate release PR token
+        id: release-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Create release PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ steps.release-token.outputs.token }}
+          branch: chore/maker-plugin-${{ steps.version.outputs.version }}
+          delete-branch: true
+          title: 'chore(maker-plugin): prepare ${{ steps.version.outputs.version }}'
+          commit-message: |
+            chore(maker-plugin): prepare ${{ steps.version.outputs.version }}
+
+            - Increment the independent Maker client plugin patch version
+            - Regenerate Codex and WorkBuddy self-contained plugin packages
+            - Keep the embedded Maker MCP version on its own release line
+            - Verification: lint, format check, tests, and release packaging
+          body: |
+            Prepares Maker client plugin `${{ steps.version.outputs.version }}`.
+
+            After merge, `Publish Maker Plugin` creates tag
+            `${{ steps.version.outputs.tag }}` and uploads both client ZIPs plus checksums.

--- a/.github/workflows/prepare-maker-plugin-release.yml
+++ b/.github/workflows/prepare-maker-plugin-release.yml
@@ -18,7 +18,7 @@ jobs:
       support_ready: ${{ steps.support.outputs.support_ready }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Detect plugin release support
         id: support
@@ -69,12 +69,12 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/prepare-maker-plugin-release.yml
+++ b/.github/workflows/prepare-maker-plugin-release.yml
@@ -4,18 +4,69 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: prepare-maker-plugin-release
   cancel-in-progress: false
 
 jobs:
+  preflight:
+    name: Check plugin release support
+    runs-on: ubuntu-latest
+    outputs:
+      support_ready: ${{ steps.support.outputs.support_ready }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect plugin release support
+        id: support
+        shell: bash
+        run: |
+          set -euo pipefail
+          required_files=(
+            package.json
+            config/maker-plugin-version.json
+            scripts/resolve-maker-plugin-version.js
+            scripts/update-maker-plugin-version.js
+            scripts/package-maker-client-plugins.js
+            scripts/prepare-maker-codex-plugin.js
+            scripts/prepare-maker-workbuddy-plugin.js
+          )
+          missing=()
+          for file in "${required_files[@]}"; do
+            [[ -f "$file" ]] || missing+=("$file")
+          done
+          required_scripts=(
+            maker:codex-plugin:prepare
+            maker:workbuddy-plugin:prepare
+            maker:plugins:package
+          )
+          for script in "${required_scripts[@]}"; do
+            node -e "const p=require('./package.json'); process.exit(p.scripts?.[process.argv[1]] ? 0 : 1)" "$script" || missing+=("package.json#scripts.$script")
+          done
+          if (( ${#missing[@]} > 0 )); then
+            echo "support_ready=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Maker plugin release is not enabled yet"
+              echo
+              echo "The workflow is installed, but plugin support has not reached this branch."
+              echo "Missing files:"
+              printf -- '- `%s`\n' "${missing[@]}"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          echo "support_ready=true" >> "$GITHUB_OUTPUT"
+
   prepare:
     name: Prepare next plugin patch
-    if: github.ref_name == 'main'
+    needs: preflight
+    if: github.ref_name == 'main' && needs.preflight.outputs.support_ready == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -35,9 +86,13 @@ jobs:
         id: version
         shell: bash
         run: |
-          latest_tag="$(git tag --list 'maker-plugin-v*' --sort=-v:refname | head -n 1)"
-          latest_tag="${latest_tag:-none}"
-          result="$(node scripts/resolve-maker-plugin-version.js --latest-tag "$latest_tag" --json)"
+          set -euo pipefail
+          current_version="$(node -e "const p=require('./config/maker-plugin-version.json'); process.stdout.write(p.version)")"
+          if git rev-parse "refs/tags/maker-plugin-v$current_version" >/dev/null 2>&1; then
+            result="$(node scripts/resolve-maker-plugin-version.js --latest-tag "maker-plugin-v$current_version" --json)"
+          else
+            result="$(node -e 'const version=process.argv[1]; process.stdout.write(JSON.stringify({version, tag:`maker-plugin-v${version}`}))' "$current_version")"
+          fi
           echo "version=$(node -e 'const value=JSON.parse(process.argv[1]); process.stdout.write(value.version)' "$result")" >> "$GITHUB_OUTPUT"
           echo "tag=$(node -e 'const value=JSON.parse(process.argv[1]); process.stdout.write(value.tag)' "$result")" >> "$GITHUB_OUTPUT"
 
@@ -56,13 +111,13 @@ jobs:
 
       - name: Generate release PR token
         id: release-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Create release PR
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           token: ${{ steps.release-token.outputs.token }}
           branch: chore/maker-plugin-${{ steps.version.outputs.version }}

--- a/.github/workflows/publish-maker-plugin.yml
+++ b/.github/workflows/publish-maker-plugin.yml
@@ -9,17 +9,69 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
-  group: publish-maker-plugin
+  group: publish-maker-plugin-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
+  preflight:
+    name: Check plugin release support
+    runs-on: ubuntu-latest
+    outputs:
+      support_ready: ${{ steps.support.outputs.support_ready }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect plugin release support
+        id: support
+        shell: bash
+        run: |
+          set -euo pipefail
+          required_files=(
+            package.json
+            config/maker-plugin-version.json
+            scripts/package-maker-client-plugins.js
+            scripts/prepare-maker-codex-plugin.js
+            scripts/prepare-maker-workbuddy-plugin.js
+            scripts/resolve-maker-plugin-version.js
+          )
+          missing=()
+          for file in "${required_files[@]}"; do
+            [[ -f "$file" ]] || missing+=("$file")
+          done
+          required_scripts=(
+            maker:codex-plugin:prepare
+            maker:workbuddy-plugin:prepare
+            maker:plugins:package
+          )
+          for script in "${required_scripts[@]}"; do
+            node -e "const p=require('./package.json'); process.exit(p.scripts?.[process.argv[1]] ? 0 : 1)" "$script" || missing+=("package.json#scripts.$script")
+          done
+          if (( ${#missing[@]} > 0 )); then
+            echo "support_ready=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Maker plugin release is not enabled yet"
+              echo
+              echo "The workflow is installed, but plugin support has not reached this branch."
+              echo "Missing files:"
+              printf -- '- `%s`\n' "${missing[@]}"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          echo "support_ready=true" >> "$GITHUB_OUTPUT"
+
   publish:
     name: Publish Maker client plugin
-    if: github.ref_name == 'main'
+    needs: preflight
+    if: >-
+      needs.preflight.outputs.support_ready == 'true' &&
+      (github.ref_name == 'main' || github.ref_name == 'develop')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -39,13 +91,29 @@ jobs:
         id: version
         shell: bash
         run: |
-          version="$(node -e "const p=require('./config/maker-plugin-version.json'); process.stdout.write(p.version)")"
+          set -euo pipefail
+          base_version="$(node -e "const p=require('./config/maker-plugin-version.json'); process.stdout.write(p.version)")"
+          if [[ "${{ github.ref_name }}" == "develop" ]]; then
+            channel=dev
+            if git rev-parse "refs/tags/maker-plugin-v$base_version" >/dev/null 2>&1; then
+              next="$(node scripts/resolve-maker-plugin-version.js --latest-tag "maker-plugin-v$base_version" --json)"
+              next_version="$(node -e 'const value=JSON.parse(process.argv[1]); process.stdout.write(value.version)' "$next")"
+            else
+              next_version="$base_version"
+            fi
+            version="${next_version}-dev.${GITHUB_RUN_NUMBER}"
+          else
+            channel=stable
+            version="$base_version"
+          fi
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "tag=maker-plugin-v$version" >> "$GITHUB_OUTPUT"
 
       - name: Validate an existing release tag
         shell: bash
         run: |
+          set -euo pipefail
           if git rev-parse "refs/tags/${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
             tagged_sha="$(git rev-list -n 1 "${{ steps.version.outputs.tag }}")"
             if [[ "$tagged_sha" != "${{ github.sha }}" ]]; then
@@ -55,10 +123,17 @@ jobs:
           fi
 
       - name: Verify generated plugins are current
+        if: steps.version.outputs.channel == 'stable'
+        shell: bash
         run: |
+          set -euo pipefail
           npm run maker:codex-plugin:prepare
           npm run maker:workbuddy-plugin:prepare
-          git diff --exit-code
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "::error::Generated plugin files are out of date. Run the prepare scripts and commit the result."
+            git status --porcelain
+            exit 1
+          fi
 
       - name: Verify release candidate
         run: |
@@ -67,15 +142,25 @@ jobs:
           npm test -- --runInBand
 
       - name: Package release assets
-        run: node scripts/package-maker-client-plugins.js --output-dir artifacts/maker-plugins
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ steps.version.outputs.version }}"
+          if [[ "${{ steps.version.outputs.channel }}" == "dev" ]]; then
+            node -e "const fs=require('fs'); const path='config/maker-plugin-version.json'; const p=require('./'+path); p.version=process.argv[1]; fs.writeFileSync(path, JSON.stringify(p, null, 2)+'\\n')" "$version"
+            node -e "const fs=require('fs'); const path='.codebuddy-plugin/marketplace.json'; const p=require('./'+path); const entry=p.plugins.find(item=>item.name==='taptap-maker'); if(!entry) throw new Error('Missing taptap-maker marketplace entry'); entry.version=process.argv[1]; fs.writeFileSync(path, JSON.stringify(p, null, 2)+'\\n')" "$version"
+          fi
+          npm run maker:plugins:package -- --output-dir artifacts/maker-plugins
 
       - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
+          set -euo pipefail
           version="${{ steps.version.outputs.version }}"
           tag="${{ steps.version.outputs.tag }}"
+          channel="${{ steps.version.outputs.channel }}"
           maker_version="$(node -e "const p=require('./config/maker-version-policy.json'); process.stdout.write(p.latest)")"
           notes="$RUNNER_TEMP/maker-plugin-release-notes.md"
           {
@@ -91,7 +176,11 @@ jobs:
               --notes-file "$notes"
             gh release upload "$tag" artifacts/maker-plugins/* --clobber
           else
-            gh release create "$tag" artifacts/maker-plugins/* \
+            release_flags=()
+            if [[ "$channel" == "dev" ]]; then
+              release_flags+=(--prerelease)
+            fi
+            gh release create "$tag" artifacts/maker-plugins/* "${release_flags[@]}" \
               --target "${{ github.sha }}" \
               --title "TapTap Maker Client Plugins $version" \
               --notes-file "$notes"

--- a/.github/workflows/publish-maker-plugin.yml
+++ b/.github/workflows/publish-maker-plugin.yml
@@ -23,7 +23,7 @@ jobs:
       support_ready: ${{ steps.support.outputs.support_ready }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Detect plugin release support
         id: support
@@ -75,12 +75,12 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/publish-maker-plugin.yml
+++ b/.github/workflows/publish-maker-plugin.yml
@@ -32,6 +32,7 @@ jobs:
           set -euo pipefail
           required_files=(
             package.json
+            .codebuddy-plugin/marketplace.json
             config/maker-plugin-version.json
             scripts/package-maker-client-plugins.js
             scripts/prepare-maker-codex-plugin.js

--- a/.github/workflows/publish-maker-plugin.yml
+++ b/.github/workflows/publish-maker-plugin.yml
@@ -1,0 +1,98 @@
+name: Publish Maker Plugin
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - config/maker-plugin-version.json
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-maker-plugin
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish Maker client plugin
+    if: github.ref_name == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Read release identity
+        id: version
+        shell: bash
+        run: |
+          version="$(node -e "const p=require('./config/maker-plugin-version.json'); process.stdout.write(p.version)")"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=maker-plugin-v$version" >> "$GITHUB_OUTPUT"
+
+      - name: Validate an existing release tag
+        shell: bash
+        run: |
+          if git rev-parse "refs/tags/${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+            tagged_sha="$(git rev-list -n 1 "${{ steps.version.outputs.tag }}")"
+            if [[ "$tagged_sha" != "${{ github.sha }}" ]]; then
+              echo "::error::Release tag ${{ steps.version.outputs.tag }} points to $tagged_sha, not ${{ github.sha }}."
+              exit 1
+            fi
+          fi
+
+      - name: Verify generated plugins are current
+        run: |
+          npm run maker:codex-plugin:prepare
+          npm run maker:workbuddy-plugin:prepare
+          git diff --exit-code
+
+      - name: Verify release candidate
+        run: |
+          npm run lint
+          npm run format:check
+          npm test -- --runInBand
+
+      - name: Package release assets
+        run: node scripts/package-maker-client-plugins.js --output-dir artifacts/maker-plugins
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          version="${{ steps.version.outputs.version }}"
+          tag="${{ steps.version.outputs.tag }}"
+          maker_version="$(node -e "const p=require('./config/maker-version-policy.json'); process.stdout.write(p.latest)")"
+          notes="$RUNNER_TEMP/maker-plugin-release-notes.md"
+          {
+            echo "# TapTap Maker Client Plugins $version"
+            echo
+            echo "Bundled Maker MCP version: $maker_version"
+            echo
+            echo "Assets: Codex plugin ZIP, WorkBuddy plugin ZIP, SHA256SUMS, and machine-readable release metadata."
+          } > "$notes"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release edit "$tag" \
+              --title "TapTap Maker Client Plugins $version" \
+              --notes-file "$notes"
+            gh release upload "$tag" artifacts/maker-plugins/* --clobber
+          else
+            gh release create "$tag" artifacts/maker-plugins/* \
+              --target "${{ github.sha }}" \
+              --title "TapTap Maker Client Plugins $version" \
+              --notes-file "$notes"
+          fi

--- a/scripts/release-scope.cjs
+++ b/scripts/release-scope.cjs
@@ -15,6 +15,8 @@ const MAKER_PATH_PREFIXES = [
 ];
 
 const MAKER_EXACT_PATHS = new Set([
+  '.github/workflows/prepare-maker-plugin-release.yml',
+  '.github/workflows/publish-maker-plugin.yml',
   '.github/workflows/publish-maker.yml',
   'bin/taptap-maker',
   'config/maker-version-policy.json',
@@ -31,6 +33,8 @@ const RELEASE_INFRA_EXACT_PATHS = new Set([
   '.github/workflows/pr.yml',
   '.github/workflows/release.yml',
   '.github/workflows/publish-maker.yml',
+  '.github/workflows/prepare-maker-plugin-release.yml',
+  '.github/workflows/publish-maker-plugin.yml',
   '.releaserc.cjs',
   'CONTRIBUTING.md',
   'README.md',
@@ -50,6 +54,7 @@ const RELEASE_INFRA_EXACT_PATHS = new Set([
   'src/__tests__/mainReleaseVersionPolicy.test.ts',
   'src/__tests__/mainReleaseNotes.test.ts',
   'src/__tests__/makerVersionPolicy.test.ts',
+  'src/__tests__/makerPluginReleaseWorkflow.test.ts',
   'src/__tests__/releaseScope.test.ts',
   'src/__tests__/releaseScopeCli.test.ts',
   'src/__tests__/semanticReleaseMainAnalyzer.test.ts',

--- a/scripts/release-scope.cjs
+++ b/scripts/release-scope.cjs
@@ -8,6 +8,9 @@ const MAKER_MARKER_PATTERN = /\(maker\)/i;
 
 const MAKER_PATH_PREFIXES = [
   'packages/maker/',
+  'plugin-sources/taptap-maker/',
+  'plugins/taptap-maker/',
+  'plugins/workbuddy/taptap-maker/',
   'src/maker/',
   'skills/taptap-maker-local/',
   'skills/taptap-maker-dev-kit-guide/',
@@ -15,16 +18,24 @@ const MAKER_PATH_PREFIXES = [
 ];
 
 const MAKER_EXACT_PATHS = new Set([
+  '.agents/plugins/marketplace.json',
+  '.codebuddy-plugin/marketplace.json',
   '.github/workflows/prepare-maker-plugin-release.yml',
   '.github/workflows/publish-maker-plugin.yml',
   '.github/workflows/publish-maker.yml',
   'bin/taptap-maker',
+  'config/maker-plugin-version.json',
   'config/maker-version-policy.json',
   'docs/MAKER.md',
   'docs/MAKER_CLI_MCP_SKILL_REWORK_OVERVIEW.md',
   'scripts/bundle-maker.js',
+  'scripts/package-maker-client-plugins.js',
   'scripts/prepare-maker-package.js',
+  'scripts/prepare-maker-codex-plugin.js',
+  'scripts/prepare-maker-workbuddy-plugin.js',
+  'scripts/resolve-maker-plugin-version.js',
   'scripts/resolve-maker-version.js',
+  'scripts/update-maker-plugin-version.js',
   'scripts/update-maker-version-policy.cjs',
 ]);
 

--- a/src/__tests__/makerPluginReleaseWorkflow.test.ts
+++ b/src/__tests__/makerPluginReleaseWorkflow.test.ts
@@ -16,12 +16,14 @@ describe('Maker plugin release workflows', () => {
       expect(workflow).toContain("needs.preflight.outputs.support_ready == 'true'");
       expect(workflow).toContain('package.json#scripts.$script');
     }
+    expect(publish).toContain('.codebuddy-plugin/marketplace.json');
   });
 
   it('keeps an unpublished configured stable version and only increments a published one', () => {
     expect(prepare).toContain('refs/tags/maker-plugin-v$current_version');
     expect(prepare).toContain('const version=process.argv[1]');
     expect(prepare).toContain('scripts/resolve-maker-plugin-version.js');
+    expect(prepare).toContain("title: 'chore(maker): prepare plugin");
   });
 
   it('supports stable main releases and public develop prereleases', () => {

--- a/src/__tests__/makerPluginReleaseWorkflow.test.ts
+++ b/src/__tests__/makerPluginReleaseWorkflow.test.ts
@@ -39,6 +39,12 @@ describe('Maker plugin release workflows', () => {
   });
 
   it('pins actions that receive the release private key or token', () => {
+    for (const workflow of [prepare, publish]) {
+      expect(workflow).toContain('actions/checkout@11d5960a326750d5838078e36cf38b85af677262');
+      expect(workflow).toContain('actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020');
+      expect(workflow).not.toContain('actions/checkout@v4');
+      expect(workflow).not.toContain('actions/setup-node@v4');
+    }
     expect(prepare).toContain(
       'actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349'
     );

--- a/src/__tests__/makerPluginReleaseWorkflow.test.ts
+++ b/src/__tests__/makerPluginReleaseWorkflow.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+function readWorkflow(name: string) {
+  return readFileSync(join(process.cwd(), '.github', 'workflows', name), 'utf8');
+}
+
+describe('Maker plugin release workflows', () => {
+  const prepare = readWorkflow('prepare-maker-plugin-release.yml');
+  const publish = readWorkflow('publish-maker-plugin.yml');
+
+  it('gates release jobs until plugin support is present', () => {
+    for (const workflow of [prepare, publish]) {
+      expect(workflow).toContain('name: Check plugin release support');
+      expect(workflow).toContain('support_ready');
+      expect(workflow).toContain("needs.preflight.outputs.support_ready == 'true'");
+      expect(workflow).toContain('package.json#scripts.$script');
+    }
+  });
+
+  it('keeps an unpublished configured stable version and only increments a published one', () => {
+    expect(prepare).toContain('refs/tags/maker-plugin-v$current_version');
+    expect(prepare).toContain('const version=process.argv[1]');
+    expect(prepare).toContain('scripts/resolve-maker-plugin-version.js');
+  });
+
+  it('supports stable main releases and public develop prereleases', () => {
+    expect(publish).toContain("github.ref_name == 'main' || github.ref_name == 'develop'");
+    expect(publish).toContain('channel=stable');
+    expect(publish).toContain('channel=dev');
+    expect(publish).toContain('maker-plugin-v$base_version');
+    expect(publish).toContain('refs/tags/maker-plugin-v$base_version');
+    expect(publish).toContain('next_version');
+    expect(publish).toContain('--prerelease');
+    expect(publish).toContain('p.version=process.argv[1]');
+    expect(publish).toContain("path='.codebuddy-plugin/marketplace.json'");
+  });
+
+  it('pins actions that receive the release private key or token', () => {
+    expect(prepare).toContain(
+      'actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349'
+    );
+    expect(prepare).toContain(
+      'peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c'
+    );
+    expect(prepare).not.toContain('actions/create-github-app-token@v2');
+    expect(prepare).not.toContain('peter-evans/create-pull-request@v6');
+  });
+
+  it('grants write permissions only to jobs that publish repository state', () => {
+    for (const workflow of [prepare, publish]) {
+      expect(workflow).toContain('permissions:\n  contents: read');
+      expect(workflow).toContain('permissions:\n      contents: write');
+    }
+    expect(prepare).toContain('pull-requests: write');
+  });
+
+  it('detects tracked and untracked generated changes and uses one package entry point', () => {
+    expect(publish).toContain('git status --porcelain');
+    expect(prepare).toContain('npm run maker:plugins:package --');
+    expect(publish).toContain('npm run maker:plugins:package --');
+    expect(publish).not.toContain('node scripts/package-maker-client-plugins.js --output-dir');
+  });
+});

--- a/src/__tests__/releaseScope.test.ts
+++ b/src/__tests__/releaseScope.test.ts
@@ -18,6 +18,19 @@ describe('release-scope classifier', () => {
       releaseScope.isMakerOwnedPath('.github/workflows/prepare-maker-plugin-release.yml')
     ).toBe(true);
     expect(releaseScope.isMakerOwnedPath('.github/workflows/publish-maker-plugin.yml')).toBe(true);
+    expect(releaseScope.isMakerOwnedPath('config/maker-plugin-version.json')).toBe(true);
+    expect(releaseScope.isMakerOwnedPath('.agents/plugins/marketplace.json')).toBe(true);
+    expect(releaseScope.isMakerOwnedPath('.codebuddy-plugin/marketplace.json')).toBe(true);
+    expect(
+      releaseScope.isMakerOwnedPath('plugin-sources/taptap-maker/workbuddy/bin/run-node')
+    ).toBe(true);
+    expect(releaseScope.isMakerOwnedPath('plugins/taptap-maker/.mcp.json')).toBe(true);
+    expect(releaseScope.isMakerOwnedPath('plugins/workbuddy/taptap-maker/.mcp.json')).toBe(true);
+    expect(releaseScope.isMakerOwnedPath('scripts/package-maker-client-plugins.js')).toBe(true);
+    expect(releaseScope.isMakerOwnedPath('scripts/prepare-maker-codex-plugin.js')).toBe(true);
+    expect(releaseScope.isMakerOwnedPath('scripts/prepare-maker-workbuddy-plugin.js')).toBe(true);
+    expect(releaseScope.isMakerOwnedPath('scripts/resolve-maker-plugin-version.js')).toBe(true);
+    expect(releaseScope.isMakerOwnedPath('scripts/update-maker-plugin-version.js')).toBe(true);
     expect(releaseScope.isMakerOwnedPath('.github/workflows/release.yml')).toBe(false);
     expect(releaseScope.isMakerOwnedPath('package.json')).toBe(false);
   });

--- a/src/__tests__/releaseScope.test.ts
+++ b/src/__tests__/releaseScope.test.ts
@@ -14,6 +14,10 @@ describe('release-scope classifier', () => {
     expect(releaseScope.isMakerOwnedPath('src/__tests__/makerRuntimeLogs.test.ts')).toBe(true);
     expect(releaseScope.isMakerOwnedPath('config/maker-version-policy.json')).toBe(true);
     expect(releaseScope.isMakerOwnedPath('scripts/update-maker-version-policy.cjs')).toBe(true);
+    expect(
+      releaseScope.isMakerOwnedPath('.github/workflows/prepare-maker-plugin-release.yml')
+    ).toBe(true);
+    expect(releaseScope.isMakerOwnedPath('.github/workflows/publish-maker-plugin.yml')).toBe(true);
     expect(releaseScope.isMakerOwnedPath('.github/workflows/release.yml')).toBe(false);
     expect(releaseScope.isMakerOwnedPath('package.json')).toBe(false);
   });
@@ -45,6 +49,8 @@ describe('release-scope classifier', () => {
       '.github/workflows/claude-review.yml',
       '.github/workflows/release.yml',
       '.github/workflows/publish-maker.yml',
+      '.github/workflows/prepare-maker-plugin-release.yml',
+      '.github/workflows/publish-maker-plugin.yml',
       'scripts/release-scope.cjs',
       'scripts/update-maker-version-policy.cjs',
       'scripts/resolve-main-release-version.js',
@@ -65,6 +71,20 @@ describe('release-scope classifier', () => {
     expect(classification.hasMakerChanges).toBe(true);
     expect(classification.hasNonMakerChanges).toBe(true);
     expect(classification.onlyReleaseInfrastructureChanged).toBe(true);
+  });
+
+  it('keeps Maker plugin release workflows out of the main package release', () => {
+    const result = releaseScope.shouldSkipLegacyRelease({
+      files: [
+        '.github/workflows/prepare-maker-plugin-release.yml',
+        '.github/workflows/publish-maker-plugin.yml',
+      ],
+      markerText: 'ci(maker-plugin): update plugin publishing',
+    });
+
+    expect(result.onlyMakerChanged).toBe(true);
+    expect(result.onlyReleaseInfrastructureChanged).toBe(true);
+    expect(result.skipLegacyRelease).toBe(true);
   });
 
   it('uses three-dot diff to avoid base-only changes in PR scope detection', () => {


### PR DESCRIPTION
## 改动内容

- 新增 Maker 插件 patch 版本准备 workflow，并自动创建版本更新 PR
- 新增 Codex 与 WorkBuddy 插件 GitHub Release 发布 workflow
- 注册插件 workflow 为 Maker release infrastructure，避免进入主包发布范围
- 支持 `main` 稳定版与未来 `develop` 公开测试版的独立发布身份
- 插件支持尚未合入目标分支时安全跳过，并显示缺失依赖

## 分支与版本策略

- `main`：稳定版，使用 `maker-plugin-v<version>` tag 和正式 GitHub Release
- `develop`：公开测试版，使用下一 patch 的 `<version>-dev.<run_number>` 和 GitHub Prerelease
- 两个分支使用独立 tag，测试版不会覆盖稳定版
- workflow 只预留 `develop` 支持，本 PR 不创建该长期分支

## 影响面

- 本 PR 仅包含 GitHub Actions、release-scope 分类及 workflow 契约测试
- 当前 main 尚无插件脚本和 `config/maker-plugin-version.json`；在插件支持代码合入前，手动运行只执行预检并安全跳过
- 不调用 `npm publish`，不影响 Maker MCP 和主包现有发布流程
- 接触 GitHub App 私钥/token 的 Actions 固定到完整 commit SHA

## 验证

- 全量测试：51 suites、760 tests passed
- Lint 与 Prettier 检查通过
- YAML 解析通过
- `git diff --check` 通过