### PR TITLE
fix(maker-plugin): 完善 WorkBuddy 插件生命周期与跨平台兼容

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,6 +353,9 @@ Maker 本地开发的默认路径是 CLI-first + PAT-first：
   managed Node 目录，再回退系统 PATH。Windows 必须同时支持版本目录根和 `bin` 子目录中的
   `node.exe`。插件不依赖 npm/npx，也不固定项目 `cwd`。
   `create-project` 和 `sync-project` 是仅有的两个快捷命令，执行前必须要求空 workspace。
+  WorkBuddy 插件的 `init` 和 `dev-kit update` 必须逐项检查
+  `.workbuddy/skills/taptap-maker-*`，只从 `.installer/skills` 补齐缺失的项目 Skill，不得覆盖已有
+  同名 Skill。该同步不得影响独立 Maker MCP、Codex 插件或其他客户端；目录链接不可用时才复制。
 - 客户端插件发布只使用 `Prepare Maker Plugin Release` 和 `Publish Maker Plugin` workflows。
   前者按最新 `maker-plugin-v*` tag 自动递增 patch 并创建版本 PR；后者在 PR 合并后发布两份完整
   marketplace ZIP、`SHA256SUMS` 和 `maker-plugin-release.json`。插件发布不得调用 npm publish、
@@ -362,8 +365,9 @@ Maker 本地开发的默认路径是 CLI-first + PAT-first：
   `src/maker/` 的 runtime/CLI，不复制 Maker tools、resources 或 proxy 业务逻辑。
 - 插件模式必须先按 `taptap-maker-plugin-lifecycle` 检查对应客户端的旧 Maker MCP。Codex 禁用只写
   `enabled = false`；WorkBuddy 同时检查 `~/.workbuddy/mcp.json` 和旧 `.mcp.json`，禁用只写
-  `disabled: true`。禁用和恢复都要求用户明确确认，保留原配置、最新备份和恢复状态。不得删除旧注册、
-  PAT、Maker home、项目绑定、WorkBuddy connector trust 或游戏文件。初始化必须使用
+  `disabled: true`。WorkBuddy 插件通过只读 SessionStart Hook 检查冲突并向 AI 注入提醒；只有用户
+  明确确认后才调用迁移 CLI。禁用和恢复都要求用户明确确认，保留原配置、最新备份和恢复状态。
+  不得删除旧注册、PAT、Maker home、项目绑定、WorkBuddy connector trust 或游戏文件。初始化必须使用
   `taptap-maker init --skip-mcp-install`。插件用户通过当前客户端 marketplace 更新，不运行独立 npm
   包升级。
   Codex 插件产物必须使用插件专用 `update-taptap-mcp`，不得复制 npm 发行版的更新 Skill。旧 MCP

--- a/plugin-sources/taptap-maker/workbuddy/bin/run-node
+++ b/plugin-sources/taptap-maker/workbuddy/bin/run-node
@@ -4,6 +4,10 @@
 
 set -e
 
+: "${TAPTAP_MAKER_DISTRIBUTION:=workbuddy_plugin}"
+: "${TAPTAP_MCP_CLIENT_IDE:=workbuddy}"
+export TAPTAP_MAKER_DISTRIBUTION TAPTAP_MCP_CLIENT_IDE
+
 resolve_from_extra_paths() {
   paths=${WORKBUDDY_EXTRA_PATHS:-}
   [ -n "$paths" ] || return 1

--- a/plugin-sources/taptap-maker/workbuddy/bin/run-node.cmd
+++ b/plugin-sources/taptap-maker/workbuddy/bin/run-node.cmd
@@ -2,6 +2,8 @@
 setlocal EnableExtensions
 
 set "WB_NODE="
+if not defined TAPTAP_MAKER_DISTRIBUTION set "TAPTAP_MAKER_DISTRIBUTION=workbuddy_plugin"
+if not defined TAPTAP_MCP_CLIENT_IDE set "TAPTAP_MCP_CLIENT_IDE=workbuddy"
 
 if defined WORKBUDDY_EXTRA_PATHS (
   for %%D in ("%WORKBUDDY_EXTRA_PATHS:;=" "%") do (

--- a/plugin-sources/taptap-maker/workbuddy/commands/create-project.md
+++ b/plugin-sources/taptap-maker/workbuddy/commands/create-project.md
@@ -8,7 +8,13 @@ Create a new TapTap Maker project only in an empty workspace directory.
    project or configuration files count as content. If it is not empty, stop and ask the user to
    open a new empty directory in WorkBuddy.
 2. If the user has not provided a project name, ask for one. Do not invent it.
-3. Run the bundled CLI without npm or npx:
+3. Run the bundled CLI without npm or npx. On Windows use:
+
+```bat
+"${CODEBUDDY_PLUGIN_ROOT}/bin/run-node.cmd" "${CODEBUDDY_PLUGIN_ROOT}/dist/maker.js" init --create --name "<PROJECT_NAME>" --skip-mcp-install
+```
+
+On macOS or Linux use:
 
 ```bash
 "${CODEBUDDY_PLUGIN_ROOT}/bin/run-node" "${CODEBUDDY_PLUGIN_ROOT}/dist/maker.js" init --create --name "<PROJECT_NAME>" --skip-mcp-install

--- a/plugin-sources/taptap-maker/workbuddy/commands/sync-project.md
+++ b/plugin-sources/taptap-maker/workbuddy/commands/sync-project.md
@@ -7,7 +7,13 @@ Sync an existing TapTap Maker game only into an empty workspace directory.
 1. Resolve the current WorkBuddy workspace root and verify that it exists and is empty. Hidden
    project or configuration files count as content. If it is not empty, stop and ask the user to
    open a new empty directory in WorkBuddy.
-2. Run the bundled CLI without npm or npx:
+2. Run the bundled CLI without npm or npx. On Windows use:
+
+```bat
+"${CODEBUDDY_PLUGIN_ROOT}/bin/run-node.cmd" "${CODEBUDDY_PLUGIN_ROOT}/dist/maker.js" init --skip-mcp-install
+```
+
+On macOS or Linux use:
 
 ```bash
 "${CODEBUDDY_PLUGIN_ROOT}/bin/run-node" "${CODEBUDDY_PLUGIN_ROOT}/dist/maker.js" init --skip-mcp-install

--- a/plugin-sources/taptap-maker/workbuddy/hooks/hooks.json
+++ b/plugin-sources/taptap-maker/workbuddy/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CODEBUDDY_PLUGIN_ROOT}/hooks/session-start.cjs\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugin-sources/taptap-maker/workbuddy/hooks/session-start.cjs
+++ b/plugin-sources/taptap-maker/workbuddy/hooks/session-start.cjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const pluginRoot = process.env.CODEBUDDY_PLUGIN_ROOT || path.resolve(__dirname, '..');
+const bundlePath = path.join(pluginRoot, 'dist', 'maker.js');
+
+function writeHookOutput(additionalContext) {
+  const hookSpecificOutput = additionalContext ? { additionalContext } : {};
+  process.stdout.write(`${JSON.stringify({ hookSpecificOutput })}\n`);
+}
+
+function inspectLegacyMakerMcp() {
+  const result = spawnSync(
+    process.execPath,
+    [bundlePath, 'plugin', 'inspect', '--client', 'workbuddy', '--json'],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        TAPTAP_MAKER_DISTRIBUTION: 'workbuddy_plugin',
+        TAPTAP_MCP_CLIENT_IDE: 'workbuddy',
+      },
+    }
+  );
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || `inspect exited with status ${String(result.status)}`);
+  }
+  return JSON.parse(result.stdout.trim());
+}
+
+try {
+  const inspection = inspectLegacyMakerMcp();
+  if (inspection.status === 'active') {
+    writeHookOutput(
+      'TapTap Maker 插件检测到旧的独立 Maker MCP 仍处于启用状态。继续 Maker 工作前，必须向用户说明两套 Maker MCP 会造成重复工具和双 runtime 冲突，并询问是否禁用旧 MCP。只有得到用户明确确认后，才执行插件内 CLI 的 plugin migrate --client workbuddy --confirm --json；未确认时不得修改配置。'
+    );
+  } else if (inspection.status === 'ambiguous') {
+    writeHookOutput(
+      `TapTap Maker 插件在多个 WorkBuddy 配置中检测到仍启用的独立 Maker MCP：${inspection.config_paths.join(', ')}。继续 Maker 工作前必须告知用户存在重复注册；不要自动选择或修改配置，应请用户先明确保留哪一个旧注册。`
+    );
+  } else {
+    writeHookOutput();
+  }
+} catch (error) {
+  writeHookOutput(
+    `TapTap Maker 插件未能完成旧 MCP 冲突检查：${error instanceof Error ? error.message : String(error)}。开始 Maker 工作前应加载 taptap-maker-plugin-lifecycle Skill 并执行只读检查，不要假设旧 MCP 已禁用。`
+  );
+}

--- a/plugin-sources/taptap-maker/workbuddy/skills/taptap-maker-plugin-lifecycle/SKILL.md
+++ b/plugin-sources/taptap-maker/workbuddy/skills/taptap-maker-plugin-lifecycle/SKILL.md
@@ -12,20 +12,32 @@ game files remain shared and unchanged.
 ## Bundled CLI
 
 Always use the plugin launcher with the bundled runtime. It resolves WorkBuddy's managed Node.js
-first and falls back to a system Node.js only when needed:
+first and falls back to a system Node.js only when needed. On Windows, use:
+
+```bat
+"${CODEBUDDY_PLUGIN_ROOT}/bin/run-node.cmd" "${CODEBUDDY_PLUGIN_ROOT}/dist/maker.js" <arguments>
+```
+
+On macOS or Linux, use:
 
 ```bash
 "${CODEBUDDY_PLUGIN_ROOT}/bin/run-node" "${CODEBUDDY_PLUGIN_ROOT}/dist/maker.js" <arguments>
 ```
 
+Both launchers set `TAPTAP_MAKER_DISTRIBUTION=workbuddy_plugin` and
+`TAPTAP_MCP_CLIENT_IDE=workbuddy` before starting the bundled runtime.
+In the commands below, replace `<PLUGIN_CLI>` with the complete two-part launcher command selected
+for the current operating system above.
 Do not assume `taptap-maker`, npm, or npx is on `PATH`.
 
 ## First Use and Legacy MCP Migration
 
-Before the first Maker workflow in a WorkBuddy plugin session, inspect standalone registrations:
+The plugin SessionStart hook performs a read-only inspection and injects a reminder when an active
+standalone registration exists. It never changes MCP configuration. Before the first Maker workflow
+in a WorkBuddy plugin session, follow that reminder or inspect standalone registrations directly:
 
 ```bash
-"${CODEBUDDY_PLUGIN_ROOT}/bin/run-node" "${CODEBUDDY_PLUGIN_ROOT}/dist/maker.js" plugin inspect --client workbuddy --json
+<PLUGIN_CLI> plugin inspect --client workbuddy --json
 ```
 
 Act on `status`:
@@ -40,7 +52,7 @@ Act on `status`:
 Only after explicit confirmation, disable the active standalone registration:
 
 ```bash
-"${CODEBUDDY_PLUGIN_ROOT}/bin/run-node" "${CODEBUDDY_PLUGIN_ROOT}/dist/maker.js" plugin migrate --client workbuddy --confirm --json
+<PLUGIN_CLI> plugin migrate --client workbuddy --confirm --json
 ```
 
 Migration only sets `disabled: true`, writes a latest backup, and records plugin ownership for
@@ -64,7 +76,7 @@ If the user wants to remove the plugin and resume a registration migrated by thi
 explicit confirmation, then run:
 
 ```bash
-"${CODEBUDDY_PLUGIN_ROOT}/bin/run-node" "${CODEBUDDY_PLUGIN_ROOT}/dist/maker.js" plugin restore --client workbuddy --confirm --json
+<PLUGIN_CLI> plugin restore --client workbuddy --confirm --json
 ```
 
 Restore only configuration owned by the migration state. Preserve unrelated WorkBuddy settings and

--- a/plugins/taptap-maker/README.md
+++ b/plugins/taptap-maker/README.md
@@ -1,27 +1,32 @@
-# TapTap Maker 客户端插件
+# TapTap Maker 客户端插件安装
 
-TapTap Maker 的 Codex 与 WorkBuddy 客户端插件发布页。
+这是 TapTap Maker 的统一插件安装入口，支持 Codex 和 WorkBuddy。两个插件使用同一版本，
+但安装包和客户端配置彼此独立。
 
 - 插件版本：`0.0.1`
 - 内置 Maker MCP 版本：`0.0.30`
 
-## 交给 AI 安装
+## 用户如何安装
 
-将本页面链接交给 Codex 或 WorkBuddy，并告诉 AI：`安装这个 TapTap Maker 插件`。AI 应根据
-当前客户端选择对应安装方式，不要安装独立 npm MCP。
+把本页面链接交给当前正在使用的 AI，并告诉它：`请按照页面说明安装 TapTap Maker 插件`。
 
-### Codex
+## 给安装 AI 的选择规则
 
-```bash
-codex plugin marketplace add taptap/instant-games-open-mcp --ref main \
-  --sparse .agents/plugins --sparse plugins/taptap-maker
-codex plugin add taptap-maker@taptap-maker
-```
+安装前必须先识别自己当前运行在哪个宿主客户端，再选择安装包：
 
-### WorkBuddy
+| 当前宿主客户端             | 只能选择的安装包                          |
+| -------------------------- | ----------------------------------------- |
+| 当前宿主客户端是 Codex     | `taptap-maker-codex-plugin-0.0.1.zip`     |
+| 当前宿主客户端是 WorkBuddy | `taptap-maker-workbuddy-plugin-0.0.1.zip` |
 
-在插件市场中添加本 GitHub 仓库作为本地市场源，然后安装 `taptap-maker`。如果当前版本暂不
-支持 GitHub 市场源，可下载下方 WorkBuddy ZIP 并按客户端的本地插件导入方式安装。
+必须遵守以下规则：
+
+1. 以当前对话所属的宿主客户端为准。不要根据操作系统、Node.js 环境，或本机是否存在
+   `~/.codex`、`~/.workbuddy` 目录来猜测；同一台电脑可能同时安装两个客户端。
+2. 无法确认当前宿主客户端时，先询问用户“你现在使用的是 Codex 还是 WorkBuddy？”，得到明确
+   回答前不要下载或安装。
+3. 一次只安装当前客户端对应的一个 ZIP，不要同时安装两个插件包。
+4. 不要通过 npm 或 npx 安装独立 Maker MCP；ZIP 已包含完整 MCP runtime、CLI 和 Skills。
 
 ## 下载
 
@@ -29,18 +34,37 @@ codex plugin add taptap-maker@taptap-maker
 - [WorkBuddy 插件 ZIP](https://github.com/taptap/instant-games-open-mcp/releases/download/maker-plugin-v0.0.1/taptap-maker-workbuddy-plugin-0.0.1.zip)
 - [SHA256 校验文件](https://github.com/taptap/instant-games-open-mcp/releases/download/maker-plugin-v0.0.1/SHA256SUMS)
 
-ZIP 是完整的离线 marketplace 包。AI 下载对应 ZIP 和 `SHA256SUMS`、验证 SHA-256 并解压后：
+ZIP 是完整的离线 marketplace 包。AI 只下载所选 ZIP 和 `SHA256SUMS`，验证 SHA-256 后解压。
 
-- Codex：执行 `codex plugin marketplace add <解压目录>`，再执行
-  `codex plugin add taptap-maker@taptap-maker`。
-- WorkBuddy：在 `/plugin` 中把解压目录添加为 marketplace，安装 `taptap-maker`，然后执行
-  `/reload-plugins`。
+## 安装所选插件
+
+### Codex
+
+仅当当前宿主是 Codex 时执行：
+
+1. 执行 `codex plugin marketplace add <解压目录>`。
+2. 执行 `codex plugin add taptap-maker@taptap-maker`。
+3. 重新加载插件或新建任务，确认 TapTap Maker 插件已启用。
+
+### WorkBuddy
+
+仅当当前宿主是 WorkBuddy 时执行：
+
+1. 在 `/plugin` 中把解压目录添加为 marketplace。
+2. 安装 marketplace 中的 `taptap-maker`。
+3. 执行 `/reload-plugins`，确认 TapTap Maker 插件已启用。
+
+如果当前客户端既不是 Codex 也不是 WorkBuddy，应告知用户该客户端暂未提供对应安装包，不要把
+其中一个 ZIP 当作通用 MCP 包安装。
+
+## 兼容已有 Maker MCP
 
 插件内置本地 MCP runtime、CLI、工作流 Skills 和连接排障文档。运行时不会通过 npm 或 npx
 下载或启动 Maker 包。
 
-插件会复用现有 Maker 鉴权和项目绑定。首次使用时先通过插件内 CLI 检查旧的独立 Maker MCP；
-只有用户明确确认后，才把旧 Codex 注册设置为 `enabled = false`。迁移会保留最新备份并支持恢复，
-不会删除旧注册、鉴权、项目绑定或游戏文件。
+插件会复用现有 Maker 鉴权和项目绑定。首次使用时会检查旧的独立 Maker MCP；WorkBuddy 通过
+SessionStart Hook 做只读检查并提醒 AI。只有用户明确确认后，才把旧 Codex 注册设置为
+`enabled = false`，或把旧 WorkBuddy 注册设置为 `disabled: true`。迁移会保留最新备份并支持
+恢复，不会删除旧注册、鉴权、项目绑定或游戏文件。
 
 正常 Maker 开发流程见 `skills/taptap-maker-local/SKILL.md`。

--- a/plugins/workbuddy/taptap-maker/.codebuddy-plugin/plugin.json
+++ b/plugins/workbuddy/taptap-maker/.codebuddy-plugin/plugin.json
@@ -16,5 +16,6 @@
     "./skills/taptap-maker-plugin-lifecycle",
     "./skills/update-taptap-mcp"
   ],
-  "mcpServers": "./.mcp.json"
+  "mcpServers": "./.mcp.json",
+  "hooks": "./hooks/hooks.json"
 }

--- a/plugins/workbuddy/taptap-maker/.mcp.json
+++ b/plugins/workbuddy/taptap-maker/.mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "taptap-maker-plugin": {
-      "command": "${CODEBUDDY_PLUGIN_ROOT}/bin/run-node",
+      "command": "node",
       "args": ["${CODEBUDDY_PLUGIN_ROOT}/dist/maker.js"],
       "env": {
         "TAPTAP_MAKER_DISTRIBUTION": "workbuddy_plugin",

--- a/plugins/workbuddy/taptap-maker/README.md
+++ b/plugins/workbuddy/taptap-maker/README.md
@@ -4,5 +4,11 @@
 CLI、工作流 Skills、快捷命令和连接排障文档。启动器优先使用 WorkBuddy 管理的 Node.js，必要时
 回退系统 Node.js，不会通过 npm 或 npx 下载和启动 Maker。
 
+WorkBuddy 会话启动时，插件会只读检查是否仍有独立 Maker MCP 启用。发现冲突后会要求 AI 先向
+用户说明风险并取得明确确认，再把旧注册设置为 `disabled: true`；插件不会未经确认修改配置。
+
 在空 workspace 中使用 `/taptap-maker:create-project` 创建新游戏，或使用
 `/taptap-maker:sync-project` 同步已有 Maker 游戏。插件复用现有 Maker 鉴权和项目绑定。
+
+初始化或更新 dev-kit 后，插件会把项目内 `.installer/skills` 中的 Skills 补充到
+`.workbuddy/skills/taptap-maker-*`。同步只补齐缺失项，不覆盖已有同名 Skill。

--- a/plugins/workbuddy/taptap-maker/bin/run-node
+++ b/plugins/workbuddy/taptap-maker/bin/run-node
@@ -4,6 +4,10 @@
 
 set -e
 
+: "${TAPTAP_MAKER_DISTRIBUTION:=workbuddy_plugin}"
+: "${TAPTAP_MCP_CLIENT_IDE:=workbuddy}"
+export TAPTAP_MAKER_DISTRIBUTION TAPTAP_MCP_CLIENT_IDE
+
 resolve_from_extra_paths() {
   paths=${WORKBUDDY_EXTRA_PATHS:-}
   [ -n "$paths" ] || return 1

--- a/plugins/workbuddy/taptap-maker/bin/run-node.cmd
+++ b/plugins/workbuddy/taptap-maker/bin/run-node.cmd
@@ -2,6 +2,8 @@
 setlocal EnableExtensions
 
 set "WB_NODE="
+if not defined TAPTAP_MAKER_DISTRIBUTION set "TAPTAP_MAKER_DISTRIBUTION=workbuddy_plugin"
+if not defined TAPTAP_MCP_CLIENT_IDE set "TAPTAP_MCP_CLIENT_IDE=workbuddy"
 
 if defined WORKBUDDY_EXTRA_PATHS (
   for %%D in ("%WORKBUDDY_EXTRA_PATHS:;=" "%") do (

--- a/plugins/workbuddy/taptap-maker/commands/create-project.md
+++ b/plugins/workbuddy/taptap-maker/commands/create-project.md
@@ -8,7 +8,13 @@ Create a new TapTap Maker project only in an empty workspace directory.
    project or configuration files count as content. If it is not empty, stop and ask the user to
    open a new empty directory in WorkBuddy.
 2. If the user has not provided a project name, ask for one. Do not invent it.
-3. Run the bundled CLI without npm or npx:
+3. Run the bundled CLI without npm or npx. On Windows use:
+
+```bat
+"${CODEBUDDY_PLUGIN_ROOT}/bin/run-node.cmd" "${CODEBUDDY_PLUGIN_ROOT}/dist/maker.js" init --create --name "<PROJECT_NAME>" --skip-mcp-install
+```
+
+On macOS or Linux use:
 
 ```bash
 "${CODEBUDDY_PLUGIN_ROOT}/bin/run-node" "${CODEBUDDY_PLUGIN_ROOT}/dist/maker.js" init --create --name "<PROJECT_NAME>" --skip-mcp-install

--- a/plugins/workbuddy/taptap-maker/commands/sync-project.md
+++ b/plugins/workbuddy/taptap-maker/commands/sync-project.md
@@ -7,7 +7,13 @@ Sync an existing TapTap Maker game only into an empty workspace directory.
 1. Resolve the current WorkBuddy workspace root and verify that it exists and is empty. Hidden
    project or configuration files count as content. If it is not empty, stop and ask the user to
    open a new empty directory in WorkBuddy.
-2. Run the bundled CLI without npm or npx:
+2. Run the bundled CLI without npm or npx. On Windows use:
+
+```bat
+"${CODEBUDDY_PLUGIN_ROOT}/bin/run-node.cmd" "${CODEBUDDY_PLUGIN_ROOT}/dist/maker.js" init --skip-mcp-install
+```
+
+On macOS or Linux use:
 
 ```bash
 "${CODEBUDDY_PLUGIN_ROOT}/bin/run-node" "${CODEBUDDY_PLUGIN_ROOT}/dist/maker.js" init --skip-mcp-install

--- a/plugins/workbuddy/taptap-maker/dist/maker.js
+++ b/plugins/workbuddy/taptap-maker/dist/maker.js
@@ -3234,8 +3234,8 @@ var require_utils = __commonJS({
       }
       return ind;
     }
-    function removeDotSegments(path27) {
-      let input2 = path27;
+    function removeDotSegments(path28) {
+      let input2 = path28;
       const output2 = [];
       let nextSlash = -1;
       let len = 0;
@@ -3434,8 +3434,8 @@ var require_schemes = __commonJS({
         wsComponent.secure = void 0;
       }
       if (wsComponent.resourceName) {
-        const [path27, query] = wsComponent.resourceName.split("?");
-        wsComponent.path = path27 && path27 !== "/" ? path27 : void 0;
+        const [path28, query] = wsComponent.resourceName.split("?");
+        wsComponent.path = path28 && path28 !== "/" ? path28 : void 0;
         wsComponent.query = query;
         wsComponent.resourceName = void 0;
       }
@@ -12492,12 +12492,12 @@ var require_dist = __commonJS({
         throw new Error(`Unknown format "${name}"`);
       return f;
     };
-    function addFormats(ajv, list, fs25, exportName) {
+    function addFormats(ajv, list, fs26, exportName) {
       var _a3;
       var _b;
       (_a3 = (_b = ajv.opts.code).formats) !== null && _a3 !== void 0 ? _a3 : _b.formats = (0, codegen_1._)`require("ajv-formats/dist/formats").${exportName}`;
       for (const f of list)
-        ajv.addFormat(f, fs25[f]);
+        ajv.addFormat(f, fs26[f]);
     }
     module.exports = exports = formatsPlugin;
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -12510,8 +12510,8 @@ var require_windows = __commonJS({
   "node_modules/isexe/windows.js"(exports, module) {
     module.exports = isexe;
     isexe.sync = sync;
-    var fs25 = __require("fs");
-    function checkPathExt(path27, options) {
+    var fs26 = __require("fs");
+    function checkPathExt(path28, options) {
       var pathext = options.pathExt !== void 0 ? options.pathExt : process.env.PATHEXT;
       if (!pathext) {
         return true;
@@ -12522,25 +12522,25 @@ var require_windows = __commonJS({
       }
       for (var i = 0; i < pathext.length; i++) {
         var p = pathext[i].toLowerCase();
-        if (p && path27.substr(-p.length).toLowerCase() === p) {
+        if (p && path28.substr(-p.length).toLowerCase() === p) {
           return true;
         }
       }
       return false;
     }
-    function checkStat(stat, path27, options) {
+    function checkStat(stat, path28, options) {
       if (!stat.isSymbolicLink() && !stat.isFile()) {
         return false;
       }
-      return checkPathExt(path27, options);
+      return checkPathExt(path28, options);
     }
-    function isexe(path27, options, cb) {
-      fs25.stat(path27, function(er, stat) {
-        cb(er, er ? false : checkStat(stat, path27, options));
+    function isexe(path28, options, cb) {
+      fs26.stat(path28, function(er, stat) {
+        cb(er, er ? false : checkStat(stat, path28, options));
       });
     }
-    function sync(path27, options) {
-      return checkStat(fs25.statSync(path27), path27, options);
+    function sync(path28, options) {
+      return checkStat(fs26.statSync(path28), path28, options);
     }
   }
 });
@@ -12550,14 +12550,14 @@ var require_mode = __commonJS({
   "node_modules/isexe/mode.js"(exports, module) {
     module.exports = isexe;
     isexe.sync = sync;
-    var fs25 = __require("fs");
-    function isexe(path27, options, cb) {
-      fs25.stat(path27, function(er, stat) {
+    var fs26 = __require("fs");
+    function isexe(path28, options, cb) {
+      fs26.stat(path28, function(er, stat) {
         cb(er, er ? false : checkStat(stat, options));
       });
     }
-    function sync(path27, options) {
-      return checkStat(fs25.statSync(path27), options);
+    function sync(path28, options) {
+      return checkStat(fs26.statSync(path28), options);
     }
     function checkStat(stat, options) {
       return stat.isFile() && checkMode(stat, options);
@@ -12581,7 +12581,7 @@ var require_mode = __commonJS({
 // node_modules/isexe/index.js
 var require_isexe = __commonJS({
   "node_modules/isexe/index.js"(exports, module) {
-    var fs25 = __require("fs");
+    var fs26 = __require("fs");
     var core;
     if (process.platform === "win32" || global.TESTING_WINDOWS) {
       core = require_windows();
@@ -12590,7 +12590,7 @@ var require_isexe = __commonJS({
     }
     module.exports = isexe;
     isexe.sync = sync;
-    function isexe(path27, options, cb) {
+    function isexe(path28, options, cb) {
       if (typeof options === "function") {
         cb = options;
         options = {};
@@ -12600,7 +12600,7 @@ var require_isexe = __commonJS({
           throw new TypeError("callback not provided");
         }
         return new Promise(function(resolve, reject) {
-          isexe(path27, options || {}, function(er, is) {
+          isexe(path28, options || {}, function(er, is) {
             if (er) {
               reject(er);
             } else {
@@ -12609,7 +12609,7 @@ var require_isexe = __commonJS({
           });
         });
       }
-      core(path27, options || {}, function(er, is) {
+      core(path28, options || {}, function(er, is) {
         if (er) {
           if (er.code === "EACCES" || options && options.ignoreErrors) {
             er = null;
@@ -12619,9 +12619,9 @@ var require_isexe = __commonJS({
         cb(er, is);
       });
     }
-    function sync(path27, options) {
+    function sync(path28, options) {
       try {
-        return core.sync(path27, options || {});
+        return core.sync(path28, options || {});
       } catch (er) {
         if (options && options.ignoreErrors || er.code === "EACCES") {
           return false;
@@ -12637,7 +12637,7 @@ var require_isexe = __commonJS({
 var require_which = __commonJS({
   "node_modules/which/which.js"(exports, module) {
     var isWindows = process.platform === "win32" || process.env.OSTYPE === "cygwin" || process.env.OSTYPE === "msys";
-    var path27 = __require("path");
+    var path28 = __require("path");
     var COLON = isWindows ? ";" : ":";
     var isexe = require_isexe();
     var getNotFoundError = (cmd) => Object.assign(new Error(`not found: ${cmd}`), { code: "ENOENT" });
@@ -12675,7 +12675,7 @@ var require_which = __commonJS({
           return opt.all && found.length ? resolve(found) : reject(getNotFoundError(cmd));
         const ppRaw = pathEnv[i];
         const pathPart = /^".*"$/.test(ppRaw) ? ppRaw.slice(1, -1) : ppRaw;
-        const pCmd = path27.join(pathPart, cmd);
+        const pCmd = path28.join(pathPart, cmd);
         const p = !pathPart && /^\.[\\\/]/.test(cmd) ? cmd.slice(0, 2) + pCmd : pCmd;
         resolve(subStep(p, i, 0));
       });
@@ -12702,7 +12702,7 @@ var require_which = __commonJS({
       for (let i = 0; i < pathEnv.length; i++) {
         const ppRaw = pathEnv[i];
         const pathPart = /^".*"$/.test(ppRaw) ? ppRaw.slice(1, -1) : ppRaw;
-        const pCmd = path27.join(pathPart, cmd);
+        const pCmd = path28.join(pathPart, cmd);
         const p = !pathPart && /^\.[\\\/]/.test(cmd) ? cmd.slice(0, 2) + pCmd : pCmd;
         for (let j = 0; j < pathExt.length; j++) {
           const cur = p + pathExt[j];
@@ -12750,7 +12750,7 @@ var require_path_key = __commonJS({
 var require_resolveCommand = __commonJS({
   "node_modules/cross-spawn/lib/util/resolveCommand.js"(exports, module) {
     "use strict";
-    var path27 = __require("path");
+    var path28 = __require("path");
     var which = require_which();
     var getPathKey = require_path_key();
     function resolveCommandAttempt(parsed, withoutPathExt) {
@@ -12768,7 +12768,7 @@ var require_resolveCommand = __commonJS({
       try {
         resolved = which.sync(parsed.command, {
           path: env[getPathKey({ env })],
-          pathExt: withoutPathExt ? path27.delimiter : void 0
+          pathExt: withoutPathExt ? path28.delimiter : void 0
         });
       } catch (e) {
       } finally {
@@ -12777,7 +12777,7 @@ var require_resolveCommand = __commonJS({
         }
       }
       if (resolved) {
-        resolved = path27.resolve(hasCustomCwd ? parsed.options.cwd : "", resolved);
+        resolved = path28.resolve(hasCustomCwd ? parsed.options.cwd : "", resolved);
       }
       return resolved;
     }
@@ -12831,8 +12831,8 @@ var require_shebang_command = __commonJS({
       if (!match) {
         return null;
       }
-      const [path27, argument] = match[0].replace(/#! ?/, "").split(" ");
-      const binary = path27.split("/").pop();
+      const [path28, argument] = match[0].replace(/#! ?/, "").split(" ");
+      const binary = path28.split("/").pop();
       if (binary === "env") {
         return argument;
       }
@@ -12845,16 +12845,16 @@ var require_shebang_command = __commonJS({
 var require_readShebang = __commonJS({
   "node_modules/cross-spawn/lib/util/readShebang.js"(exports, module) {
     "use strict";
-    var fs25 = __require("fs");
+    var fs26 = __require("fs");
     var shebangCommand = require_shebang_command();
     function readShebang(command) {
       const size = 150;
       const buffer = Buffer.alloc(size);
       let fd;
       try {
-        fd = fs25.openSync(command, "r");
-        fs25.readSync(fd, buffer, 0, size, 0);
-        fs25.closeSync(fd);
+        fd = fs26.openSync(command, "r");
+        fs26.readSync(fd, buffer, 0, size, 0);
+        fs26.closeSync(fd);
       } catch (e) {
       }
       return shebangCommand(buffer.toString());
@@ -12867,7 +12867,7 @@ var require_readShebang = __commonJS({
 var require_parse = __commonJS({
   "node_modules/cross-spawn/lib/parse.js"(exports, module) {
     "use strict";
-    var path27 = __require("path");
+    var path28 = __require("path");
     var resolveCommand = require_resolveCommand();
     var escape2 = require_escape();
     var readShebang = require_readShebang();
@@ -12892,7 +12892,7 @@ var require_parse = __commonJS({
       const needsShell = !isExecutableRegExp.test(commandFile);
       if (parsed.options.forceShell || needsShell) {
         const needsDoubleEscapeMetaChars = isCmdShimRegExp.test(commandFile);
-        parsed.command = path27.normalize(parsed.command);
+        parsed.command = path28.normalize(parsed.command);
         parsed.command = escape2.command(parsed.command);
         parsed.args = parsed.args.map((arg) => escape2.argument(arg, needsDoubleEscapeMetaChars));
         const shellCommand = [parsed.command].concat(parsed.args).join(" ");
@@ -13079,17 +13079,17 @@ var require_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    function visit_(key, node, visitor, path27) {
-      const ctrl = callVisitor(key, node, visitor, path27);
+    function visit_(key, node, visitor, path28) {
+      const ctrl = callVisitor(key, node, visitor, path28);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path27, ctrl);
-        return visit_(key, ctrl, visitor, path27);
+        replaceNode(key, path28, ctrl);
+        return visit_(key, ctrl, visitor, path28);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path27 = Object.freeze(path27.concat(node));
+          path28 = Object.freeze(path28.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = visit_(i, node.items[i], visitor, path27);
+            const ci = visit_(i, node.items[i], visitor, path28);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -13100,13 +13100,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path27 = Object.freeze(path27.concat(node));
-          const ck = visit_("key", node.key, visitor, path27);
+          path28 = Object.freeze(path28.concat(node));
+          const ck = visit_("key", node.key, visitor, path28);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = visit_("value", node.value, visitor, path27);
+          const cv = visit_("value", node.value, visitor, path28);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -13127,17 +13127,17 @@ var require_visit = __commonJS({
     visitAsync.BREAK = BREAK;
     visitAsync.SKIP = SKIP;
     visitAsync.REMOVE = REMOVE;
-    async function visitAsync_(key, node, visitor, path27) {
-      const ctrl = await callVisitor(key, node, visitor, path27);
+    async function visitAsync_(key, node, visitor, path28) {
+      const ctrl = await callVisitor(key, node, visitor, path28);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path27, ctrl);
-        return visitAsync_(key, ctrl, visitor, path27);
+        replaceNode(key, path28, ctrl);
+        return visitAsync_(key, ctrl, visitor, path28);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path27 = Object.freeze(path27.concat(node));
+          path28 = Object.freeze(path28.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = await visitAsync_(i, node.items[i], visitor, path27);
+            const ci = await visitAsync_(i, node.items[i], visitor, path28);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -13148,13 +13148,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path27 = Object.freeze(path27.concat(node));
-          const ck = await visitAsync_("key", node.key, visitor, path27);
+          path28 = Object.freeze(path28.concat(node));
+          const ck = await visitAsync_("key", node.key, visitor, path28);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = await visitAsync_("value", node.value, visitor, path27);
+          const cv = await visitAsync_("value", node.value, visitor, path28);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -13181,24 +13181,24 @@ var require_visit = __commonJS({
       }
       return visitor;
     }
-    function callVisitor(key, node, visitor, path27) {
+    function callVisitor(key, node, visitor, path28) {
       var _a3, _b, _c, _d, _e;
       if (typeof visitor === "function")
-        return visitor(key, node, path27);
+        return visitor(key, node, path28);
       if (identity.isMap(node))
-        return (_a3 = visitor.Map) == null ? void 0 : _a3.call(visitor, key, node, path27);
+        return (_a3 = visitor.Map) == null ? void 0 : _a3.call(visitor, key, node, path28);
       if (identity.isSeq(node))
-        return (_b = visitor.Seq) == null ? void 0 : _b.call(visitor, key, node, path27);
+        return (_b = visitor.Seq) == null ? void 0 : _b.call(visitor, key, node, path28);
       if (identity.isPair(node))
-        return (_c = visitor.Pair) == null ? void 0 : _c.call(visitor, key, node, path27);
+        return (_c = visitor.Pair) == null ? void 0 : _c.call(visitor, key, node, path28);
       if (identity.isScalar(node))
-        return (_d = visitor.Scalar) == null ? void 0 : _d.call(visitor, key, node, path27);
+        return (_d = visitor.Scalar) == null ? void 0 : _d.call(visitor, key, node, path28);
       if (identity.isAlias(node))
-        return (_e = visitor.Alias) == null ? void 0 : _e.call(visitor, key, node, path27);
+        return (_e = visitor.Alias) == null ? void 0 : _e.call(visitor, key, node, path28);
       return void 0;
     }
-    function replaceNode(key, path27, node) {
-      const parent = path27[path27.length - 1];
+    function replaceNode(key, path28, node) {
+      const parent = path28[path28.length - 1];
       if (identity.isCollection(parent)) {
         parent.items[key] = node;
       } else if (identity.isPair(parent)) {
@@ -13810,10 +13810,10 @@ var require_Collection = __commonJS({
     var createNode = require_createNode();
     var identity = require_identity();
     var Node = require_Node();
-    function collectionFromPath(schema, path27, value) {
+    function collectionFromPath(schema, path28, value) {
       let v = value;
-      for (let i = path27.length - 1; i >= 0; --i) {
-        const k = path27[i];
+      for (let i = path28.length - 1; i >= 0; --i) {
+        const k = path28[i];
         if (typeof k === "number" && Number.isInteger(k) && k >= 0) {
           const a = [];
           a[k] = v;
@@ -13832,7 +13832,7 @@ var require_Collection = __commonJS({
         sourceObjects: /* @__PURE__ */ new Map()
       });
     }
-    var isEmptyPath = (path27) => path27 == null || typeof path27 === "object" && !!path27[Symbol.iterator]().next().done;
+    var isEmptyPath = (path28) => path28 == null || typeof path28 === "object" && !!path28[Symbol.iterator]().next().done;
     var Collection = class extends Node.NodeBase {
       constructor(type, schema) {
         super(type);
@@ -13862,11 +13862,11 @@ var require_Collection = __commonJS({
        * be a Pair instance or a `{ key, value }` object, which may not have a key
        * that already exists in the map.
        */
-      addIn(path27, value) {
-        if (isEmptyPath(path27))
+      addIn(path28, value) {
+        if (isEmptyPath(path28))
           this.add(value);
         else {
-          const [key, ...rest] = path27;
+          const [key, ...rest] = path28;
           const node = this.get(key, true);
           if (identity.isCollection(node))
             node.addIn(rest, value);
@@ -13880,8 +13880,8 @@ var require_Collection = __commonJS({
        * Removes a value from the collection.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path27) {
-        const [key, ...rest] = path27;
+      deleteIn(path28) {
+        const [key, ...rest] = path28;
         if (rest.length === 0)
           return this.delete(key);
         const node = this.get(key, true);
@@ -13895,8 +13895,8 @@ var require_Collection = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path27, keepScalar) {
-        const [key, ...rest] = path27;
+      getIn(path28, keepScalar) {
+        const [key, ...rest] = path28;
         const node = this.get(key, true);
         if (rest.length === 0)
           return !keepScalar && identity.isScalar(node) ? node.value : node;
@@ -13914,8 +13914,8 @@ var require_Collection = __commonJS({
       /**
        * Checks if the collection includes a value with the key `key`.
        */
-      hasIn(path27) {
-        const [key, ...rest] = path27;
+      hasIn(path28) {
+        const [key, ...rest] = path28;
         if (rest.length === 0)
           return this.has(key);
         const node = this.get(key, true);
@@ -13925,8 +13925,8 @@ var require_Collection = __commonJS({
        * Sets a value in this collection. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path27, value) {
-        const [key, ...rest] = path27;
+      setIn(path28, value) {
+        const [key, ...rest] = path28;
         if (rest.length === 0) {
           this.set(key, value);
         } else {
@@ -16440,9 +16440,9 @@ var require_Document = __commonJS({
           this.contents.add(value);
       }
       /** Adds a value to the document. */
-      addIn(path27, value) {
+      addIn(path28, value) {
         if (assertCollection(this.contents))
-          this.contents.addIn(path27, value);
+          this.contents.addIn(path28, value);
       }
       /**
        * Create a new `Alias` node, ensuring that the target `node` has the required anchor.
@@ -16517,14 +16517,14 @@ var require_Document = __commonJS({
        * Removes a value from the document.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path27) {
-        if (Collection.isEmptyPath(path27)) {
+      deleteIn(path28) {
+        if (Collection.isEmptyPath(path28)) {
           if (this.contents == null)
             return false;
           this.contents = null;
           return true;
         }
-        return assertCollection(this.contents) ? this.contents.deleteIn(path27) : false;
+        return assertCollection(this.contents) ? this.contents.deleteIn(path28) : false;
       }
       /**
        * Returns item at `key`, or `undefined` if not found. By default unwraps
@@ -16539,10 +16539,10 @@ var require_Document = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path27, keepScalar) {
-        if (Collection.isEmptyPath(path27))
+      getIn(path28, keepScalar) {
+        if (Collection.isEmptyPath(path28))
           return !keepScalar && identity.isScalar(this.contents) ? this.contents.value : this.contents;
-        return identity.isCollection(this.contents) ? this.contents.getIn(path27, keepScalar) : void 0;
+        return identity.isCollection(this.contents) ? this.contents.getIn(path28, keepScalar) : void 0;
       }
       /**
        * Checks if the document includes a value with the key `key`.
@@ -16553,10 +16553,10 @@ var require_Document = __commonJS({
       /**
        * Checks if the document includes a value at `path`.
        */
-      hasIn(path27) {
-        if (Collection.isEmptyPath(path27))
+      hasIn(path28) {
+        if (Collection.isEmptyPath(path28))
           return this.contents !== void 0;
-        return identity.isCollection(this.contents) ? this.contents.hasIn(path27) : false;
+        return identity.isCollection(this.contents) ? this.contents.hasIn(path28) : false;
       }
       /**
        * Sets a value in this document. For `!!set`, `value` needs to be a
@@ -16573,13 +16573,13 @@ var require_Document = __commonJS({
        * Sets a value in this document. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path27, value) {
-        if (Collection.isEmptyPath(path27)) {
+      setIn(path28, value) {
+        if (Collection.isEmptyPath(path28)) {
           this.contents = value;
         } else if (this.contents == null) {
-          this.contents = Collection.collectionFromPath(this.schema, Array.from(path27), value);
+          this.contents = Collection.collectionFromPath(this.schema, Array.from(path28), value);
         } else if (assertCollection(this.contents)) {
-          this.contents.setIn(path27, value);
+          this.contents.setIn(path28, value);
         }
       }
       /**
@@ -18542,9 +18542,9 @@ var require_cst_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    visit.itemAtPath = (cst, path27) => {
+    visit.itemAtPath = (cst, path28) => {
       let item = cst;
-      for (const [field, index] of path27) {
+      for (const [field, index] of path28) {
         const tok = item == null ? void 0 : item[field];
         if (tok && "items" in tok) {
           item = tok.items[index];
@@ -18553,23 +18553,23 @@ var require_cst_visit = __commonJS({
       }
       return item;
     };
-    visit.parentCollection = (cst, path27) => {
-      const parent = visit.itemAtPath(cst, path27.slice(0, -1));
-      const field = path27[path27.length - 1][0];
+    visit.parentCollection = (cst, path28) => {
+      const parent = visit.itemAtPath(cst, path28.slice(0, -1));
+      const field = path28[path28.length - 1][0];
       const coll = parent == null ? void 0 : parent[field];
       if (coll && "items" in coll)
         return coll;
       throw new Error("Parent collection not found");
     };
-    function _visit(path27, item, visitor) {
-      let ctrl = visitor(item, path27);
+    function _visit(path28, item, visitor) {
+      let ctrl = visitor(item, path28);
       if (typeof ctrl === "symbol")
         return ctrl;
       for (const field of ["key", "value"]) {
         const token = item[field];
         if (token && "items" in token) {
           for (let i = 0; i < token.items.length; ++i) {
-            const ci = _visit(Object.freeze(path27.concat([[field, i]])), token.items[i], visitor);
+            const ci = _visit(Object.freeze(path28.concat([[field, i]])), token.items[i], visitor);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -18580,10 +18580,10 @@ var require_cst_visit = __commonJS({
             }
           }
           if (typeof ctrl === "function" && field === "key")
-            ctrl = ctrl(item, path27);
+            ctrl = ctrl(item, path28);
         }
       }
-      return typeof ctrl === "function" ? ctrl(item, path27) : ctrl;
+      return typeof ctrl === "function" ? ctrl(item, path28) : ctrl;
     }
     exports.visit = visit;
   }
@@ -19870,14 +19870,14 @@ var require_parser = __commonJS({
             case "scalar":
             case "single-quoted-scalar":
             case "double-quoted-scalar": {
-              const fs25 = this.flowScalar(this.type);
+              const fs26 = this.flowScalar(this.type);
               if (atNextItem || it.value) {
-                map2.items.push({ start, key: fs25, sep: [] });
+                map2.items.push({ start, key: fs26, sep: [] });
                 this.onKeyLine = true;
               } else if (it.sep) {
-                this.stack.push(fs25);
+                this.stack.push(fs26);
               } else {
-                Object.assign(it, { key: fs25, sep: [] });
+                Object.assign(it, { key: fs26, sep: [] });
                 this.onKeyLine = true;
               }
               return;
@@ -20006,13 +20006,13 @@ var require_parser = __commonJS({
             case "scalar":
             case "single-quoted-scalar":
             case "double-quoted-scalar": {
-              const fs25 = this.flowScalar(this.type);
+              const fs26 = this.flowScalar(this.type);
               if (!it || it.value)
-                fc.items.push({ start: [], key: fs25, sep: [] });
+                fc.items.push({ start: [], key: fs26, sep: [] });
               else if (it.sep)
-                this.stack.push(fs25);
+                this.stack.push(fs26);
               else
-                Object.assign(it, { key: fs25, sep: [] });
+                Object.assign(it, { key: fs26, sep: [] });
               return;
             }
             case "flow-map-end":
@@ -20685,8 +20685,8 @@ function getErrorMap() {
 
 // node_modules/zod/v3/helpers/parseUtil.js
 var makeIssue = (params) => {
-  const { data, path: path27, errorMaps, issueData } = params;
-  const fullPath = [...path27, ...issueData.path || []];
+  const { data, path: path28, errorMaps, issueData } = params;
+  const fullPath = [...path28, ...issueData.path || []];
   const fullIssue = {
     ...issueData,
     path: fullPath
@@ -20801,11 +20801,11 @@ var errorUtil;
 
 // node_modules/zod/v3/types.js
 var ParseInputLazyPath = class {
-  constructor(parent, value, path27, key) {
+  constructor(parent, value, path28, key) {
     this._cachedPath = [];
     this.parent = parent;
     this.data = value;
-    this._path = path27;
+    this._path = path28;
     this._key = key;
   }
   get path() {
@@ -24454,10 +24454,10 @@ function mergeDefs(...defs) {
 function cloneDef(schema) {
   return mergeDefs(schema._zod.def);
 }
-function getElementAtPath(obj, path27) {
-  if (!path27)
+function getElementAtPath(obj, path28) {
+  if (!path28)
     return obj;
-  return path27.reduce((acc, key) => acc == null ? void 0 : acc[key], obj);
+  return path28.reduce((acc, key) => acc == null ? void 0 : acc[key], obj);
 }
 function promiseAllObject(promisesObj) {
   const keys = Object.keys(promisesObj);
@@ -24842,11 +24842,11 @@ function aborted(x, startIndex = 0) {
   }
   return false;
 }
-function prefixIssues(path27, issues) {
+function prefixIssues(path28, issues) {
   return issues.map((iss) => {
     var _a3;
     (_a3 = iss).path ?? (_a3.path = []);
-    iss.path.unshift(path27);
+    iss.path.unshift(path28);
     return iss;
   });
 }
@@ -47501,9 +47501,9 @@ function indent2(value) {
 // src/maker/cli/commands.ts
 import { spawnSync as spawnSync8 } from "node:child_process";
 import crypto4 from "node:crypto";
-import fs23 from "node:fs";
+import fs24 from "node:fs";
 import os7 from "node:os";
-import path24 from "node:path";
+import path25 from "node:path";
 import readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
 import { pathToFileURL } from "node:url";
@@ -49300,17 +49300,20 @@ function inspectWorkBuddyLegacyMakerMcp(options = {}) {
   if (registrations.length === 0) {
     return createWorkBuddyInspection(configPaths[0], "not_found", []);
   }
-  if (registrations.length > 1) {
+  const activeRegistrations = registrations.filter((entry) => entry.registration.disabled !== true);
+  if (activeRegistrations.length > 1) {
     return createWorkBuddyInspection(configPaths[0], "ambiguous", registrationPaths);
   }
-  const enabled = registrations[0].registration.disabled !== true;
+  if (activeRegistrations.length === 0) {
+    return {
+      ...createWorkBuddyInspection(registrations[0].configPath, "disabled", registrationPaths),
+      enabled: false
+    };
+  }
+  const active = activeRegistrations[0];
   return {
-    ...createWorkBuddyInspection(
-      registrations[0].configPath,
-      enabled ? "active" : "disabled",
-      registrationPaths
-    ),
-    enabled
+    ...createWorkBuddyInspection(active.configPath, "active", registrationPaths),
+    enabled: true
   };
 }
 function migrateWorkBuddyLegacyMakerMcp(options = {}) {
@@ -49326,12 +49329,16 @@ function migrateWorkBuddyLegacyMakerMcp(options = {}) {
       `WorkBuddy Maker MCP migration found registrations in multiple config files: ${inspection.config_paths.join(", ")}`
     );
   }
-  const current = findWorkBuddyMakerRegistrations(configPaths)[0];
+  const registrations = findWorkBuddyMakerRegistrations(configPaths);
   if (inspection.status === "disabled") {
     const state2 = readWorkBuddyMigrationState(statePath);
-    const owned = (state2 == null ? void 0 : state2.config_path) === current.configPath && hashWorkBuddyRegistration(current.registration) === state2.migrated_registration_sha256;
+    const current2 = state2 ? registrations.find((entry) => entry.configPath === state2.config_path) : registrations[0];
+    const owned = Boolean(
+      state2 && current2 && hashWorkBuddyRegistration(current2.registration) === state2.migrated_registration_sha256
+    );
     return {
       ...inspection,
+      ...owned && current2 ? { config_path: current2.configPath } : {},
       action: owned ? "already_migrated" : "already_disabled",
       changed: false,
       ...owned ? { state_path: statePath } : {}
@@ -49339,6 +49346,10 @@ function migrateWorkBuddyLegacyMakerMcp(options = {}) {
   }
   if (!options.confirm) {
     throw new Error("Disabling the legacy WorkBuddy Maker MCP requires explicit confirmation.");
+  }
+  const current = registrations.find((entry) => entry.configPath === inspection.config_path);
+  if (!current) {
+    throw new Error("The active WorkBuddy Maker MCP registration could not be resolved.");
   }
   const originalRegistration = { ...current.registration };
   const previousDisabled = Object.prototype.hasOwnProperty.call(originalRegistration, "disabled") ? false : "missing";
@@ -49357,8 +49368,10 @@ function migrateWorkBuddyLegacyMakerMcp(options = {}) {
   };
   fs22.mkdirSync(path23.dirname(statePath), { recursive: true });
   const write = writeConfigWithTapTapBackupIfChanged(current.configPath, nextContent, () => {
-    const migratedInspection = inspectWorkBuddyLegacyMakerMcp({ configPaths });
-    if (migratedInspection.status !== "disabled" || migratedInspection.config_path !== current.configPath) {
+    const migrated = findWorkBuddyMakerRegistrations(configPaths).find(
+      (entry) => entry.configPath === current.configPath
+    );
+    if (!migrated || hashWorkBuddyRegistration(migrated.registration) !== state.migrated_registration_sha256) {
       throw new Error(
         "WorkBuddy Maker MCP migration validation did not find the disabled registration."
       );
@@ -49366,8 +49379,10 @@ function migrateWorkBuddyLegacyMakerMcp(options = {}) {
     fs22.writeFileSync(statePath, `${JSON.stringify(state, null, 2)}
 `, "utf8");
   });
+  const migratedInspection = inspectWorkBuddyLegacyMakerMcp({ configPaths });
   return {
-    ...inspectWorkBuddyLegacyMakerMcp({ configPaths }),
+    ...migratedInspection,
+    config_path: current.configPath,
     action: "disabled",
     changed: write.changed,
     ...write.backupPath ? { backup_path: write.backupPath } : {},
@@ -49396,20 +49411,35 @@ function restoreWorkBuddyLegacyMakerMcp(options = {}) {
       "The migrated WorkBuddy Maker MCP registration no longer exists and cannot be restored."
     );
   }
-  if (inspection.config_path !== state.config_path) {
-    return { ...inspection, action: "not_owned", changed: false };
+  const current = findWorkBuddyMakerRegistrations(configPaths).find(
+    (entry) => entry.configPath === state.config_path
+  );
+  if (!current) {
+    throw new Error(
+      "The migrated WorkBuddy Maker MCP registration no longer exists and cannot be restored."
+    );
   }
-  const current = findWorkBuddyMakerRegistrations(configPaths)[0];
   const registrationSha256 = hashWorkBuddyRegistration(current.registration);
-  if (inspection.status === "active") {
+  const currentEnabled = current.registration.disabled !== true;
+  if (currentEnabled) {
     if (registrationSha256 !== state.original_registration_sha256) {
-      return { ...inspection, action: "not_owned", changed: false };
+      return {
+        ...inspection,
+        config_path: current.configPath,
+        action: "not_owned",
+        changed: false
+      };
     }
     fs22.unlinkSync(statePath);
-    return { ...inspection, action: "already_restored", changed: false };
+    return {
+      ...inspection,
+      config_path: current.configPath,
+      action: "already_restored",
+      changed: false
+    };
   }
   if (registrationSha256 !== state.migrated_registration_sha256) {
-    return { ...inspection, action: "not_owned", changed: false };
+    return { ...inspection, config_path: current.configPath, action: "not_owned", changed: false };
   }
   const restoredRegistration = { ...current.registration };
   if (state.previous_disabled === "missing") {
@@ -49427,14 +49457,17 @@ function restoreWorkBuddyLegacyMakerMcp(options = {}) {
         "WorkBuddy Maker MCP restoration validation did not find an active registration."
       );
     }
-    const restored = findWorkBuddyMakerRegistrations(configPaths)[0];
-    if (hashWorkBuddyRegistration(restored.registration) !== state.original_registration_sha256) {
+    const restored = findWorkBuddyMakerRegistrations(configPaths).find(
+      (entry) => entry.configPath === state.config_path
+    );
+    if (!restored || hashWorkBuddyRegistration(restored.registration) !== state.original_registration_sha256) {
       throw new Error("WorkBuddy Maker MCP restoration changed the registration identity.");
     }
     fs22.unlinkSync(statePath);
   });
   return {
     ...inspectWorkBuddyLegacyMakerMcp({ configPaths }),
+    config_path: current.configPath,
     action: "restored",
     changed: write.changed,
     ...write.backupPath ? { backup_path: write.backupPath } : {},
@@ -49517,6 +49550,94 @@ function createWorkBuddyInspection(configPath, status, configPaths) {
 }
 function isRecord5(value) {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+// src/maker/cli/workBuddyProjectSkills.ts
+import fs23 from "node:fs";
+import path24 from "node:path";
+function syncWorkBuddyProjectSkills(targetDir, options = {}) {
+  const platform = options.platform ?? process.platform;
+  const projectDir = path24.resolve(targetDir);
+  const sourceDir = path24.join(projectDir, ".installer", "skills");
+  const workBuddySkillsDir = path24.join(projectDir, ".workbuddy", "skills");
+  const result = {
+    status: "skipped",
+    sourceDir,
+    targetDir: workBuddySkillsDir,
+    installedSkills: [],
+    skippedSkills: []
+  };
+  if (!isDirectory(sourceDir)) {
+    result.reason = "source_not_found";
+    return result;
+  }
+  const sourceSkills = fs23.readdirSync(sourceDir, { withFileTypes: true }).filter(
+    (entry) => entry.isDirectory() && fs23.existsSync(path24.join(sourceDir, entry.name, "SKILL.md"))
+  ).map((entry) => entry.name).sort();
+  for (const sourceSkillName of sourceSkills) {
+    const workBuddySkillName = `taptap-maker-${sourceSkillName}`;
+    const workBuddySkillDir = path24.join(workBuddySkillsDir, workBuddySkillName);
+    if (pathEntryExists(workBuddySkillDir)) {
+      result.skippedSkills.push(workBuddySkillName);
+      continue;
+    }
+    fs23.mkdirSync(workBuddySkillsDir, { recursive: true });
+    installSkillContents(path24.join(sourceDir, sourceSkillName), workBuddySkillDir, platform);
+    result.installedSkills.push(workBuddySkillName);
+  }
+  if (result.installedSkills.length > 0) {
+    result.status = "installed";
+  }
+  return result;
+}
+function installSkillContents(sourceDir, targetDir, platform) {
+  fs23.mkdirSync(targetDir);
+  try {
+    for (const entry of fs23.readdirSync(sourceDir)) {
+      linkOrCopyEntry(path24.join(sourceDir, entry), path24.join(targetDir, entry), platform);
+    }
+  } catch (error2) {
+    fs23.rmSync(targetDir, { recursive: true, force: true });
+    throw error2;
+  }
+}
+function linkOrCopyEntry(source, target, platform) {
+  const stat = fs23.statSync(source);
+  if (platform === "win32" && stat.isFile()) {
+    fs23.copyFileSync(source, target);
+    return;
+  }
+  try {
+    const linkTarget = platform === "win32" ? source : path24.relative(path24.dirname(target), source);
+    const linkType = stat.isDirectory() ? platform === "win32" ? "junction" : "dir" : "file";
+    fs23.symlinkSync(linkTarget, target, linkType);
+  } catch (error2) {
+    try {
+      fs23.cpSync(source, target, { recursive: stat.isDirectory() });
+    } catch (copyError) {
+      throw new Error(
+        `Failed to install WorkBuddy project skill entry ${source}: ${formatError3(error2)}; copy fallback: ${formatError3(copyError)}`
+      );
+    }
+  }
+}
+function isDirectory(value) {
+  try {
+    return fs23.statSync(value).isDirectory();
+  } catch {
+    return false;
+  }
+}
+function pathEntryExists(value) {
+  try {
+    fs23.lstatSync(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+function formatError3(error2) {
+  return error2 instanceof Error ? error2.message : String(error2);
 }
 
 // src/maker/cli/commands.ts
@@ -49726,7 +49847,7 @@ function toOptionKey(value) {
 }
 async function runInit(parsed, ctx) {
   rejectPackageOption(parsed);
-  const targetDir = path24.resolve(stringOption(parsed, "target_dir") || process.cwd());
+  const targetDir = path25.resolve(stringOption(parsed, "target_dir") || process.cwd());
   const env = makerEnvOption(parsed);
   const skipConfirm = booleanOption(parsed, "skip_confirm");
   const skipMcpInstall = booleanOption(parsed, "skip_mcp_install");
@@ -49841,7 +49962,7 @@ async function runInit(parsed, ctx) {
 }
 async function runDoctor(parsed, ctx) {
   var _a3, _b;
-  const targetDir = path24.resolve(stringOption(parsed, "target_dir") || process.cwd());
+  const targetDir = path25.resolve(stringOption(parsed, "target_dir") || process.cwd());
   const env = makerEnvOption(parsed);
   const git = checkGitEnvironment();
   const python = checkMakerPythonEnvironment();
@@ -49932,8 +50053,8 @@ async function runDoctor(parsed, ctx) {
   );
 }
 function inspectMakerDoctorExecutionContext(options) {
-  const doctorCwd = path24.resolve(process.cwd());
-  const makerProjectDir = options.makerProjectDir ? path24.resolve(options.makerProjectDir) : void 0;
+  const doctorCwd = path25.resolve(process.cwd());
+  const makerProjectDir = options.makerProjectDir ? path25.resolve(options.makerProjectDir) : void 0;
   if (!makerProjectDir) {
     return {
       active_client_session: "not_checked",
@@ -49968,9 +50089,9 @@ function samePath2(left, right) {
   return normalizePathForCompare3(left) === normalizePathForCompare3(right);
 }
 function normalizePathForCompare3(value) {
-  const resolved = path24.resolve(value);
+  const resolved = path25.resolve(value);
   try {
-    return fs23.realpathSync.native(resolved);
+    return fs24.realpathSync.native(resolved);
   } catch {
     return resolved;
   }
@@ -50288,7 +50409,7 @@ async function runPatSet(parsed, ctx) {
 }
 async function resolvePatSet(parsed, ctx) {
   if (booleanOption(parsed, "pat_stdin") || booleanOption(parsed, "pat_from_stdin")) {
-    const pat = fs23.readFileSync(0, "utf8").trim();
+    const pat = fs24.readFileSync(0, "utf8").trim();
     if (!pat) {
       throw new Error("No PAT found on stdin.");
     }
@@ -50343,17 +50464,17 @@ async function prepareMcpLauncher(options) {
     if (options.mode === "self") {
       launcher = materializeMakerSelfLauncher({
         version: VERSION2,
-        bundleUrl: typeof __MAKER_BUNDLE_URL__ !== "undefined" ? __MAKER_BUNDLE_URL__ : pathToFileURL(path24.resolve(process.cwd(), "dist", "maker.js")).href,
+        bundleUrl: typeof __MAKER_BUNDLE_URL__ !== "undefined" ? __MAKER_BUNDLE_URL__ : pathToFileURL(path25.resolve(process.cwd(), "dist", "maker.js")).href,
         makerHome: getMakerHome()
       });
     } else {
       const packageSpec = resolveMakerPackageSpec(MAKER_NPM_PACKAGE, VERSION2);
       launcher = resolveMakerMcpLauncher({ packageName: packageSpec });
       const configuredCache = process.env.npm_config_cache || process.env.NPM_CONFIG_CACHE;
-      const npmCacheDir = path24.resolve(
-        configuredCache || path24.join(getMakerHome(), "cache", "npm")
+      const npmCacheDir = path25.resolve(
+        configuredCache || path25.join(getMakerHome(), "cache", "npm")
       );
-      fs23.mkdirSync(npmCacheDir, { recursive: true });
+      fs24.mkdirSync(npmCacheDir, { recursive: true });
       launcherEnv = { npm_config_cache: npmCacheDir };
     }
   } catch (error2) {
@@ -50486,7 +50607,7 @@ ${indent3(payload.stderr)}` : "",
 }
 async function runMcpReport(parsed, ctx) {
   rejectPackageOption(parsed);
-  const targetDir = path24.resolve(stringOption(parsed, "target_dir") || process.cwd());
+  const targetDir = path25.resolve(stringOption(parsed, "target_dir") || process.cwd());
   const contextInput = booleanOption(parsed, "context_stdin") ? await readStdinText() : "";
   const context = parseMakerMcpReportContext(contextInput);
   const reportRuntime = resolveMakerMcpReportRuntime({
@@ -50566,7 +50687,7 @@ async function runMcpReport(parsed, ctx) {
   );
 }
 async function runAgentsUpdate(parsed, ctx) {
-  const targetDir = path24.resolve(stringOption(parsed, "target_dir") || process.cwd());
+  const targetDir = path25.resolve(stringOption(parsed, "target_dir") || process.cwd());
   const result = updateMakerAgentsPolicy(targetDir);
   if (ctx.json) {
     writeJson(result);
@@ -50585,7 +50706,7 @@ async function runAgentsUpdate(parsed, ctx) {
 async function runUpgrade(parsed, ctx) {
   rejectPackageOption(parsed);
   const explicitTargetDir = stringOption(parsed, "target_dir");
-  const targetDir = path24.resolve(explicitTargetDir || process.cwd());
+  const targetDir = path25.resolve(explicitTargetDir || process.cwd());
   const env = makerEnvOption(parsed);
   const ides = parseIdeList(stringOption(parsed, "ide") || stringOption(parsed, "ides") || "");
   const prepared = await prepareMcpLauncher({ env, mode: mcpLauncherOption(parsed) });
@@ -50669,19 +50790,20 @@ function getMcpVerifyNextSteps(mode, commandText) {
   ];
 }
 async function runDevKitUpdate(parsed, ctx) {
-  const targetDir = path24.resolve(stringOption(parsed, "target_dir") || process.cwd());
+  const targetDir = path25.resolve(stringOption(parsed, "target_dir") || process.cwd());
   const result = await installAiDevKit({
     targetDir,
     preserveExisting: false,
     replaceManagedEntries: true,
     environment: makerEnvOption(parsed)
   });
+  syncWorkBuddyDevKitSkills(targetDir, ctx);
   finalizeStagedDevKitGitignore(targetDir);
   emit(ctx, "dev_kit", formatDevKitInstallMessage("AI dev kit updated", result), result);
   emitDevKitSkillInstallerFailure(ctx, result.skillInstaller, "AI skills install failed");
 }
 async function runLogsWatch(parsed, ctx) {
-  const targetDir = path24.resolve(stringOption(parsed, "target_dir") || process.cwd());
+  const targetDir = path25.resolve(stringOption(parsed, "target_dir") || process.cwd());
   const intervalMs = parseDurationMs(stringOption(parsed, "interval") || "5s");
   const timeoutMs = numberOption(parsed, "timeout_ms") ?? DEFAULT_TOOL_CALL_TIMEOUT_MS;
   const maxPolls = numberOption(parsed, "max_polls");
@@ -50691,9 +50813,9 @@ async function runLogsWatch(parsed, ctx) {
     serverUrl: stringOption(parsed, "server_url"),
     env: makerEnvOption(parsed)
   });
-  const runtimeDir = path24.join(proxy.projectRoot, ".maker", "logs", "runtime");
-  const runtimeLog = path24.join(runtimeDir, "runtime.log");
-  const pidFile = path24.join(runtimeDir, "watcher.pid");
+  const runtimeDir = path25.join(proxy.projectRoot, ".maker", "logs", "runtime");
+  const runtimeLog = path25.join(runtimeDir, "runtime.log");
+  const pidFile = path25.join(runtimeDir, "watcher.pid");
   const replacedWatcher = registerRuntimeLogWatcherProcess(pidFile);
   const runtimeLogClient = createRemoteRuntimeLogClient(proxy, timeoutMs);
   emit(ctx, "logs_watch_start", "Maker runtime log watcher started", {
@@ -50738,10 +50860,10 @@ async function runLogsWatch(parsed, ctx) {
   }
 }
 function registerRuntimeLogWatcherProcess(pidFile) {
-  fs23.mkdirSync(path24.dirname(pidFile), { recursive: true });
+  fs24.mkdirSync(path25.dirname(pidFile), { recursive: true });
   const existingPid = readPidFile(pidFile);
   const previous = existingPid && existingPid !== process.pid ? stopExistingRuntimeLogWatcher(pidFile) : {};
-  fs23.writeFileSync(
+  fs24.writeFileSync(
     pidFile,
     `${JSON.stringify(
       {
@@ -50759,10 +50881,10 @@ function registerRuntimeLogWatcherProcess(pidFile) {
   return previous;
 }
 function readPidFile(pidFile) {
-  if (!fs23.existsSync(pidFile)) {
+  if (!fs24.existsSync(pidFile)) {
     return void 0;
   }
-  const raw = fs23.readFileSync(pidFile, "utf8").trim();
+  const raw = fs24.readFileSync(pidFile, "utf8").trim();
   let pid = Number(raw);
   if (!Number.isInteger(pid) || pid <= 0) {
     try {
@@ -50782,7 +50904,7 @@ function installRuntimeLogWatcherPidCleanup(pidFile) {
     }
     cleaned = true;
     if (readPidFile(pidFile) === process.pid) {
-      fs23.rmSync(pidFile, { force: true });
+      fs24.rmSync(pidFile, { force: true });
     }
   };
   process.once("exit", cleanup);
@@ -50933,9 +51055,10 @@ async function prepareDevKit(targetDir, ctx, options = {}) {
         onStart: (event) => emitSkillInstallerStart(ctx, event)
       });
       writeDevKitStagedGitignore(
-        path24.join(targetDir, DEV_KIT_GITIGNORE_STAGING_FILE),
+        path25.join(targetDir, DEV_KIT_GITIGNORE_STAGING_FILE),
         listPresentDevKitManagedEntries(targetDir)
       );
+      syncWorkBuddyDevKitSkills(targetDir, ctx);
       if (options.finalizeGitignore) {
         finalizeStagedDevKitGitignore(targetDir);
       }
@@ -50950,7 +51073,7 @@ async function prepareDevKit(targetDir, ctx, options = {}) {
       );
     } catch (error2) {
       writeDevKitStagedGitignore(
-        path24.join(targetDir, DEV_KIT_GITIGNORE_STAGING_FILE),
+        path25.join(targetDir, DEV_KIT_GITIGNORE_STAGING_FILE),
         listPresentDevKitManagedEntries(targetDir)
       );
       if (options.finalizeGitignore) {
@@ -50971,6 +51094,7 @@ ${detail}`, {
       environment: options.environment,
       onSkillInstallerStart: (event) => emitSkillInstallerStart(ctx, event)
     });
+    syncWorkBuddyDevKitSkills(targetDir, ctx);
     if (options.finalizeGitignore) {
       finalizeStagedDevKitGitignore(targetDir);
     }
@@ -50983,6 +51107,38 @@ ${detail}`, {
   } catch (error2) {
     const detail = error2 instanceof Error ? error2.message : String(error2);
     emit(ctx, "dev_kit_warning", `AI dev kit preparation failed; clone will continue
+${detail}`, {
+      error: detail
+    });
+  }
+}
+function syncWorkBuddyDevKitSkills(targetDir, ctx) {
+  var _a3;
+  if (((_a3 = resolveMakerPluginDistribution()) == null ? void 0 : _a3.client) !== "workbuddy") {
+    return;
+  }
+  try {
+    const result = syncWorkBuddyProjectSkills(targetDir);
+    const managedSkillPaths = [...result.installedSkills, ...result.skippedSkills].map(
+      (skillName) => path25.join(".workbuddy", "skills", skillName)
+    );
+    if (managedSkillPaths.length > 0) {
+      writeDevKitStagedGitignore(path25.join(targetDir, DEV_KIT_GITIGNORE_STAGING_FILE), [
+        ...listPresentDevKitManagedEntries(targetDir),
+        ...managedSkillPaths
+      ]);
+    }
+    if (result.installedSkills.length > 0) {
+      emit(
+        ctx,
+        "dev_kit",
+        `WorkBuddy project skills installed: ${result.installedSkills.length}`,
+        result
+      );
+    }
+  } catch (error2) {
+    const detail = error2 instanceof Error ? error2.message : String(error2);
+    emit(ctx, "dev_kit_warning", `WorkBuddy project skills install failed
 ${detail}`, {
       error: detail
     });
@@ -51044,12 +51200,12 @@ function installMcpConfig(ide, options) {
 }
 function installMcpConfigUnsafe(ide, options) {
   if (ide === "codex") {
-    const configPath = path24.join(os7.homedir(), ".codex", "config.toml");
+    const configPath = path25.join(os7.homedir(), ".codex", "config.toml");
     const write = mergeCodexMcpConfig(configPath, withClientIde(options, "codex"));
     return [createMcpInstallResult(ide, "Codex", configPath, write)];
   }
   if (ide === "cursor") {
-    const configPath = path24.join(os7.homedir(), ".cursor", "mcp.json");
+    const configPath = path25.join(os7.homedir(), ".cursor", "mcp.json");
     const write = mergeJsonMcpConfig(configPath, withClientIde(options, "cursor"));
     return [createMcpInstallResult(ide, "Cursor", configPath, write)];
   }
@@ -51066,7 +51222,7 @@ function installMcpConfigUnsafe(ide, options) {
         }
       ];
     }
-    const configPath = path24.join(os7.homedir(), ".claude.json");
+    const configPath = path25.join(os7.homedir(), ".claude.json");
     const write = mergeJsonMcpConfig(configPath, claudeOptions);
     return [createMcpInstallResult(ide, "Claude fallback", configPath, write)];
   }
@@ -51080,7 +51236,7 @@ function installMcpConfigUnsafe(ide, options) {
   }
   if (ide === "opencode") {
     const configPath = getOpenCodeMcpConfigPath();
-    if (!fs23.existsSync(configPath)) {
+    if (!fs24.existsSync(configPath)) {
       return [{ ide, ok: false, message: "Skipped OpenCode: no supported config file found" }];
     }
     const write = mergeOpenCodeMcpConfig(configPath, withClientIde(options, "opencode"));
@@ -51163,13 +51319,13 @@ function getDefaultMcpInstallIdes() {
   if (getTraeMcpInstallPaths().length > 0) {
     ides.push("trae");
   }
-  if (fs23.existsSync(getOpenCodeMcpConfigPath())) {
+  if (fs24.existsSync(getOpenCodeMcpConfigPath())) {
     ides.push("opencode");
   }
   if (getWorkBuddyMcpInstallPaths().length > 0) {
     ides.push("workbuddy");
   }
-  if (fs23.existsSync(getDshHome())) {
+  if (fs24.existsSync(getDshHome())) {
     ides.push("dsh");
   }
   return ides;
@@ -51183,7 +51339,7 @@ function getExistingTraeUserConfigPaths(paths) {
   const seen = /* @__PURE__ */ new Set();
   return paths.filter((configPath) => {
     const key = normalizeConfigPathKey(configPath);
-    if (seen.has(key) || !fs23.existsSync(path24.dirname(configPath))) {
+    if (seen.has(key) || !fs24.existsSync(path25.dirname(configPath))) {
       return false;
     }
     seen.add(key);
@@ -51194,7 +51350,7 @@ function getExistingConfigPaths(paths) {
   const seen = /* @__PURE__ */ new Set();
   return paths.filter((configPath) => {
     const key = normalizeConfigPathKey(configPath);
-    if (seen.has(key) || !fs23.existsSync(configPath)) {
+    if (seen.has(key) || !fs24.existsSync(configPath)) {
       return false;
     }
     seen.add(key);
@@ -51202,62 +51358,62 @@ function getExistingConfigPaths(paths) {
   });
 }
 function normalizeConfigPathKey(configPath) {
-  const resolved = path24.resolve(configPath);
+  const resolved = path25.resolve(configPath);
   return process.platform === "win32" || process.platform === "darwin" ? resolved.toLowerCase() : resolved;
 }
 function getTraeSoloMcpConfigPaths() {
   if (process.platform === "win32") {
-    const roaming = process.env.APPDATA || path24.join(os7.homedir(), "AppData", "Roaming");
+    const roaming = process.env.APPDATA || path25.join(os7.homedir(), "AppData", "Roaming");
     return [
-      path24.join(roaming, "TRAE SOLO", "User", "mcp.json"),
-      path24.join(roaming, "TRAE SOLO CN", "User", "mcp.json")
+      path25.join(roaming, "TRAE SOLO", "User", "mcp.json"),
+      path25.join(roaming, "TRAE SOLO CN", "User", "mcp.json")
     ];
   }
-  const appSupport = path24.join(os7.homedir(), "Library", "Application Support");
+  const appSupport = path25.join(os7.homedir(), "Library", "Application Support");
   return [
-    path24.join(appSupport, "TRAE SOLO CN", "User", "mcp.json"),
-    path24.join(appSupport, "TRAE SOLO", "User", "mcp.json")
+    path25.join(appSupport, "TRAE SOLO CN", "User", "mcp.json"),
+    path25.join(appSupport, "TRAE SOLO", "User", "mcp.json")
   ];
 }
 function getTraeUnverifiedMcpConfigPaths() {
   if (process.platform === "win32") {
-    const roaming = process.env.APPDATA || path24.join(os7.homedir(), "AppData", "Roaming");
+    const roaming = process.env.APPDATA || path25.join(os7.homedir(), "AppData", "Roaming");
     return [
-      path24.join(roaming, "Trae", "User", "mcp.json"),
-      path24.join(roaming, "TRAE", "User", "mcp.json"),
-      path24.join(roaming, "Trae CN", "User", "mcp.json")
+      path25.join(roaming, "Trae", "User", "mcp.json"),
+      path25.join(roaming, "TRAE", "User", "mcp.json"),
+      path25.join(roaming, "Trae CN", "User", "mcp.json")
     ];
   }
-  const appSupport = path24.join(os7.homedir(), "Library", "Application Support");
+  const appSupport = path25.join(os7.homedir(), "Library", "Application Support");
   return [
-    path24.join(appSupport, "Trae", "User", "mcp.json"),
-    path24.join(appSupport, "TRAE", "User", "mcp.json"),
-    path24.join(appSupport, "Trae CN", "User", "mcp.json")
+    path25.join(appSupport, "Trae", "User", "mcp.json"),
+    path25.join(appSupport, "TRAE", "User", "mcp.json"),
+    path25.join(appSupport, "Trae CN", "User", "mcp.json")
   ];
 }
 function getOpenCodeMcpConfigPath() {
-  return path24.join(os7.homedir(), ".config", "opencode", "opencode.jsonc");
+  return path25.join(os7.homedir(), ".config", "opencode", "opencode.jsonc");
 }
 function getWorkBuddyHome() {
-  return path24.join(os7.homedir(), ".workbuddy");
+  return path25.join(os7.homedir(), ".workbuddy");
 }
 function getWorkBuddyMcpInstallPaths(options = {}) {
-  const primary = path24.join(getWorkBuddyHome(), "mcp.json");
-  if (fs23.existsSync(primary) || options.createPrimary) {
+  const primary = path25.join(getWorkBuddyHome(), "mcp.json");
+  if (fs24.existsSync(primary) || options.createPrimary) {
     return [primary];
   }
-  const legacy = path24.join(getWorkBuddyHome(), ".mcp.json");
-  if (fs23.existsSync(legacy)) {
+  const legacy = path25.join(getWorkBuddyHome(), ".mcp.json");
+  if (fs24.existsSync(legacy)) {
     return [legacy];
   }
   return [];
 }
 function inspectWorkBuddyTrustState(mcpName) {
   const workbuddyHome = getWorkBuddyHome();
-  const connectorsDir = path24.join(workbuddyHome, "connectors");
+  const connectorsDir = path25.join(workbuddyHome, "connectors");
   const accounts = [];
   const stateFiles = [];
-  if (!fs23.existsSync(connectorsDir)) {
+  if (!fs24.existsSync(connectorsDir)) {
     return {
       status: "not_found",
       mcp_name: mcpName,
@@ -51267,12 +51423,12 @@ function inspectWorkBuddyTrustState(mcpName) {
       accounts
     };
   }
-  for (const entry of fs23.readdirSync(connectorsDir, { withFileTypes: true })) {
+  for (const entry of fs24.readdirSync(connectorsDir, { withFileTypes: true })) {
     if (!entry.isDirectory()) {
       continue;
     }
-    const statePath = path24.join(connectorsDir, entry.name, "connector-states.json");
-    if (!fs23.existsSync(statePath)) {
+    const statePath = path25.join(connectorsDir, entry.name, "connector-states.json");
+    if (!fs24.existsSync(statePath)) {
       continue;
     }
     stateFiles.push(statePath);
@@ -51351,7 +51507,7 @@ function mergeJsonMcpConfig(configPath, options) {
   );
 }
 function mergeOpenCodeMcpConfig(configPath, options) {
-  const rawContent = fs23.readFileSync(configPath, "utf8");
+  const rawContent = fs24.readFileSync(configPath, "utf8");
   const rewroteJsonc = normalizeJsonConfigContent(rawContent, { jsonc: true }) !== rawContent;
   const existing = readJsonObject(configPath, { jsonc: true });
   const mcp = asObject(existing.mcp);
@@ -51383,7 +51539,7 @@ function mergeOpenCodeMcpConfig(configPath, options) {
   return { ...write, rewroteJsonc: write.changed && rewroteJsonc };
 }
 function mergeCodexMcpConfig(configPath, options) {
-  const existing = fs23.existsSync(configPath) ? fs23.readFileSync(configPath, "utf8") : "";
+  const existing = fs24.existsSync(configPath) ? fs24.readFileSync(configPath, "utf8") : "";
   const withoutOld = removeCodexMcpTables(existing, options.mcpName).trimEnd();
   const launch = options.launcher;
   const envValues = createMcpEnvironmentValues(options.env, options.clientIde, options.launcherEnv);
@@ -51417,7 +51573,7 @@ function mergeCodexMcpConfig(configPath, options) {
   );
 }
 function tryClaudeMcpAdd(options) {
-  const configPath = path24.join(os7.homedir(), ".claude.json");
+  const configPath = path25.join(os7.homedir(), ".claude.json");
   try {
     const existing = readJsonObject(configPath);
     const server = asObject(asObject(existing.mcpServers)[options.mcpName]);
@@ -51510,10 +51666,10 @@ function rejectPackageOption(parsed) {
   }
 }
 function readJsonObject(filePath, options = {}) {
-  if (!fs23.existsSync(filePath)) {
+  if (!fs24.existsSync(filePath)) {
     return {};
   }
-  const raw = fs23.readFileSync(filePath, "utf8");
+  const raw = fs24.readFileSync(filePath, "utf8");
   try {
     const normalized = normalizeJsonConfigContent(raw, options);
     const parsed = JSON.parse(normalized);
@@ -51685,10 +51841,10 @@ function formatMcpInstallMessage(label, configPath, write) {
   ].filter(Boolean).join("\n");
 }
 function saveInitState(targetDir, state) {
-  fs23.mkdirSync(getMakerHome(), { recursive: true });
-  const key = crypto4.createHash("sha256").update(path24.resolve(targetDir)).digest("hex").slice(0, 16);
-  fs23.writeFileSync(
-    path24.join(getMakerHome(), `init-state-${key}.json`),
+  fs24.mkdirSync(getMakerHome(), { recursive: true });
+  const key = crypto4.createHash("sha256").update(path25.resolve(targetDir)).digest("hex").slice(0, 16);
+  fs24.writeFileSync(
+    path25.join(getMakerHome(), `init-state-${key}.json`),
     `${JSON.stringify({ ...state, updated_at: (/* @__PURE__ */ new Date()).toISOString() }, null, 2)}
 `,
     "utf8"
@@ -51836,7 +51992,7 @@ function makerEnvOption(parsed) {
     return env;
   }
   const targetDir = stringOption(parsed, "target_dir");
-  return getMakerEnvironment(void 0, targetDir ? path24.resolve(targetDir) : process.cwd());
+  return getMakerEnvironment(void 0, targetDir ? path25.resolve(targetDir) : process.cwd());
 }
 function makerMcpConfigEnvOption(parsed) {
   return stringOption(parsed, "env") === "rnd" ? "rnd" : "production";
@@ -53357,7 +53513,7 @@ var StreamableHTTPClientTransport = class {
 };
 
 // src/mcp-proxy/proxy.ts
-import * as path26 from "node:path";
+import * as path27 from "node:path";
 import * as crypto7 from "node:crypto";
 
 // src/mcp-proxy/cookieJar.ts
@@ -53539,8 +53695,8 @@ function createCookieFetch(cookieJar) {
 }
 
 // src/core/utils/logWriter.ts
-import * as fs24 from "node:fs";
-import * as path25 from "node:path";
+import * as fs25 from "node:fs";
+import * as path26 from "node:path";
 import * as crypto6 from "node:crypto";
 
 // src/core/types/log.ts
@@ -53581,7 +53737,7 @@ var LogWriter = class {
       return;
     }
     try {
-      await fs24.promises.mkdir(this.config.logDir, { recursive: true });
+      await fs25.promises.mkdir(this.config.logDir, { recursive: true });
       await this.cleanupOldLogs();
       this.initialized = true;
     } catch (error2) {
@@ -53604,7 +53760,7 @@ var LogWriter = class {
    */
   getLogFilePath(date5) {
     const d = date5 || this.getCurrentDate();
-    return path25.join(this.config.logDir, `${this.config.prefix}-${d}.log`);
+    return path26.join(this.config.logDir, `${this.config.prefix}-${d}.log`);
   }
   /**
    * 获取或创建写入流
@@ -53619,7 +53775,7 @@ var LogWriter = class {
       }
       this.currentDate = date5;
       try {
-        this.writeStream = fs24.createWriteStream(this.getLogFilePath(date5), {
+        this.writeStream = fs25.createWriteStream(this.getLogFilePath(date5), {
           flags: "a",
           encoding: "utf8"
         });
@@ -53671,11 +53827,11 @@ var LogWriter = class {
     if (this.shouldWriteToFile(level) && this.initialized && this.config.enabled) {
       try {
         const filePath = this.getLogFilePath();
-        const dir = path25.dirname(filePath);
-        if (!fs24.existsSync(dir)) {
-          fs24.mkdirSync(dir, { recursive: true });
+        const dir = path26.dirname(filePath);
+        if (!fs25.existsSync(dir)) {
+          fs25.mkdirSync(dir, { recursive: true });
         }
-        fs24.appendFileSync(filePath, message, "utf8");
+        fs25.appendFileSync(filePath, message, "utf8");
       } catch {
       }
     }
@@ -53686,7 +53842,7 @@ var LogWriter = class {
   async cleanupOldLogs() {
     if (this.config.maxDays <= 0) return;
     try {
-      const files = await fs24.promises.readdir(this.config.logDir);
+      const files = await fs25.promises.readdir(this.config.logDir);
       const cutoffDate = /* @__PURE__ */ new Date();
       cutoffDate.setDate(cutoffDate.getDate() - this.config.maxDays);
       const prefix = this.config.prefix;
@@ -53701,7 +53857,7 @@ var LogWriter = class {
           if (!Number.isNaN(year) && !Number.isNaN(month) && !Number.isNaN(day)) {
             const fileDate = new Date(year, month - 1, day);
             if (fileDate < cutoffDate) {
-              await fs24.promises.unlink(path25.join(this.config.logDir, file2));
+              await fs25.promises.unlink(path26.join(this.config.logDir, file2));
               process.stderr.write(`[LogWriter] Deleted old log: ${file2}
 `);
             }
@@ -53822,10 +53978,10 @@ var TapTapMCPProxy = class {
     const { user_id, project_id } = this.config.tenant;
     let logDir;
     if (user_id && project_id) {
-      logDir = path26.join(logRoot, "proxy", user_id, project_id);
+      logDir = path27.join(logRoot, "proxy", user_id, project_id);
     } else {
       const kidHash = crypto7.createHash("sha256").update(this.config.auth.kid).digest("hex").substring(0, 8);
-      logDir = path26.join(logRoot, "proxy", kidHash);
+      logDir = path27.join(logRoot, "proxy", kidHash);
     }
     return new LogWriter({
       logDir,

--- a/plugins/workbuddy/taptap-maker/hooks/hooks.json
+++ b/plugins/workbuddy/taptap-maker/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CODEBUDDY_PLUGIN_ROOT}/hooks/session-start.cjs\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/workbuddy/taptap-maker/hooks/session-start.cjs
+++ b/plugins/workbuddy/taptap-maker/hooks/session-start.cjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const pluginRoot = process.env.CODEBUDDY_PLUGIN_ROOT || path.resolve(__dirname, '..');
+const bundlePath = path.join(pluginRoot, 'dist', 'maker.js');
+
+function writeHookOutput(additionalContext) {
+  const hookSpecificOutput = additionalContext ? { additionalContext } : {};
+  process.stdout.write(`${JSON.stringify({ hookSpecificOutput })}\n`);
+}
+
+function inspectLegacyMakerMcp() {
+  const result = spawnSync(
+    process.execPath,
+    [bundlePath, 'plugin', 'inspect', '--client', 'workbuddy', '--json'],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        TAPTAP_MAKER_DISTRIBUTION: 'workbuddy_plugin',
+        TAPTAP_MCP_CLIENT_IDE: 'workbuddy',
+      },
+    }
+  );
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || `inspect exited with status ${String(result.status)}`);
+  }
+  return JSON.parse(result.stdout.trim());
+}
+
+try {
+  const inspection = inspectLegacyMakerMcp();
+  if (inspection.status === 'active') {
+    writeHookOutput(
+      'TapTap Maker 插件检测到旧的独立 Maker MCP 仍处于启用状态。继续 Maker 工作前，必须向用户说明两套 Maker MCP 会造成重复工具和双 runtime 冲突，并询问是否禁用旧 MCP。只有得到用户明确确认后，才执行插件内 CLI 的 plugin migrate --client workbuddy --confirm --json；未确认时不得修改配置。'
+    );
+  } else if (inspection.status === 'ambiguous') {
+    writeHookOutput(
+      `TapTap Maker 插件在多个 WorkBuddy 配置中检测到仍启用的独立 Maker MCP：${inspection.config_paths.join(', ')}。继续 Maker 工作前必须告知用户存在重复注册；不要自动选择或修改配置，应请用户先明确保留哪一个旧注册。`
+    );
+  } else {
+    writeHookOutput();
+  }
+} catch (error) {
+  writeHookOutput(
+    `TapTap Maker 插件未能完成旧 MCP 冲突检查：${error instanceof Error ? error.message : String(error)}。开始 Maker 工作前应加载 taptap-maker-plugin-lifecycle Skill 并执行只读检查，不要假设旧 MCP 已禁用。`
+  );
+}

--- a/plugins/workbuddy/taptap-maker/skills/taptap-maker-plugin-lifecycle/SKILL.md
+++ b/plugins/workbuddy/taptap-maker/skills/taptap-maker-plugin-lifecycle/SKILL.md
@@ -12,20 +12,32 @@ game files remain shared and unchanged.
 ## Bundled CLI
 
 Always use the plugin launcher with the bundled runtime. It resolves WorkBuddy's managed Node.js
-first and falls back to a system Node.js only when needed:
+first and falls back to a system Node.js only when needed. On Windows, use:
+
+```bat
+"${CODEBUDDY_PLUGIN_ROOT}/bin/run-node.cmd" "${CODEBUDDY_PLUGIN_ROOT}/dist/maker.js" <arguments>
+```
+
+On macOS or Linux, use:
 
 ```bash
 "${CODEBUDDY_PLUGIN_ROOT}/bin/run-node" "${CODEBUDDY_PLUGIN_ROOT}/dist/maker.js" <arguments>
 ```
 
+Both launchers set `TAPTAP_MAKER_DISTRIBUTION=workbuddy_plugin` and
+`TAPTAP_MCP_CLIENT_IDE=workbuddy` before starting the bundled runtime.
+In the commands below, replace `<PLUGIN_CLI>` with the complete two-part launcher command selected
+for the current operating system above.
 Do not assume `taptap-maker`, npm, or npx is on `PATH`.
 
 ## First Use and Legacy MCP Migration
 
-Before the first Maker workflow in a WorkBuddy plugin session, inspect standalone registrations:
+The plugin SessionStart hook performs a read-only inspection and injects a reminder when an active
+standalone registration exists. It never changes MCP configuration. Before the first Maker workflow
+in a WorkBuddy plugin session, follow that reminder or inspect standalone registrations directly:
 
 ```bash
-"${CODEBUDDY_PLUGIN_ROOT}/bin/run-node" "${CODEBUDDY_PLUGIN_ROOT}/dist/maker.js" plugin inspect --client workbuddy --json
+<PLUGIN_CLI> plugin inspect --client workbuddy --json
 ```
 
 Act on `status`:
@@ -40,7 +52,7 @@ Act on `status`:
 Only after explicit confirmation, disable the active standalone registration:
 
 ```bash
-"${CODEBUDDY_PLUGIN_ROOT}/bin/run-node" "${CODEBUDDY_PLUGIN_ROOT}/dist/maker.js" plugin migrate --client workbuddy --confirm --json
+<PLUGIN_CLI> plugin migrate --client workbuddy --confirm --json
 ```
 
 Migration only sets `disabled: true`, writes a latest backup, and records plugin ownership for
@@ -64,7 +76,7 @@ If the user wants to remove the plugin and resume a registration migrated by thi
 explicit confirmation, then run:
 
 ```bash
-"${CODEBUDDY_PLUGIN_ROOT}/bin/run-node" "${CODEBUDDY_PLUGIN_ROOT}/dist/maker.js" plugin restore --client workbuddy --confirm --json
+<PLUGIN_CLI> plugin restore --client workbuddy --confirm --json
 ```
 
 Restore only configuration owned by the migration state. Preserve unrelated WorkBuddy settings and

--- a/scripts/prepare-maker-codex-plugin.js
+++ b/scripts/prepare-maker-codex-plugin.js
@@ -180,30 +180,35 @@ async function writeJson(filePath, value) {
 }
 
 function createReadme(pluginVersion, makerVersion) {
-  return `# TapTap Maker 客户端插件
+  return `# TapTap Maker 客户端插件安装
 
-TapTap Maker 的 Codex 与 WorkBuddy 客户端插件发布页。
+这是 TapTap Maker 的统一插件安装入口，支持 Codex 和 WorkBuddy。两个插件使用同一版本，
+但安装包和客户端配置彼此独立。
 
 - 插件版本：\`${pluginVersion}\`
 - 内置 Maker MCP 版本：\`${makerVersion}\`
 
-## 交给 AI 安装
+## 用户如何安装
 
-将本页面链接交给 Codex 或 WorkBuddy，并告诉 AI：\`安装这个 TapTap Maker 插件\`。AI 应根据
-当前客户端选择对应安装方式，不要安装独立 npm MCP。
+把本页面链接交给当前正在使用的 AI，并告诉它：\`请按照页面说明安装 TapTap Maker 插件\`。
 
-### Codex
+## 给安装 AI 的选择规则
 
-\`\`\`bash
-codex plugin marketplace add taptap/instant-games-open-mcp --ref main \\
-  --sparse .agents/plugins --sparse plugins/taptap-maker
-codex plugin add taptap-maker@taptap-maker
-\`\`\`
+安装前必须先识别自己当前运行在哪个宿主客户端，再选择安装包：
 
-### WorkBuddy
+| 当前宿主客户端 | 只能选择的安装包 |
+| --- | --- |
+| 当前宿主客户端是 Codex | \`taptap-maker-codex-plugin-${pluginVersion}.zip\` |
+| 当前宿主客户端是 WorkBuddy | \`taptap-maker-workbuddy-plugin-${pluginVersion}.zip\` |
 
-在插件市场中添加本 GitHub 仓库作为本地市场源，然后安装 \`taptap-maker\`。如果当前版本暂不
-支持 GitHub 市场源，可下载下方 WorkBuddy ZIP 并按客户端的本地插件导入方式安装。
+必须遵守以下规则：
+
+1. 以当前对话所属的宿主客户端为准。不要根据操作系统、Node.js 环境，或本机是否存在
+   \`~/.codex\`、\`~/.workbuddy\` 目录来猜测；同一台电脑可能同时安装两个客户端。
+2. 无法确认当前宿主客户端时，先询问用户“你现在使用的是 Codex 还是 WorkBuddy？”，得到明确
+   回答前不要下载或安装。
+3. 一次只安装当前客户端对应的一个 ZIP，不要同时安装两个插件包。
+4. 不要通过 npm 或 npx 安装独立 Maker MCP；ZIP 已包含完整 MCP runtime、CLI 和 Skills。
 
 ## 下载
 
@@ -211,19 +216,38 @@ codex plugin add taptap-maker@taptap-maker
 - [WorkBuddy 插件 ZIP](https://github.com/taptap/instant-games-open-mcp/releases/download/maker-plugin-v${pluginVersion}/taptap-maker-workbuddy-plugin-${pluginVersion}.zip)
 - [SHA256 校验文件](https://github.com/taptap/instant-games-open-mcp/releases/download/maker-plugin-v${pluginVersion}/SHA256SUMS)
 
-ZIP 是完整的离线 marketplace 包。AI 下载对应 ZIP 和 \`SHA256SUMS\`、验证 SHA-256 并解压后：
+ZIP 是完整的离线 marketplace 包。AI 只下载所选 ZIP 和 \`SHA256SUMS\`，验证 SHA-256 后解压。
 
-- Codex：执行 \`codex plugin marketplace add <解压目录>\`，再执行
-  \`codex plugin add taptap-maker@taptap-maker\`。
-- WorkBuddy：在 \`/plugin\` 中把解压目录添加为 marketplace，安装 \`taptap-maker\`，然后执行
-  \`/reload-plugins\`。
+## 安装所选插件
+
+### Codex
+
+仅当当前宿主是 Codex 时执行：
+
+1. 执行 \`codex plugin marketplace add <解压目录>\`。
+2. 执行 \`codex plugin add taptap-maker@taptap-maker\`。
+3. 重新加载插件或新建任务，确认 TapTap Maker 插件已启用。
+
+### WorkBuddy
+
+仅当当前宿主是 WorkBuddy 时执行：
+
+1. 在 \`/plugin\` 中把解压目录添加为 marketplace。
+2. 安装 marketplace 中的 \`taptap-maker\`。
+3. 执行 \`/reload-plugins\`，确认 TapTap Maker 插件已启用。
+
+如果当前客户端既不是 Codex 也不是 WorkBuddy，应告知用户该客户端暂未提供对应安装包，不要把
+其中一个 ZIP 当作通用 MCP 包安装。
+
+## 兼容已有 Maker MCP
 
 插件内置本地 MCP runtime、CLI、工作流 Skills 和连接排障文档。运行时不会通过 npm 或 npx
 下载或启动 Maker 包。
 
-插件会复用现有 Maker 鉴权和项目绑定。首次使用时先通过插件内 CLI 检查旧的独立 Maker MCP；
-只有用户明确确认后，才把旧 Codex 注册设置为 \`enabled = false\`。迁移会保留最新备份并支持恢复，
-不会删除旧注册、鉴权、项目绑定或游戏文件。
+插件会复用现有 Maker 鉴权和项目绑定。首次使用时会检查旧的独立 Maker MCP；WorkBuddy 通过
+SessionStart Hook 做只读检查并提醒 AI。只有用户明确确认后，才把旧 Codex 注册设置为
+\`enabled = false\`，或把旧 WorkBuddy 注册设置为 \`disabled: true\`。迁移会保留最新备份并支持
+恢复，不会删除旧注册、鉴权、项目绑定或游戏文件。
 
 正常 Maker 开发流程见 \`skills/taptap-maker-local/SKILL.md\`。
 `;
@@ -274,7 +298,11 @@ async function main() {
 
   await writeJson(join(pluginRoot, '.codex-plugin', 'plugin.json'), createManifest(pluginVersion));
   await writeJson(join(pluginRoot, '.mcp.json'), createMcpConfig());
-  writeFileSync(join(pluginRoot, 'README.md'), createReadme(pluginVersion, makerVersion), 'utf8');
+  writeFileSync(
+    join(pluginRoot, 'README.md'),
+    await format(createReadme(pluginVersion, makerVersion), { parser: 'markdown' }),
+    'utf8'
+  );
 
   const bundle = readFileSync(join(pluginRoot, 'dist', 'maker.js'), 'utf8');
   if (!bundle.includes(`// TapTap Maker MCP version: ${makerVersion}`)) {

--- a/scripts/prepare-maker-workbuddy-plugin.js
+++ b/scripts/prepare-maker-workbuddy-plugin.js
@@ -30,6 +30,7 @@ const VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/
 const SHARED_SKILLS = ['taptap-maker-local', 'taptap-maker-dev-kit-guide'];
 const WORKBUDDY_SKILLS = ['taptap-maker-plugin-lifecycle', 'update-taptap-mcp'];
 const WORKBUDDY_COMMANDS = ['create-project.md', 'sync-project.md'];
+const WORKBUDDY_HOOK_FILES = ['hooks.json', 'session-start.cjs'];
 const PLUGIN_DESCRIPTION = 'TapTap Maker 本地游戏开发插件，内置 MCP、CLI、开发技能和项目工作流。';
 const PLUGIN_DESCRIPTION_EN =
   'Local TapTap Maker game development with bundled MCP, CLI, and workflows.';
@@ -172,6 +173,7 @@ function createManifest(pluginVersion) {
     commands: WORKBUDDY_COMMANDS.map((command) => `./commands/${command}`),
     skills: [...SHARED_SKILLS, ...WORKBUDDY_SKILLS].map((skill) => `./skills/${skill}`),
     mcpServers: './.mcp.json',
+    hooks: './hooks/hooks.json',
   };
 }
 
@@ -179,7 +181,7 @@ function createMcpConfig() {
   return {
     mcpServers: {
       'taptap-maker-plugin': {
-        command: '${CODEBUDDY_PLUGIN_ROOT}/bin/run-node',
+        command: 'node',
         args: ['${CODEBUDDY_PLUGIN_ROOT}/dist/maker.js'],
         env: {
           TAPTAP_MAKER_DISTRIBUTION: 'workbuddy_plugin',
@@ -201,8 +203,14 @@ function createReadme(pluginVersion, makerVersion) {
 CLI、工作流 Skills、快捷命令和连接排障文档。启动器优先使用 WorkBuddy 管理的 Node.js，必要时
 回退系统 Node.js，不会通过 npm 或 npx 下载和启动 Maker。
 
+WorkBuddy 会话启动时，插件会只读检查是否仍有独立 Maker MCP 启用。发现冲突后会要求 AI 先向
+用户说明风险并取得明确确认，再把旧注册设置为 \`disabled: true\`；插件不会未经确认修改配置。
+
 在空 workspace 中使用 \`/taptap-maker:create-project\` 创建新游戏，或使用
 \`/taptap-maker:sync-project\` 同步已有 Maker 游戏。插件复用现有 Maker 鉴权和项目绑定。
+
+初始化或更新 dev-kit 后，插件会把项目内 \`.installer/skills\` 中的 Skills 补充到
+\`.workbuddy/skills/taptap-maker-*\`。同步只补齐缺失项，不覆盖已有同名 Skill。
 `;
 }
 
@@ -265,6 +273,13 @@ async function main() {
       join(workBuddySourceRoot, 'commands', command),
       join(pluginRoot, 'commands', command),
       `WorkBuddy plugin ${command} command`
+    );
+  }
+  for (const hookFile of WORKBUDDY_HOOK_FILES) {
+    copyRequiredFile(
+      join(workBuddySourceRoot, 'hooks', hookFile),
+      join(pluginRoot, 'hooks', hookFile),
+      `WorkBuddy plugin ${hookFile} hook`
     );
   }
   for (const [relativePath, description] of Object.entries(WORKBUDDY_DISPLAY_DESCRIPTIONS)) {

--- a/src/__tests__/makerCliCommands.test.ts
+++ b/src/__tests__/makerCliCommands.test.ts
@@ -18,6 +18,7 @@ import {
   installAiDevKit,
   installAiDevKitSkills,
 } from '../maker/cli/devKit';
+import { syncWorkBuddyProjectSkills } from '../maker/cli/workBuddyProjectSkills';
 import { formatMakerPackageUpdateStatus, getMakerPackageUpdateStatus } from '../maker/versionCheck';
 import { runMakerCli } from '../maker/cli/commands';
 import {
@@ -147,6 +148,16 @@ jest.mock('../maker/cli/devKit', () => ({
   writeDevKitStagedGitignore: jest.fn(),
 }));
 
+jest.mock('../maker/cli/workBuddyProjectSkills', () => ({
+  syncWorkBuddyProjectSkills: jest.fn(() => ({
+    status: 'installed',
+    sourceDir: '/project/.installer/skills',
+    targetDir: '/project/.workbuddy/skills',
+    installedSkills: ['taptap-maker-materials'],
+    skippedSkills: [],
+  })),
+}));
+
 jest.mock('../maker/versionCheck', () => ({
   formatMakerPackageUpdateStatus: jest.fn(() =>
     [
@@ -197,6 +208,7 @@ describe('Maker CLI commands', () => {
   const originalPythonBin = process.env.TAPTAP_MAKER_PYTHON_BIN;
   const originalNpmCache = process.env.npm_config_cache;
   const originalDshHome = process.env.DSH_HOME;
+  const originalMakerDistribution = process.env.TAPTAP_MAKER_DISTRIBUTION;
   const originalStdinIsTty = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
   let homedirSpy: jest.SpyInstance;
   let stdoutSpy: jest.SpyInstance;
@@ -239,6 +251,7 @@ describe('Maker CLI commands', () => {
     delete process.env.TAPTAP_MAKER_PYTHON_BIN;
     delete process.env.npm_config_cache;
     delete process.env.DSH_HOME;
+    delete process.env.TAPTAP_MAKER_DISTRIBUTION;
     setMakerEnvironmentOverride(undefined);
     homedirSpy = jest.spyOn(os, 'homedir').mockReturnValue(tempDir);
     stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
@@ -288,6 +301,11 @@ describe('Maker CLI commands', () => {
       delete process.env.DSH_HOME;
     } else {
       process.env.DSH_HOME = originalDshHome;
+    }
+    if (originalMakerDistribution === undefined) {
+      delete process.env.TAPTAP_MAKER_DISTRIBUTION;
+    } else {
+      process.env.TAPTAP_MAKER_DISTRIBUTION = originalMakerDistribution;
     }
     setMakerEnvironmentOverride(undefined);
     if (originalStdinIsTty) {
@@ -2712,6 +2730,70 @@ describe('Maker CLI commands', () => {
     expect(output).toContain('AI skills install result: claude=13, codex=13, cursor=13, gemini=13');
   });
 
+  test('WorkBuddy plugin init syncs missing project skills after dev-kit preparation', async () => {
+    process.env.TAPTAP_MAKER_DISTRIBUTION = 'workbuddy_plugin';
+    jest.mocked(inspectAiDevKit).mockReturnValueOnce({
+      targetDir: tempDir,
+      requiredEntries: ['CLAUDE.md'],
+      presentEntries: [],
+      missingEntries: ['CLAUDE.md'],
+      ready: false,
+    });
+    jest.mocked(installAiDevKit).mockResolvedValueOnce({
+      targetDir: tempDir,
+      sourceDir: path.join(tempDir, 'source'),
+      installedEntries: ['.installer', 'CLAUDE.md', 'tools'],
+      skippedEntries: [],
+      gitignorePath: path.join(tempDir, '.gitignore'),
+      stagedGitignorePath: path.join(tempDir, '.gitignore.dev-kit-before-clone'),
+    });
+
+    await runMakerCli([
+      'init',
+      '--skip-confirm',
+      'app-1',
+      '--target-dir',
+      tempDir,
+      '--skip-mcp-install',
+      '--pat',
+      'secret-maker-token',
+    ]);
+
+    expect(syncWorkBuddyProjectSkills).toHaveBeenCalledWith(tempDir);
+    expect(stdoutSpy.mock.calls.join('')).toContain('WorkBuddy project skills installed: 1');
+  });
+
+  test('standalone Maker init does not create WorkBuddy project skills', async () => {
+    jest.mocked(inspectAiDevKit).mockReturnValueOnce({
+      targetDir: tempDir,
+      requiredEntries: ['CLAUDE.md'],
+      presentEntries: [],
+      missingEntries: ['CLAUDE.md'],
+      ready: false,
+    });
+    jest.mocked(installAiDevKit).mockResolvedValueOnce({
+      targetDir: tempDir,
+      sourceDir: path.join(tempDir, 'source'),
+      installedEntries: ['.installer', 'CLAUDE.md', 'tools'],
+      skippedEntries: [],
+      gitignorePath: path.join(tempDir, '.gitignore'),
+      stagedGitignorePath: path.join(tempDir, '.gitignore.dev-kit-before-clone'),
+    });
+
+    await runMakerCli([
+      'init',
+      '--skip-confirm',
+      'app-1',
+      '--target-dir',
+      tempDir,
+      '--skip-mcp-install',
+      '--pat',
+      'secret-maker-token',
+    ]);
+
+    expect(syncWorkBuddyProjectSkills).not.toHaveBeenCalled();
+  });
+
   test('init clones before installing dev kit and allows dev kit to overwrite checkout files', async () => {
     jest.mocked(inspectAiDevKit).mockReturnValueOnce({
       targetDir: tempDir,
@@ -2882,6 +2964,22 @@ describe('Maker CLI commands', () => {
         environment: 'rnd',
       })
     );
+  });
+
+  test('WorkBuddy plugin dev-kit update restores missing project skills', async () => {
+    process.env.TAPTAP_MAKER_DISTRIBUTION = 'workbuddy_plugin';
+    jest.mocked(installAiDevKit).mockResolvedValueOnce({
+      targetDir: tempDir,
+      sourceDir: path.join(tempDir, 'source'),
+      installedEntries: ['.installer', 'CLAUDE.md', 'tools'],
+      skippedEntries: [],
+      gitignorePath: path.join(tempDir, '.gitignore'),
+      stagedGitignorePath: path.join(tempDir, '.gitignore.dev-kit-before-clone'),
+    });
+
+    await runMakerCli(['dev-kit', 'update', '--target-dir', tempDir]);
+
+    expect(syncWorkBuddyProjectSkills).toHaveBeenCalledWith(tempDir);
   });
 
   test('doctor includes AI dev kit update state in json output', async () => {

--- a/src/__tests__/makerCodexPluginPackage.test.ts
+++ b/src/__tests__/makerCodexPluginPackage.test.ts
@@ -175,6 +175,13 @@ describe('TapTap Maker Codex plugin package', () => {
 
     expect(readme).toContain(`插件版本：\`${pluginVersion}\``);
     expect(readme).toContain(`内置 Maker MCP 版本：\`${makerVersion}\``);
+    expect(readme).toContain('当前宿主客户端是 Codex');
+    expect(readme).toContain('当前宿主客户端是 WorkBuddy');
+    expect(readme).toContain('不要根据操作系统');
+    expect(readme).toContain('不要同时安装两个插件包');
+    expect(readme).toContain('无法确认当前宿主客户端');
+    expect(readme).toContain('SessionStart Hook');
+    expect(readme).toContain('`disabled: true`');
     expect(readme).toContain(
       `/releases/download/maker-plugin-v${pluginVersion}/taptap-maker-codex-plugin-${pluginVersion}.zip`
     );

--- a/src/__tests__/makerWorkBuddyPluginMigration.test.ts
+++ b/src/__tests__/makerWorkBuddyPluginMigration.test.ts
@@ -77,7 +77,7 @@ describe('Maker WorkBuddy plugin migration', () => {
     expect(inspect()).toMatchObject({ status: 'disabled', enabled: false });
   });
 
-  test('refuses to choose when both WorkBuddy config files register Maker', () => {
+  test('selects the only active registration when another config already disabled Maker', () => {
     writeConfig(primaryPath, {
       mcpServers: { 'taptap-maker': { command: 'node', disabled: false } },
     });
@@ -87,10 +87,70 @@ describe('Maker WorkBuddy plugin migration', () => {
 
     expect(inspect()).toEqual({
       client: 'workbuddy',
+      status: 'active',
+      config_path: primaryPath,
+      config_paths: [primaryPath, legacyPath],
+      registration_count: 2,
+      enabled: true,
+    });
+  });
+
+  test('refuses to choose when both WorkBuddy config files enable Maker', () => {
+    writeConfig(primaryPath, {
+      mcpServers: { 'taptap-maker': { command: 'node', disabled: false } },
+    });
+    writeConfig(legacyPath, {
+      mcpServers: { 'taptap-maker': { command: 'npx' } },
+    });
+
+    expect(inspect()).toEqual({
+      client: 'workbuddy',
       status: 'ambiguous',
       config_path: primaryPath,
       config_paths: [primaryPath, legacyPath],
       registration_count: 2,
+    });
+  });
+
+  test('migrates and restores the only active registration across both config files', () => {
+    writeConfig(primaryPath, {
+      mcpServers: { 'taptap-maker': { command: 'node', disabled: true } },
+    });
+    writeConfig(legacyPath, {
+      mcpServers: { 'taptap-maker': { command: 'npx' } },
+    });
+
+    const migrated = migrateWorkBuddyLegacyMakerMcp({
+      configPaths: [primaryPath, legacyPath],
+      makerHome,
+      confirm: true,
+    });
+
+    expect(migrated).toMatchObject({
+      status: 'disabled',
+      action: 'disabled',
+      changed: true,
+      config_path: legacyPath,
+      registration_count: 2,
+    });
+    expect(JSON.parse(fs.readFileSync(primaryPath, 'utf8')).mcpServers['taptap-maker']).toEqual({
+      command: 'node',
+      disabled: true,
+    });
+    expect(JSON.parse(fs.readFileSync(legacyPath, 'utf8')).mcpServers['taptap-maker']).toEqual({
+      command: 'npx',
+      disabled: true,
+    });
+
+    const restored = restoreWorkBuddyLegacyMakerMcp({
+      configPaths: [primaryPath, legacyPath],
+      makerHome,
+      confirm: true,
+    });
+
+    expect(restored).toMatchObject({ action: 'restored', changed: true, config_path: legacyPath });
+    expect(JSON.parse(fs.readFileSync(legacyPath, 'utf8')).mcpServers['taptap-maker']).toEqual({
+      command: 'npx',
     });
   });
 

--- a/src/__tests__/makerWorkBuddyPluginPackage.test.ts
+++ b/src/__tests__/makerWorkBuddyPluginPackage.test.ts
@@ -67,6 +67,7 @@ describe('TapTap Maker WorkBuddy plugin package', () => {
         ],
         commands: ['./commands/create-project.md', './commands/sync-project.md'],
         mcpServers: './.mcp.json',
+        hooks: './hooks/hooks.json',
         author: { name: 'TapTap Team' },
       })
     );
@@ -88,12 +89,12 @@ describe('TapTap Maker WorkBuddy plugin package', () => {
     }
   });
 
-  test('launches the bundled runtime through the WorkBuddy-managed Node resolver', () => {
+  test('launches the bundled runtime through WorkBuddy-provided Node', () => {
     const mcpText = fs.readFileSync(path.join(pluginRoot, '.mcp.json'), 'utf8');
     const mcp = JSON.parse(mcpText);
 
     expect(mcp.mcpServers['taptap-maker-plugin']).toEqual({
-      command: '${CODEBUDDY_PLUGIN_ROOT}/bin/run-node',
+      command: 'node',
       args: ['${CODEBUDDY_PLUGIN_ROOT}/dist/maker.js'],
       env: {
         TAPTAP_MAKER_DISTRIBUTION: 'workbuddy_plugin',
@@ -113,6 +114,8 @@ describe('TapTap Maker WorkBuddy plugin package', () => {
       'bin/run-node.cmd',
       'bin/taptap-maker',
       'bin/taptap-maker.cmd',
+      'hooks/hooks.json',
+      'hooks/session-start.cjs',
       'commands/create-project.md',
       'commands/sync-project.md',
       'skills/taptap-maker-local/SKILL.md',
@@ -139,6 +142,9 @@ describe('TapTap Maker WorkBuddy plugin package', () => {
     expect(fs.readFileSync(path.join(pluginRoot, 'icon.svg'), 'utf8')).toContain(
       'href="assets/taptap-maker.png"'
     );
+    const readme = fs.readFileSync(path.join(pluginRoot, 'README.md'), 'utf8');
+    expect(readme).toContain('.workbuddy/skills/taptap-maker-*');
+    expect(readme).toContain('只补齐缺失项，不覆盖已有同名 Skill');
   });
 
   test('uses Chinese display descriptions for commands and skills', () => {
@@ -169,6 +175,73 @@ describe('TapTap Maker WorkBuddy plugin package', () => {
     }
   });
 
+  test('prompts for confirmation when a standalone WorkBuddy Maker MCP is active', () => {
+    const workBuddyHome = path.join(tempDir, 'hook-active-home');
+    const configPath = path.join(workBuddyHome, '.workbuddy', '.mcp.json');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      `${JSON.stringify({ mcpServers: { 'taptap-maker': { command: 'npx' } } }, null, 2)}\n`,
+      'utf8'
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      [path.join(pluginRoot, 'hooks', 'session-start.cjs')],
+      {
+        cwd: pluginRoot,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          HOME: workBuddyHome,
+          USERPROFILE: workBuddyHome,
+          CODEBUDDY_PLUGIN_ROOT: pluginRoot,
+        },
+      }
+    );
+
+    expect(result.status).toBe(0);
+    const output = JSON.parse(result.stdout);
+    expect(output.hookSpecificOutput.additionalContext).toContain('旧的独立 Maker MCP');
+    expect(output.hookSpecificOutput.additionalContext).toContain('明确确认');
+    expect(output.hookSpecificOutput.additionalContext).toContain(
+      'plugin migrate --client workbuddy'
+    );
+  });
+
+  test('keeps the session hook silent when standalone Maker registrations are disabled', () => {
+    const workBuddyHome = path.join(tempDir, 'hook-disabled-home');
+    const configPath = path.join(workBuddyHome, '.workbuddy', 'mcp.json');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      `${JSON.stringify(
+        { mcpServers: { 'taptap-maker': { command: 'node', disabled: true } } },
+        null,
+        2
+      )}\n`,
+      'utf8'
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      [path.join(pluginRoot, 'hooks', 'session-start.cjs')],
+      {
+        cwd: pluginRoot,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          HOME: workBuddyHome,
+          USERPROFILE: workBuddyHome,
+          CODEBUDDY_PLUGIN_ROOT: pluginRoot,
+        },
+      }
+    );
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({ hookSpecificOutput: {} });
+  });
+
   test('resolves WorkBuddy managed Node without relying on Node in PATH', () => {
     if (process.platform === 'win32') {
       return;
@@ -193,6 +266,35 @@ describe('TapTap Maker WorkBuddy plugin package', () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout.trim()).toBe('managed-node:maker.js --version');
+  });
+
+  test('marks every bundled launcher invocation as the WorkBuddy plugin distribution', () => {
+    if (process.platform === 'win32') {
+      return;
+    }
+
+    const fakeBin = path.join(tempDir, 'distribution-node-bin');
+    const fakeNode = path.join(fakeBin, 'node');
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.writeFileSync(
+      fakeNode,
+      '#!/bin/sh\nprintf "%s:%s\\n" "$TAPTAP_MAKER_DISTRIBUTION" "$TAPTAP_MCP_CLIENT_IDE"\n',
+      'utf8'
+    );
+    fs.chmodSync(fakeNode, 0o755);
+
+    const result = spawnSync(path.join(pluginRoot, 'bin', 'run-node'), ['maker.js'], {
+      cwd: pluginRoot,
+      encoding: 'utf8',
+      env: {
+        HOME: path.join(tempDir, 'distribution-empty-home'),
+        PATH: '/usr/bin:/bin',
+        WORKBUDDY_EXTRA_PATHS: fakeBin,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe('workbuddy_plugin:workbuddy');
   });
 
   test('selects the newest managed Node without GNU version sort', () => {
@@ -285,8 +387,11 @@ describe('TapTap Maker WorkBuddy plugin package', () => {
       const content = fs.readFileSync(path.join(pluginRoot, 'commands', command), 'utf8');
       expect(content).toContain('empty');
       expect(content).toContain('${CODEBUDDY_PLUGIN_ROOT}/dist/maker.js');
-      expect(content).toContain('${CODEBUDDY_PLUGIN_ROOT}/bin/run-node');
-      expect(content).not.toMatch(/(?:^|\s)node\s+["']/mu);
+      expect(content).toContain('${CODEBUDDY_PLUGIN_ROOT}/bin/run-node"');
+      expect(content).toContain('${CODEBUDDY_PLUGIN_ROOT}/bin/run-node.cmd"');
+      expect(content).not.toMatch(
+        /(?:^|\s)node\s+"\$\{CODEBUDDY_PLUGIN_ROOT\}\/dist\/maker\.js"/mu
+      );
       expect(content).toContain('--skip-mcp-install');
     }
     expect(
@@ -304,6 +409,18 @@ describe('TapTap Maker WorkBuddy plugin package', () => {
     expect(updateSkill).toContain('/plugin');
     expect(updateSkill).not.toMatch(/(?:^|\s)npx\s+-/mu);
     expect(updateSkill).not.toContain('taptap-maker upgrade');
+  });
+
+  test('documents both Windows and POSIX bundled CLI launchers for lifecycle commands', () => {
+    const lifecycleSkill = fs.readFileSync(
+      path.join(pluginRoot, 'skills', 'taptap-maker-plugin-lifecycle', 'SKILL.md'),
+      'utf8'
+    );
+
+    expect(lifecycleSkill).toContain('${CODEBUDDY_PLUGIN_ROOT}/bin/run-node"');
+    expect(lifecycleSkill).toContain('${CODEBUDDY_PLUGIN_ROOT}/bin/run-node.cmd"');
+    expect(lifecycleSkill).toContain('TAPTAP_MAKER_DISTRIBUTION');
+    expect(lifecycleSkill).toContain('workbuddy_plugin');
   });
 
   test('keeps the shared local workflow neutral to the active plugin host', () => {

--- a/src/__tests__/makerWorkBuddyProjectSkills.test.ts
+++ b/src/__tests__/makerWorkBuddyProjectSkills.test.ts
@@ -1,0 +1,119 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { syncWorkBuddyProjectSkills } from '../maker/cli/workBuddyProjectSkills';
+
+describe('WorkBuddy Maker project skills', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'maker-workbuddy-project-skills-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function addDevKitSkill(name: string, body = `# ${name}\n`, projectDir = tempDir): void {
+    const skillDir = path.join(projectDir, '.installer', 'skills', name);
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(skillDir, 'SKILL.md'),
+      `---\nname: ${name}\ndescription: ${name} guide\n---\n\n${body}`,
+      'utf8'
+    );
+    fs.mkdirSync(path.join(skillDir, 'references'), { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'references', 'guide.md'), `${name} reference\n`, 'utf8');
+  }
+
+  test('syncs only missing dev-kit skills into the WorkBuddy project directory', () => {
+    addDevKitSkill('materials');
+    addDevKitSkill('local-preview');
+    const existingDir = path.join(tempDir, '.workbuddy', 'skills', 'taptap-maker-materials');
+    fs.mkdirSync(existingDir, { recursive: true });
+    fs.writeFileSync(path.join(existingDir, 'SKILL.md'), 'user managed content\n', 'utf8');
+
+    const result = syncWorkBuddyProjectSkills(tempDir);
+
+    expect(result.installedSkills).toEqual(['taptap-maker-local-preview']);
+    expect(result.skippedSkills).toEqual(['taptap-maker-materials']);
+    const installedDir = path.join(tempDir, '.workbuddy', 'skills', 'taptap-maker-local-preview');
+    expect(fs.lstatSync(installedDir).isDirectory()).toBe(true);
+    expect(fs.lstatSync(installedDir).isSymbolicLink()).toBe(false);
+    expect(fs.readFileSync(path.join(existingDir, 'SKILL.md'), 'utf8')).toBe(
+      'user managed content\n'
+    );
+    expect(
+      fs.readFileSync(
+        path.join(
+          tempDir,
+          '.workbuddy',
+          'skills',
+          path.basename(installedDir),
+          'references',
+          'guide.md'
+        ),
+        'utf8'
+      )
+    ).toBe('local-preview reference\n');
+  });
+
+  test('does nothing when the dev-kit skill source is unavailable', () => {
+    const result = syncWorkBuddyProjectSkills(tempDir);
+
+    expect(result).toEqual({
+      status: 'skipped',
+      sourceDir: path.join(tempDir, '.installer', 'skills'),
+      targetDir: path.join(tempDir, '.workbuddy', 'skills'),
+      installedSkills: [],
+      skippedSkills: [],
+      reason: 'source_not_found',
+    });
+    expect(fs.existsSync(path.join(tempDir, '.workbuddy'))).toBe(false);
+  });
+
+  test('uses Windows-safe copies and directory links for paths with spaces and Chinese text', () => {
+    const projectDir = path.join(tempDir, 'Windows 用户', 'Maker 游戏 项目');
+    fs.mkdirSync(projectDir, { recursive: true });
+    addDevKitSkill('素材 指南', '# Windows skill\n', projectDir);
+
+    const result = syncWorkBuddyProjectSkills(projectDir, { platform: 'win32' });
+
+    expect(result.installedSkills).toEqual(['taptap-maker-素材 指南']);
+    const installedDir = path.join(projectDir, '.workbuddy', 'skills', 'taptap-maker-素材 指南');
+    expect(fs.lstatSync(path.join(installedDir, 'SKILL.md')).isSymbolicLink()).toBe(false);
+    const referencesStat = fs.lstatSync(path.join(installedDir, 'references'));
+    expect(referencesStat.isSymbolicLink() || referencesStat.isDirectory()).toBe(true);
+    expect(fs.readFileSync(path.join(installedDir, 'references', 'guide.md'), 'utf8')).toBe(
+      '素材 指南 reference\n'
+    );
+  });
+
+  test('copies directories when Windows junction creation is unavailable', () => {
+    const projectDir = path.join(tempDir, 'Windows 回退', 'Maker 项目');
+    fs.mkdirSync(projectDir, { recursive: true });
+    addDevKitSkill('local-preview', '# Windows fallback\n', projectDir);
+    const symlinkSpy = jest.spyOn(fs, 'symlinkSync').mockImplementation(() => {
+      throw new Error('simulated Windows junction denial');
+    });
+
+    try {
+      const result = syncWorkBuddyProjectSkills(projectDir, { platform: 'win32' });
+
+      expect(result.installedSkills).toEqual(['taptap-maker-local-preview']);
+      const installedDir = path.join(
+        projectDir,
+        '.workbuddy',
+        'skills',
+        'taptap-maker-local-preview'
+      );
+      expect(fs.lstatSync(path.join(installedDir, 'references')).isSymbolicLink()).toBe(false);
+      expect(fs.readFileSync(path.join(installedDir, 'references', 'guide.md'), 'utf8')).toBe(
+        'local-preview reference\n'
+      );
+    } finally {
+      symlinkSpy.mockRestore();
+    }
+  });
+});

--- a/src/maker/README.md
+++ b/src/maker/README.md
@@ -45,6 +45,9 @@ Node.js。插件运行时仍完全来自自身 `dist/maker.js`，不下载或调
 只设置 `disabled: true`，不删除注册、鉴权、项目绑定或 connector trust。更新使用 WorkBuddy
 插件管理器，不运行 npm/npx 或独立 `taptap-maker upgrade`。
 
+初始化或更新 dev-kit 后，WorkBuddy 插件会将 `.installer/skills` 中缺失的项目 Skills 链接到
+`.workbuddy/skills/taptap-maker-*`。已有同名 Skill 保持不变，独立 MCP 和其他插件不执行该步骤。
+
 ## 独立 CLI
 
 不使用插件时，可以通过独立包启动 Maker CLI：

--- a/src/maker/cli/commands.ts
+++ b/src/maker/cli/commands.ts
@@ -76,6 +76,7 @@ import {
 } from '../system/luaLsp.js';
 import { formatMakerSkillStatus } from './skill.js';
 import { formatMakerPackageUpdateStatus, getMakerPackageUpdateStatus } from '../versionCheck.js';
+import { resolveMakerPluginDistribution } from '../pluginDistribution.js';
 import {
   formatMakerProjectInitializationStatus,
   inspectMakerProjectInitialization,
@@ -116,6 +117,7 @@ import {
   type WorkBuddyLegacyMakerMcpMigrationResult,
 } from './pluginMigration.js';
 import { writeConfigWithTapTapBackupIfChanged } from './configWrite.js';
+import { syncWorkBuddyProjectSkills } from './workBuddyProjectSkills.js';
 import {
   escapeTomlString,
   findCodexMcpTableDuplicates,
@@ -1558,6 +1560,7 @@ async function runDevKitUpdate(parsed: ParsedArgs, ctx: CliContext): Promise<voi
     replaceManagedEntries: true,
     environment: makerEnvOption(parsed),
   });
+  syncWorkBuddyDevKitSkills(targetDir, ctx);
   finalizeStagedDevKitGitignore(targetDir);
   emit(ctx, 'dev_kit', formatDevKitInstallMessage('AI dev kit updated', result), result);
   emitDevKitSkillInstallerFailure(ctx, result.skillInstaller, 'AI skills install failed');
@@ -1874,6 +1877,7 @@ async function prepareDevKit(
         path.join(targetDir, DEV_KIT_GITIGNORE_STAGING_FILE),
         listPresentDevKitManagedEntries(targetDir)
       );
+      syncWorkBuddyDevKitSkills(targetDir, ctx);
       if (options.finalizeGitignore) {
         finalizeStagedDevKitGitignore(targetDir);
       }
@@ -1909,6 +1913,7 @@ async function prepareDevKit(
       environment: options.environment,
       onSkillInstallerStart: (event) => emitSkillInstallerStart(ctx, event),
     });
+    syncWorkBuddyDevKitSkills(targetDir, ctx);
     if (options.finalizeGitignore) {
       finalizeStagedDevKitGitignore(targetDir);
     }
@@ -1921,6 +1926,38 @@ async function prepareDevKit(
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
     emit(ctx, 'dev_kit_warning', `AI dev kit preparation failed; clone will continue\n${detail}`, {
+      error: detail,
+    });
+  }
+}
+
+function syncWorkBuddyDevKitSkills(targetDir: string, ctx: CliContext): void {
+  if (resolveMakerPluginDistribution()?.client !== 'workbuddy') {
+    return;
+  }
+
+  try {
+    const result = syncWorkBuddyProjectSkills(targetDir);
+    const managedSkillPaths = [...result.installedSkills, ...result.skippedSkills].map(
+      (skillName) => path.join('.workbuddy', 'skills', skillName)
+    );
+    if (managedSkillPaths.length > 0) {
+      writeDevKitStagedGitignore(path.join(targetDir, DEV_KIT_GITIGNORE_STAGING_FILE), [
+        ...listPresentDevKitManagedEntries(targetDir),
+        ...managedSkillPaths,
+      ]);
+    }
+    if (result.installedSkills.length > 0) {
+      emit(
+        ctx,
+        'dev_kit',
+        `WorkBuddy project skills installed: ${result.installedSkills.length}`,
+        result
+      );
+    }
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    emit(ctx, 'dev_kit_warning', `WorkBuddy project skills install failed\n${detail}`, {
       error: detail,
     });
   }

--- a/src/maker/cli/pluginMigration.ts
+++ b/src/maker/cli/pluginMigration.ts
@@ -370,18 +370,21 @@ export function inspectWorkBuddyLegacyMakerMcp(
   if (registrations.length === 0) {
     return createWorkBuddyInspection(configPaths[0], 'not_found', []);
   }
-  if (registrations.length > 1) {
+  const activeRegistrations = registrations.filter((entry) => entry.registration.disabled !== true);
+  if (activeRegistrations.length > 1) {
     return createWorkBuddyInspection(configPaths[0], 'ambiguous', registrationPaths);
   }
+  if (activeRegistrations.length === 0) {
+    return {
+      ...createWorkBuddyInspection(registrations[0].configPath, 'disabled', registrationPaths),
+      enabled: false,
+    };
+  }
 
-  const enabled = registrations[0].registration.disabled !== true;
+  const active = activeRegistrations[0];
   return {
-    ...createWorkBuddyInspection(
-      registrations[0].configPath,
-      enabled ? 'active' : 'disabled',
-      registrationPaths
-    ),
-    enabled,
+    ...createWorkBuddyInspection(active.configPath, 'active', registrationPaths),
+    enabled: true,
   };
 }
 
@@ -402,14 +405,20 @@ export function migrateWorkBuddyLegacyMakerMcp(
     );
   }
 
-  const current = findWorkBuddyMakerRegistrations(configPaths)[0];
+  const registrations = findWorkBuddyMakerRegistrations(configPaths);
   if (inspection.status === 'disabled') {
     const state = readWorkBuddyMigrationState(statePath);
-    const owned =
-      state?.config_path === current.configPath &&
-      hashWorkBuddyRegistration(current.registration) === state.migrated_registration_sha256;
+    const current = state
+      ? registrations.find((entry) => entry.configPath === state.config_path)
+      : registrations[0];
+    const owned = Boolean(
+      state &&
+        current &&
+        hashWorkBuddyRegistration(current.registration) === state.migrated_registration_sha256
+    );
     return {
       ...inspection,
+      ...(owned && current ? { config_path: current.configPath } : {}),
       action: owned ? 'already_migrated' : 'already_disabled',
       changed: false,
       ...(owned ? { state_path: statePath } : {}),
@@ -417,6 +426,10 @@ export function migrateWorkBuddyLegacyMakerMcp(
   }
   if (!options.confirm) {
     throw new Error('Disabling the legacy WorkBuddy Maker MCP requires explicit confirmation.');
+  }
+  const current = registrations.find((entry) => entry.configPath === inspection.config_path);
+  if (!current) {
+    throw new Error('The active WorkBuddy Maker MCP registration could not be resolved.');
   }
 
   const originalRegistration = { ...current.registration };
@@ -438,10 +451,12 @@ export function migrateWorkBuddyLegacyMakerMcp(
 
   fs.mkdirSync(path.dirname(statePath), { recursive: true });
   const write = writeConfigWithTapTapBackupIfChanged(current.configPath, nextContent, () => {
-    const migratedInspection = inspectWorkBuddyLegacyMakerMcp({ configPaths });
+    const migrated = findWorkBuddyMakerRegistrations(configPaths).find(
+      (entry) => entry.configPath === current.configPath
+    );
     if (
-      migratedInspection.status !== 'disabled' ||
-      migratedInspection.config_path !== current.configPath
+      !migrated ||
+      hashWorkBuddyRegistration(migrated.registration) !== state.migrated_registration_sha256
     ) {
       throw new Error(
         'WorkBuddy Maker MCP migration validation did not find the disabled registration.'
@@ -449,8 +464,10 @@ export function migrateWorkBuddyLegacyMakerMcp(
     }
     fs.writeFileSync(statePath, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
   });
+  const migratedInspection = inspectWorkBuddyLegacyMakerMcp({ configPaths });
   return {
-    ...inspectWorkBuddyLegacyMakerMcp({ configPaths }),
+    ...migratedInspection,
+    config_path: current.configPath,
     action: 'disabled',
     changed: write.changed,
     ...(write.backupPath ? { backup_path: write.backupPath } : {}),
@@ -483,21 +500,35 @@ export function restoreWorkBuddyLegacyMakerMcp(
       'The migrated WorkBuddy Maker MCP registration no longer exists and cannot be restored.'
     );
   }
-  if (inspection.config_path !== state.config_path) {
-    return { ...inspection, action: 'not_owned', changed: false };
+  const current = findWorkBuddyMakerRegistrations(configPaths).find(
+    (entry) => entry.configPath === state.config_path
+  );
+  if (!current) {
+    throw new Error(
+      'The migrated WorkBuddy Maker MCP registration no longer exists and cannot be restored.'
+    );
   }
-
-  const current = findWorkBuddyMakerRegistrations(configPaths)[0];
   const registrationSha256 = hashWorkBuddyRegistration(current.registration);
-  if (inspection.status === 'active') {
+  const currentEnabled = current.registration.disabled !== true;
+  if (currentEnabled) {
     if (registrationSha256 !== state.original_registration_sha256) {
-      return { ...inspection, action: 'not_owned', changed: false };
+      return {
+        ...inspection,
+        config_path: current.configPath,
+        action: 'not_owned',
+        changed: false,
+      };
     }
     fs.unlinkSync(statePath);
-    return { ...inspection, action: 'already_restored', changed: false };
+    return {
+      ...inspection,
+      config_path: current.configPath,
+      action: 'already_restored',
+      changed: false,
+    };
   }
   if (registrationSha256 !== state.migrated_registration_sha256) {
-    return { ...inspection, action: 'not_owned', changed: false };
+    return { ...inspection, config_path: current.configPath, action: 'not_owned', changed: false };
   }
 
   const restoredRegistration = { ...current.registration };
@@ -515,14 +546,20 @@ export function restoreWorkBuddyLegacyMakerMcp(
         'WorkBuddy Maker MCP restoration validation did not find an active registration.'
       );
     }
-    const restored = findWorkBuddyMakerRegistrations(configPaths)[0];
-    if (hashWorkBuddyRegistration(restored.registration) !== state.original_registration_sha256) {
+    const restored = findWorkBuddyMakerRegistrations(configPaths).find(
+      (entry) => entry.configPath === state.config_path
+    );
+    if (
+      !restored ||
+      hashWorkBuddyRegistration(restored.registration) !== state.original_registration_sha256
+    ) {
       throw new Error('WorkBuddy Maker MCP restoration changed the registration identity.');
     }
     fs.unlinkSync(statePath);
   });
   return {
     ...inspectWorkBuddyLegacyMakerMcp({ configPaths }),
+    config_path: current.configPath,
     action: 'restored',
     changed: write.changed,
     ...(write.backupPath ? { backup_path: write.backupPath } : {}),

--- a/src/maker/cli/workBuddyProjectSkills.ts
+++ b/src/maker/cli/workBuddyProjectSkills.ts
@@ -1,0 +1,118 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface WorkBuddyProjectSkillsSyncResult {
+  status: 'installed' | 'skipped';
+  sourceDir: string;
+  targetDir: string;
+  installedSkills: string[];
+  skippedSkills: string[];
+  reason?: 'source_not_found';
+}
+
+export function syncWorkBuddyProjectSkills(
+  targetDir: string,
+  options: { platform?: NodeJS.Platform } = {}
+): WorkBuddyProjectSkillsSyncResult {
+  const platform = options.platform ?? process.platform;
+  const projectDir = path.resolve(targetDir);
+  const sourceDir = path.join(projectDir, '.installer', 'skills');
+  const workBuddySkillsDir = path.join(projectDir, '.workbuddy', 'skills');
+  const result: WorkBuddyProjectSkillsSyncResult = {
+    status: 'skipped',
+    sourceDir,
+    targetDir: workBuddySkillsDir,
+    installedSkills: [],
+    skippedSkills: [],
+  };
+
+  if (!isDirectory(sourceDir)) {
+    result.reason = 'source_not_found';
+    return result;
+  }
+
+  const sourceSkills = fs
+    .readdirSync(sourceDir, { withFileTypes: true })
+    .filter(
+      (entry) => entry.isDirectory() && fs.existsSync(path.join(sourceDir, entry.name, 'SKILL.md'))
+    )
+    .map((entry) => entry.name)
+    .sort();
+
+  for (const sourceSkillName of sourceSkills) {
+    const workBuddySkillName = `taptap-maker-${sourceSkillName}`;
+    const workBuddySkillDir = path.join(workBuddySkillsDir, workBuddySkillName);
+    if (pathEntryExists(workBuddySkillDir)) {
+      result.skippedSkills.push(workBuddySkillName);
+      continue;
+    }
+
+    fs.mkdirSync(workBuddySkillsDir, { recursive: true });
+    installSkillContents(path.join(sourceDir, sourceSkillName), workBuddySkillDir, platform);
+    result.installedSkills.push(workBuddySkillName);
+  }
+
+  if (result.installedSkills.length > 0) {
+    result.status = 'installed';
+  }
+  return result;
+}
+
+function installSkillContents(
+  sourceDir: string,
+  targetDir: string,
+  platform: NodeJS.Platform
+): void {
+  fs.mkdirSync(targetDir);
+  try {
+    for (const entry of fs.readdirSync(sourceDir)) {
+      linkOrCopyEntry(path.join(sourceDir, entry), path.join(targetDir, entry), platform);
+    }
+  } catch (error) {
+    fs.rmSync(targetDir, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function linkOrCopyEntry(source: string, target: string, platform: NodeJS.Platform): void {
+  const stat = fs.statSync(source);
+  if (platform === 'win32' && stat.isFile()) {
+    fs.copyFileSync(source, target);
+    return;
+  }
+
+  try {
+    const linkTarget = platform === 'win32' ? source : path.relative(path.dirname(target), source);
+    const linkType = stat.isDirectory() ? (platform === 'win32' ? 'junction' : 'dir') : 'file';
+    fs.symlinkSync(linkTarget, target, linkType);
+  } catch (error) {
+    try {
+      fs.cpSync(source, target, { recursive: stat.isDirectory() });
+    } catch (copyError) {
+      throw new Error(
+        `Failed to install WorkBuddy project skill entry ${source}: ${formatError(error)}; copy fallback: ${formatError(copyError)}`
+      );
+    }
+  }
+}
+
+function isDirectory(value: string): boolean {
+  try {
+    return fs.statSync(value).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function pathEntryExists(value: string): boolean {
+  try {
+    fs.lstatSync(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}


### PR DESCRIPTION
## 变更内容

- 新增 WorkBuddy SessionStart 冲突检查和旧 Maker MCP 安全迁移/恢复
- 将 dev-kit Skills 幂等同步到 `.workbuddy/skills`
- 完善 Codex/WorkBuddy 双插件安装说明和版本分发入口
- 修复 WorkBuddy 内置 Node、Windows `.cmd` 和中文路径兼容性

## 兼容性

- 独立 Maker MCP 的安装、更新和运行行为保持不变
- Codex 与 WorkBuddy 插件源码、配置和生成产物继续隔离
- Maker MCP 版本保持 `0.0.30`，插件版本由独立发布流程管理

## 验证

- `npm test -- --runInBand`：57 suites / 846 tests passed
- `npm run lint`
- `npm run format:check`
- `npm run maker:plugins:package`
- Codex 插件规范校验和 Windows 分支模拟通过