### PR TITLE
fix(maker): 使用 WorkBuddy 托管 Node 启动 MCP

### DIFF
--- a/plugins/workbuddy/taptap-maker/.mcp.json
+++ b/plugins/workbuddy/taptap-maker/.mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "taptap-maker-plugin": {
-      "command": "node",
+      "command": "${CODEBUDDY_PLUGIN_ROOT}/bin/run-node",
       "args": ["${CODEBUDDY_PLUGIN_ROOT}/dist/maker.js"],
       "env": {
         "TAPTAP_MAKER_DISTRIBUTION": "workbuddy_plugin",

--- a/scripts/prepare-maker-workbuddy-plugin.js
+++ b/scripts/prepare-maker-workbuddy-plugin.js
@@ -181,7 +181,7 @@ function createMcpConfig() {
   return {
     mcpServers: {
       'taptap-maker-plugin': {
-        command: 'node',
+        command: '${CODEBUDDY_PLUGIN_ROOT}/bin/run-node',
         args: ['${CODEBUDDY_PLUGIN_ROOT}/dist/maker.js'],
         env: {
           TAPTAP_MAKER_DISTRIBUTION: 'workbuddy_plugin',

--- a/src/__tests__/makerWorkBuddyPluginPackage.test.ts
+++ b/src/__tests__/makerWorkBuddyPluginPackage.test.ts
@@ -94,7 +94,7 @@ describe('TapTap Maker WorkBuddy plugin package', () => {
     const mcp = JSON.parse(mcpText);
 
     expect(mcp.mcpServers['taptap-maker-plugin']).toEqual({
-      command: 'node',
+      command: '${CODEBUDDY_PLUGIN_ROOT}/bin/run-node',
       args: ['${CODEBUDDY_PLUGIN_ROOT}/dist/maker.js'],
       env: {
         TAPTAP_MAKER_DISTRIBUTION: 'workbuddy_plugin',


### PR DESCRIPTION
## 问题

WorkBuddy 插件 `.mcp.json` 直接执行裸 `node`。WorkBuddy 只提供 managed Node、系统 PATH 没有 Node 时，MCP 无法启动。

## 修复

- MCP 通过 `${CODEBUDDY_PLUGIN_ROOT}/bin/run-node` 启动 bundled Maker runtime
- macOS/Linux 使用 `bin/run-node`，Windows 由 `cross-spawn` 按 PATHEXT 解析 `bin/run-node.cmd`
- 生成脚本和契约测试同步更新

## 验证

- 17 项 WorkBuddy 插件契约测试通过
- Prettier 检查通过
- 清空系统 Node PATH、仅提供 `WORKBUDDY_EXTRA_PATHS` 时，MCP `initialize` 和 `tools/list` 成功