### PR TITLE
ci(release): 建立 Maker 插件独立发布流程

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
   schedule:
     - cron: '40 2 * * 1'
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - develop
       - beta
       - alpha
       - next

--- a/.github/workflows/prepare-maker-plugin-release.yml
+++ b/.github/workflows/prepare-maker-plugin-release.yml
@@ -31,6 +31,15 @@ jobs:
             exit 1
           fi
 
+      - name: Require plugin release support
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! -f config/maker-plugin-version.json ]]; then
+            echo "::error::Merge the Maker client plugin implementation before publishing."
+            exit 1
+          fi
+
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:

--- a/.github/workflows/prepare-maker-plugin-release.yml
+++ b/.github/workflows/prepare-maker-plugin-release.yml
@@ -1,0 +1,97 @@
+name: Prepare Maker Plugin Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: prepare-maker-plugin-release
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Prepare next plugin patch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate release branch
+        shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [[ "$REF_NAME" != "main" ]]; then
+            echo "::error::Stable Maker plugin versions must be prepared from main."
+            exit 1
+          fi
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Resolve next plugin version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          current_version="$(node -e "const p=require('./config/maker-plugin-version.json'); process.stdout.write(p.version)")"
+          if git rev-parse "refs/tags/maker-plugin-v$current_version" >/dev/null 2>&1; then
+            result="$(node scripts/resolve-maker-plugin-version.js --latest-tag "maker-plugin-v$current_version" --json)"
+          else
+            result="$(node -e 'const version=process.argv[1]; process.stdout.write(JSON.stringify({version, tag:`maker-plugin-v${version}`}))' "$current_version")"
+          fi
+          version="$(node -e 'const value=JSON.parse(process.argv[1]); process.stdout.write(value.version)' "$result")"
+          tag="$(node -e 'const value=JSON.parse(process.argv[1]); process.stdout.write(value.tag)' "$result")"
+          [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          [[ "$tag" == "maker-plugin-v$version" ]]
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Update version and generated plugins
+        env:
+          PLUGIN_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          node scripts/update-maker-plugin-version.js --version "$PLUGIN_VERSION"
+          npm run maker:codex-plugin:prepare
+          npm run maker:workbuddy-plugin:prepare
+
+      - name: Verify release candidate
+        run: npm run maker:plugins:package -- --output-dir "$RUNNER_TEMP/maker-plugins"
+
+      - name: Generate release PR token
+        id: release-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Create release PR
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
+        with:
+          token: ${{ steps.release-token.outputs.token }}
+          branch: chore/maker-plugin-${{ steps.version.outputs.version }}
+          delete-branch: true
+          title: 'chore(maker): prepare plugin ${{ steps.version.outputs.version }}'
+          commit-message: |
+            chore(maker): prepare plugin ${{ steps.version.outputs.version }}
+
+            - Increment the independent Maker client plugin patch version
+            - Regenerate Codex and WorkBuddy self-contained plugin packages
+            - Keep the embedded Maker MCP version on its own release line
+            - Verification: lint, format check, tests, and release packaging
+          body: |
+            Prepares Maker client plugin `${{ steps.version.outputs.version }}`.
+
+            After merge, `Publish Maker Plugin` creates tag
+            `${{ steps.version.outputs.tag }}` and uploads both client ZIPs plus checksums.

--- a/.github/workflows/publish-maker-plugin.yml
+++ b/.github/workflows/publish-maker-plugin.yml
@@ -1,0 +1,155 @@
+name: Publish Maker Plugin
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - config/maker-plugin-version.json
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-maker-plugin-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish Maker client plugin
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate release channel
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [[ "$REF_NAME" == "main" ]]; then
+            exit
+          fi
+          if [[ "$REF_NAME" == "develop" && "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            exit
+          fi
+          echo "::error::Publish from main, or manually dispatch from develop."
+          exit 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Read release identity
+        id: version
+        shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          base_version="$(node -e "const p=require('./config/maker-plugin-version.json'); process.stdout.write(p.version)")"
+          [[ "$base_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          if [[ "$REF_NAME" == "develop" ]]; then
+            channel=dev
+            if git rev-parse "refs/tags/maker-plugin-v$base_version" >/dev/null 2>&1; then
+              next="$(node scripts/resolve-maker-plugin-version.js --latest-tag "maker-plugin-v$base_version" --json)"
+              next_version="$(node -e 'const value=JSON.parse(process.argv[1]); process.stdout.write(value.version)' "$next")"
+            else
+              next_version="$base_version"
+            fi
+            version="${next_version}-dev.${GITHUB_RUN_NUMBER}"
+          else
+            channel=stable
+            version="$base_version"
+          fi
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=maker-plugin-v$version" >> "$GITHUB_OUTPUT"
+
+      - name: Validate an existing release tag
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+          TARGET_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if git rev-parse "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
+            tagged_sha="$(git rev-list -n 1 "$RELEASE_TAG")"
+            if [[ "$tagged_sha" != "$TARGET_SHA" ]]; then
+              echo "::error::Release tag $RELEASE_TAG points to $tagged_sha, not $TARGET_SHA."
+              exit 1
+            fi
+          fi
+
+      - name: Verify generated plugins are current
+        if: steps.version.outputs.channel == 'stable'
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run maker:codex-plugin:prepare
+          npm run maker:workbuddy-plugin:prepare
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "::error::Generated plugin files are out of date. Run the prepare scripts and commit the result."
+            git status --porcelain
+            exit 1
+          fi
+
+      - name: Package release assets
+        shell: bash
+        env:
+          RELEASE_CHANNEL: ${{ steps.version.outputs.channel }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ "$RELEASE_CHANNEL" == "dev" ]]; then
+            node -e "const fs=require('fs'); const path='config/maker-plugin-version.json'; const p=require('./'+path); p.version=process.argv[1]; fs.writeFileSync(path, JSON.stringify(p, null, 2)+'\\n')" "$RELEASE_VERSION"
+            node -e "const fs=require('fs'); const path='.codebuddy-plugin/marketplace.json'; const p=require('./'+path); const entry=p.plugins.find(item=>item.name==='taptap-maker'); if(!entry) throw new Error('Missing taptap-maker marketplace entry'); entry.version=process.argv[1]; fs.writeFileSync(path, JSON.stringify(p, null, 2)+'\\n')" "$RELEASE_VERSION"
+          fi
+          npm run maker:plugins:package -- --output-dir artifacts/maker-plugins
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_CHANNEL: ${{ steps.version.outputs.channel }}
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          TARGET_SHA: ${{ github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          maker_version="$(node -e "const p=require('./config/maker-version-policy.json'); process.stdout.write(p.latest)")"
+          notes="$RUNNER_TEMP/maker-plugin-release-notes.md"
+          {
+            echo "# TapTap Maker Client Plugins $RELEASE_VERSION"
+            echo
+            echo "Bundled Maker MCP version: $maker_version"
+            echo
+            echo "Assets: Codex plugin ZIP, WorkBuddy plugin ZIP, SHA256SUMS, and machine-readable release metadata."
+          } > "$notes"
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release edit "$RELEASE_TAG" \
+              --title "TapTap Maker Client Plugins $RELEASE_VERSION" \
+              --notes-file "$notes"
+            gh release upload "$RELEASE_TAG" artifacts/maker-plugins/* --clobber
+          else
+            release_flags=()
+            if [[ "$RELEASE_CHANNEL" == "dev" ]]; then
+              release_flags+=(--prerelease)
+            fi
+            gh release create "$RELEASE_TAG" artifacts/maker-plugins/* "${release_flags[@]}" \
+              --target "$TARGET_SHA" \
+              --title "TapTap Maker Client Plugins $RELEASE_VERSION" \
+              --notes-file "$notes"
+          fi

--- a/.github/workflows/publish-maker-plugin.yml
+++ b/.github/workflows/publish-maker-plugin.yml
@@ -43,6 +43,15 @@ jobs:
           echo "::error::Publish from main, or manually dispatch from develop."
           exit 1
 
+      - name: Require plugin release support
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! -f config/maker-plugin-version.json ]]; then
+            echo "::error::Merge the Maker client plugin implementation before publishing."
+            exit 1
+          fi
+
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -61,6 +61,7 @@
 
 ```
 main          # 稳定版本（1.2.3）- 受保护
+├── develop   # Maker 客户端插件公开测试分支，可通过 PR 合入 main
 ├── beta      # Beta 测试版（1.3.0-beta.1）
 ├── alpha     # Alpha 早期版（1.3.0-alpha.1）
 ├── next      # 下一个主版本（2.0.0-next.1）
@@ -71,6 +72,7 @@ main          # 稳定版本（1.2.3）- 受保护
 
 - **`main` 分支受组织级 Ruleset (trunk-guard) 保护**
 - 所有更改必须通过 PR 合并
+- `develop` 作为长期测试分支也必须通过 PR Check，验证后可以通过 PR 合入 `main`
 - PR 必须通过所有 CI 检查
 - Commit 消息必须符合 Conventional Commits 规范
 
@@ -399,6 +401,25 @@ Maker 包版本号使用 semver。CI 自动递增默认在 `beta` 或 `main` 分
 `0.0.17` 和 `tag=latest`。手动发布如果要改变 major 或 minor，CI 会在预检 job 的
 Actions Summary 展示当前线上 dist-tag 版本和目标版本，人工核对后点击 protected
 environment 审批按钮继续发布。
+
+### 5.6 Maker 客户端插件发布工作流
+
+Codex 和 WorkBuddy 插件共用独立插件版本，不复用 `@taptap/maker` npm 版本。版本真源是
+`config/maker-plugin-version.json`，稳定版本从 `0.0.1` 开始，只递增 patch。
+
+稳定版发布分成两个明确阶段：
+
+1. 从 `main` 手动运行 `Prepare Maker Plugin Release`。它计算下一个可用 patch，更新版本真源，
+   重新生成两个客户端插件并创建版本 PR。
+2. 版本 PR 通过普通 PR Check 并合入 `main` 后，`Publish Maker Plugin` 自动校验生成物，打包
+   Codex 与 WorkBuddy ZIP、校验和及机器可读元数据，并创建 `maker-plugin-v<version>` Release。
+
+公开测试版只能从 `develop` 手动运行 `Publish Maker Plugin`，版本格式为下一个稳定 patch 加
+`-dev.<run_number>`，并标记为 GitHub Prerelease。`develop` push 不自动发版。测试通过后，代码通过
+PR 合入 `main`，再走稳定版准备流程。
+
+插件发布只创建 GitHub Release，不执行 `npm publish`，也不修改 Maker MCP 或主包的 npm 发布规则。
+重复运行同一提交时允许更新同一 Release 的附件；同名 tag 指向其它提交时必须失败。
 
 ---
 

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -68,6 +68,18 @@ Maker 包版本号使用三段式 semver，例如 `0.0.1`。Maker 包只能从�
 目标版本，人工核对后点击 protected environment 审批按钮继续发布。发布 job 在
 `npm publish` 前会再次查询目标版本是否仍未发布，避免审批等待期间同版本被抢先发布。
 
+## Maker 客户端插件发布边界
+
+Codex 和 WorkBuddy 插件使用 `config/maker-plugin-version.json` 中的独立版本，不跟随
+`@taptap/maker` npm 版本。稳定版从 `0.0.1` 开始，只递增 patch。
+
+- 从 `main` 手动运行 `Prepare Maker Plugin Release`，生成版本 PR；PR 合入后自动创建
+  `maker-plugin-v<version>` GitHub Release，并上传两个客户端 ZIP 和 SHA-256 校验文件。
+- 从 `develop` 手动运行 `Publish Maker Plugin` 可发布 `-dev.<run_number>` 测试版；它不会因
+  `develop` push 自动触发，也不会占用稳定版本号。
+- 插件运行时不依赖 npm/npx；发布流程不执行 `npm publish`，不会发布或更新
+  `@taptap/maker`，也不会影响原 Maker MCP 的安装流程。
+
 ### 主包迁移说明
 
 主包 `@taptap/instant-games-open-mcp` 只保留 TapTap Open API MCP server 和 proxy 入口。

--- a/scripts/release-scope.cjs
+++ b/scripts/release-scope.cjs
@@ -8,6 +8,9 @@ const MAKER_MARKER_PATTERN = /\(maker\)/i;
 
 const MAKER_PATH_PREFIXES = [
   'packages/maker/',
+  'plugin-sources/taptap-maker/',
+  'plugins/taptap-maker/',
+  'plugins/workbuddy/taptap-maker/',
   'src/maker/',
   'skills/taptap-maker-local/',
   'skills/taptap-maker-dev-kit-guide/',
@@ -15,22 +18,35 @@ const MAKER_PATH_PREFIXES = [
 ];
 
 const MAKER_EXACT_PATHS = new Set([
+  '.agents/plugins/marketplace.json',
+  '.codebuddy-plugin/marketplace.json',
+  '.github/workflows/prepare-maker-plugin-release.yml',
+  '.github/workflows/publish-maker-plugin.yml',
   '.github/workflows/publish-maker.yml',
   'bin/taptap-maker',
+  'config/maker-plugin-version.json',
   'config/maker-version-policy.json',
   'docs/MAKER.md',
   'docs/MAKER_CLI_MCP_SKILL_REWORK_OVERVIEW.md',
   'scripts/bundle-maker.js',
+  'scripts/package-maker-client-plugins.js',
   'scripts/prepare-maker-package.js',
+  'scripts/prepare-maker-codex-plugin.js',
+  'scripts/prepare-maker-workbuddy-plugin.js',
+  'scripts/resolve-maker-plugin-version.js',
   'scripts/resolve-maker-version.js',
+  'scripts/update-maker-plugin-version.js',
   'scripts/update-maker-version-policy.cjs',
 ]);
 
 const RELEASE_INFRA_EXACT_PATHS = new Set([
   '.github/workflows/claude-review.yml',
+  '.github/workflows/codeql.yml',
   '.github/workflows/pr.yml',
   '.github/workflows/release.yml',
   '.github/workflows/publish-maker.yml',
+  '.github/workflows/prepare-maker-plugin-release.yml',
+  '.github/workflows/publish-maker-plugin.yml',
   '.releaserc.cjs',
   'CONTRIBUTING.md',
   'README.md',
@@ -50,6 +66,7 @@ const RELEASE_INFRA_EXACT_PATHS = new Set([
   'src/__tests__/mainReleaseVersionPolicy.test.ts',
   'src/__tests__/mainReleaseNotes.test.ts',
   'src/__tests__/makerVersionPolicy.test.ts',
+  'src/__tests__/makerPluginReleaseWorkflow.test.ts',
   'src/__tests__/releaseScope.test.ts',
   'src/__tests__/releaseScopeCli.test.ts',
   'src/__tests__/semanticReleaseMainAnalyzer.test.ts',

--- a/src/__tests__/makerPluginReleaseWorkflow.test.ts
+++ b/src/__tests__/makerPluginReleaseWorkflow.test.ts
@@ -1,0 +1,108 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { parse } from 'yaml';
+
+function readWorkflow(name: string) {
+  return readFileSync(join(process.cwd(), '.github', 'workflows', name), 'utf8');
+}
+
+function readWorkflowDocument(name: string) {
+  return parse(readWorkflow(name)) as {
+    on?: { push?: { branches?: string[] }; pull_request?: { branches?: string[] } };
+    jobs?: Record<string, { steps?: Array<{ run?: string }> }>;
+  };
+}
+
+function readRunScripts(name: string) {
+  const workflow = readWorkflowDocument(name);
+  return Object.values(workflow.jobs || {})
+    .flatMap((job) => job.steps || [])
+    .map((step) => step.run)
+    .filter((run): run is string => typeof run === 'string');
+}
+
+describe('Maker plugin release workflows', () => {
+  const prepare = readWorkflow('prepare-maker-plugin-release.yml');
+  const publish = readWorkflow('publish-maker-plugin.yml');
+
+  it('fails normally when release inputs are missing instead of reporting a green no-op', () => {
+    for (const workflow of [prepare, publish]) {
+      expect(workflow).not.toContain('support_ready');
+      expect(workflow).not.toContain('exit 0');
+      expect(workflow).not.toContain('plugin support has not reached this branch');
+    }
+  });
+
+  it('keeps an unpublished configured stable version and only increments a published one', () => {
+    expect(prepare).toContain('refs/tags/maker-plugin-v$current_version');
+    expect(prepare).toContain('const version=process.argv[1]');
+    expect(prepare).toContain('scripts/resolve-maker-plugin-version.js');
+    expect(prepare).toContain("title: 'chore(maker): prepare plugin");
+  });
+
+  it('publishes stable versions from main and manual prereleases from develop', () => {
+    const publishDocument = readWorkflowDocument('publish-maker-plugin.yml');
+
+    expect(publishDocument.on?.push?.branches).toEqual(['main']);
+    expect(publish).toContain('Publish from main, or manually dispatch from develop.');
+    expect(publish).toContain('EVENT_NAME: ${{ github.event_name }}');
+    expect(publish).toContain('REF_NAME: ${{ github.ref_name }}');
+    expect(publish).toContain('channel=stable');
+    expect(publish).toContain('channel=dev');
+    expect(publish).toContain('[[ "$base_version" =~ ^[0-9]+\\.[0-9]+\\.[0-9]+$ ]]');
+    expect(publish).toContain('maker-plugin-v$base_version');
+    expect(publish).toContain('refs/tags/maker-plugin-v$base_version');
+    expect(publish).toContain('next_version');
+    expect(publish).toContain('--prerelease');
+    expect(publish).toContain('p.version=process.argv[1]');
+    expect(publish).toContain("path='.codebuddy-plugin/marketplace.json'");
+  });
+
+  it('passes GitHub values to shell through environment variables', () => {
+    for (const workflowName of ['prepare-maker-plugin-release.yml', 'publish-maker-plugin.yml']) {
+      for (const run of readRunScripts(workflowName)) {
+        expect(run).not.toContain('${{');
+      }
+    }
+  });
+
+  it('runs the normal PR quality checks for develop changes', () => {
+    const prCheck = readWorkflowDocument('pr.yml');
+    const codeql = readWorkflowDocument('codeql.yml');
+    expect(prCheck.on?.pull_request?.branches).toContain('develop');
+    expect(codeql.on?.pull_request?.branches).toContain('develop');
+  });
+
+  it('pins actions that receive the release private key or token', () => {
+    for (const workflow of [prepare, publish]) {
+      expect(workflow).toContain('actions/checkout@11d5960a326750d5838078e36cf38b85af677262');
+      expect(workflow).toContain('actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020');
+      expect(workflow).not.toContain('actions/checkout@v4');
+      expect(workflow).not.toContain('actions/setup-node@v4');
+    }
+    expect(prepare).toContain(
+      'actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349'
+    );
+    expect(prepare).toContain(
+      'peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c'
+    );
+    expect(prepare).not.toContain('actions/create-github-app-token@v2');
+    expect(prepare).not.toContain('peter-evans/create-pull-request@v6');
+  });
+
+  it('grants write permissions only to jobs that publish repository state', () => {
+    for (const workflow of [prepare, publish]) {
+      expect(workflow).toContain('permissions:\n  contents: read');
+    }
+    expect(prepare).not.toContain('contents: write');
+    expect(prepare).not.toContain('pull-requests: write');
+    expect(publish).toContain('permissions:\n      contents: write');
+  });
+
+  it('detects tracked and untracked generated changes and uses one package entry point', () => {
+    expect(publish).toContain('git status --porcelain');
+    expect(prepare).toContain('npm run maker:plugins:package --');
+    expect(publish).toContain('npm run maker:plugins:package --');
+    expect(publish).not.toContain('node scripts/package-maker-client-plugins.js --output-dir');
+  });
+});

--- a/src/__tests__/makerPluginReleaseWorkflow.test.ts
+++ b/src/__tests__/makerPluginReleaseWorkflow.test.ts
@@ -30,6 +30,9 @@ describe('Maker plugin release workflows', () => {
       expect(workflow).not.toContain('support_ready');
       expect(workflow).not.toContain('exit 0');
       expect(workflow).not.toContain('plugin support has not reached this branch');
+      expect(workflow).toContain('name: Require plugin release support');
+      expect(workflow).toContain('config/maker-plugin-version.json');
+      expect(workflow).toContain('Merge the Maker client plugin implementation before publishing.');
     }
   });
 

--- a/src/__tests__/releaseScope.test.ts
+++ b/src/__tests__/releaseScope.test.ts
@@ -14,6 +14,23 @@ describe('release-scope classifier', () => {
     expect(releaseScope.isMakerOwnedPath('src/__tests__/makerRuntimeLogs.test.ts')).toBe(true);
     expect(releaseScope.isMakerOwnedPath('config/maker-version-policy.json')).toBe(true);
     expect(releaseScope.isMakerOwnedPath('scripts/update-maker-version-policy.cjs')).toBe(true);
+    expect(
+      releaseScope.isMakerOwnedPath('.github/workflows/prepare-maker-plugin-release.yml')
+    ).toBe(true);
+    expect(releaseScope.isMakerOwnedPath('.github/workflows/publish-maker-plugin.yml')).toBe(true);
+    expect(releaseScope.isMakerOwnedPath('config/maker-plugin-version.json')).toBe(true);
+    expect(releaseScope.isMakerOwnedPath('.agents/plugins/marketplace.json')).toBe(true);
+    expect(releaseScope.isMakerOwnedPath('.codebuddy-plugin/marketplace.json')).toBe(true);
+    expect(
+      releaseScope.isMakerOwnedPath('plugin-sources/taptap-maker/workbuddy/bin/run-node')
+    ).toBe(true);
+    expect(releaseScope.isMakerOwnedPath('plugins/taptap-maker/.mcp.json')).toBe(true);
+    expect(releaseScope.isMakerOwnedPath('plugins/workbuddy/taptap-maker/.mcp.json')).toBe(true);
+    expect(releaseScope.isMakerOwnedPath('scripts/package-maker-client-plugins.js')).toBe(true);
+    expect(releaseScope.isMakerOwnedPath('scripts/prepare-maker-codex-plugin.js')).toBe(true);
+    expect(releaseScope.isMakerOwnedPath('scripts/prepare-maker-workbuddy-plugin.js')).toBe(true);
+    expect(releaseScope.isMakerOwnedPath('scripts/resolve-maker-plugin-version.js')).toBe(true);
+    expect(releaseScope.isMakerOwnedPath('scripts/update-maker-plugin-version.js')).toBe(true);
     expect(releaseScope.isMakerOwnedPath('.github/workflows/release.yml')).toBe(false);
     expect(releaseScope.isMakerOwnedPath('package.json')).toBe(false);
   });
@@ -43,8 +60,11 @@ describe('release-scope classifier', () => {
   it('recognizes release infrastructure paths that intentionally span release ownership', () => {
     const classification = releaseScope.classifyFiles([
       '.github/workflows/claude-review.yml',
+      '.github/workflows/codeql.yml',
       '.github/workflows/release.yml',
       '.github/workflows/publish-maker.yml',
+      '.github/workflows/prepare-maker-plugin-release.yml',
+      '.github/workflows/publish-maker-plugin.yml',
       'scripts/release-scope.cjs',
       'scripts/update-maker-version-policy.cjs',
       'scripts/resolve-main-release-version.js',
@@ -65,6 +85,20 @@ describe('release-scope classifier', () => {
     expect(classification.hasMakerChanges).toBe(true);
     expect(classification.hasNonMakerChanges).toBe(true);
     expect(classification.onlyReleaseInfrastructureChanged).toBe(true);
+  });
+
+  it('keeps Maker plugin release workflows out of the main package release', () => {
+    const result = releaseScope.shouldSkipLegacyRelease({
+      files: [
+        '.github/workflows/prepare-maker-plugin-release.yml',
+        '.github/workflows/publish-maker-plugin.yml',
+      ],
+      markerText: 'ci(maker-plugin): update plugin publishing',
+    });
+
+    expect(result.onlyMakerChanged).toBe(true);
+    expect(result.onlyReleaseInfrastructureChanged).toBe(true);
+    expect(result.skipLegacyRelease).toBe(true);
   });
 
   it('uses three-dot diff to avoid base-only changes in PR scope detection', () => {


### PR DESCRIPTION
## 改动内容

- 新增 `Prepare Maker Plugin Release`，从 `main` 递增独立插件 patch 版本并创建版本 PR
- 新增 `Publish Maker Plugin`，发布 Codex 与 WorkBuddy ZIP、校验和和机器可读元数据
- 支持 `main` 稳定版与 `develop` 手动 prerelease，`develop` push 不会自动发版
- 为 `develop` PR 启用现有 PR Check 与 CodeQL，不接入主包 semantic-release

## 设计边界

- 保留 Prepare PR + Publish Release 两段式，确保版本真源和生成产物先经过分支保护
- 删除插件代码未合入时的 `support_ready` 静默兼容层，依赖缺失时直接失败
- 插件版本只读取 `config/maker-plugin-version.json`，不复用 Maker MCP 或主包版本
- 插件发布只创建 GitHub Release，不执行 `npm publish`，不影响现有 Maker MCP 和 npm 发布
- 同一提交可幂等更新 Release；同名 tag 指向其它提交时失败
- 高权限 Actions 固定完整 SHA，GitHub 上下文通过环境变量传入 shell

## 范围

本 PR 仅包含发布 workflows、共享发布范围分类、对应契约测试和正式 CI/CD 文档；不包含插件实现或 Maker MCP 运行时代码。

## 验证

- 51 个测试套件、762 个测试通过
- ESLint、Prettier、build 通过
- 全部 workflow YAML 解析通过
- commitlint、release-scope 和 `git diff --check` 通过
