### PR TITLE
fix(maker): 同步客户端插件运行时产物

### DIFF
--- a/plugins/taptap-maker/dist/maker.js
+++ b/plugins/taptap-maker/dist/maker.js
@@ -41,9 +41,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/code.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/code.js
 var require_code = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/code.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/code.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.regexpCode = exports.getEsmExportName = exports.getProperty = exports.safeStringify = exports.stringify = exports.strConcat = exports.addCodeArg = exports.str = exports._ = exports.nil = exports._Code = exports.Name = exports.IDENTIFIER = exports._CodeOrName = void 0;
@@ -195,9 +195,9 @@ var require_code = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/scope.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/scope.js
 var require_scope = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/scope.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/scope.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.ValueScope = exports.ValueScopeName = exports.Scope = exports.varKinds = exports.UsedValueState = void 0;
@@ -340,9 +340,9 @@ var require_scope = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/index.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/index.js
 var require_codegen = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/index.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.or = exports.and = exports.not = exports.CodeGen = exports.operators = exports.varKinds = exports.ValueScopeName = exports.ValueScope = exports.Scope = exports.Name = exports.regexpCode = exports.stringify = exports.getProperty = exports.nil = exports.strConcat = exports.str = exports._ = void 0;
@@ -1060,9 +1060,9 @@ var require_codegen = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/util.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/util.js
 var require_util = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/util.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/util.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.checkStrictMode = exports.getErrorPath = exports.Type = exports.useFunc = exports.setEvaluated = exports.evaluatedPropsToName = exports.mergeEvaluated = exports.eachItem = exports.unescapeJsonPointer = exports.escapeJsonPointer = exports.escapeFragment = exports.unescapeFragment = exports.schemaRefOrVal = exports.schemaHasRulesButRef = exports.schemaHasRules = exports.checkUnknownRules = exports.alwaysValidSchema = exports.toHash = void 0;
@@ -1227,9 +1227,9 @@ var require_util = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/names.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/names.js
 var require_names = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/names.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/names.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -1266,9 +1266,9 @@ var require_names = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/errors.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/errors.js
 var require_errors = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/errors.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/errors.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.extendErrors = exports.resetErrorsCount = exports.reportExtraError = exports.reportError = exports.keyword$DataError = exports.keywordError = void 0;
@@ -1388,9 +1388,9 @@ var require_errors = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/boolSchema.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/boolSchema.js
 var require_boolSchema = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/boolSchema.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/boolSchema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.boolOrEmptySchema = exports.topBoolOrEmptySchema = void 0;
@@ -1439,9 +1439,9 @@ var require_boolSchema = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/rules.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/rules.js
 var require_rules = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/rules.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/rules.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getRules = exports.isJSONType = void 0;
@@ -1470,9 +1470,9 @@ var require_rules = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/applicability.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/applicability.js
 var require_applicability = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/applicability.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/applicability.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.shouldUseRule = exports.shouldUseGroup = exports.schemaHasRulesForType = void 0;
@@ -1493,9 +1493,9 @@ var require_applicability = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/dataType.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/dataType.js
 var require_dataType = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/dataType.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/dataType.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.reportTypeError = exports.checkDataTypes = exports.checkDataType = exports.coerceAndCheckDataType = exports.getJSONTypes = exports.getSchemaTypes = exports.DataType = void 0;
@@ -1677,9 +1677,9 @@ var require_dataType = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/defaults.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/defaults.js
 var require_defaults = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/defaults.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/defaults.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.assignDefaults = void 0;
@@ -1714,9 +1714,9 @@ var require_defaults = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/code.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/code.js
 var require_code2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/code.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/code.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateUnion = exports.validateArray = exports.usePattern = exports.callValidateCode = exports.schemaProperties = exports.allSchemaProperties = exports.noPropertyInData = exports.propertyInData = exports.isOwnProperty = exports.hasPropFunc = exports.reportMissingProp = exports.checkMissingProp = exports.checkReportMissingProp = void 0;
@@ -1847,9 +1847,9 @@ var require_code2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/keyword.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/keyword.js
 var require_keyword = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/keyword.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/keyword.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateKeywordUsage = exports.validSchemaType = exports.funcKeywordCode = exports.macroKeywordCode = void 0;
@@ -1965,9 +1965,9 @@ var require_keyword = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/subschema.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/subschema.js
 var require_subschema = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/subschema.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/subschema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.extendSubschemaMode = exports.extendSubschemaData = exports.getSubschema = void 0;
@@ -2048,9 +2048,9 @@ var require_subschema = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-deep-equal/index.js
+// node_modules/fast-deep-equal/index.js
 var require_fast_deep_equal = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-deep-equal/index.js"(exports, module) {
+  "node_modules/fast-deep-equal/index.js"(exports, module) {
     "use strict";
     module.exports = function equal(a, b) {
       if (a === b) return true;
@@ -2083,9 +2083,9 @@ var require_fast_deep_equal = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse/index.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse/index.js
 var require_json_schema_traverse = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse/index.js"(exports, module) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse/index.js"(exports, module) {
     "use strict";
     var traverse = module.exports = function(schema, opts, cb) {
       if (typeof opts == "function") {
@@ -2171,9 +2171,9 @@ var require_json_schema_traverse = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/resolve.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/resolve.js
 var require_resolve = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/resolve.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/resolve.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getSchemaRefs = exports.resolveUrl = exports.normalizeId = exports._getFullPath = exports.getFullPath = exports.inlineRef = void 0;
@@ -2327,9 +2327,9 @@ var require_resolve = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/index.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/index.js
 var require_validate = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/index.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getData = exports.KeywordCxt = exports.validateFunctionCode = void 0;
@@ -2835,9 +2835,9 @@ var require_validate = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/validation_error.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/validation_error.js
 var require_validation_error = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/validation_error.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/validation_error.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var ValidationError = class extends Error {
@@ -2851,9 +2851,9 @@ var require_validation_error = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/ref_error.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/ref_error.js
 var require_ref_error = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/ref_error.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/ref_error.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var resolve_1 = require_resolve();
@@ -2868,9 +2868,9 @@ var require_ref_error = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/index.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/index.js
 var require_compile = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/index.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.resolveSchema = exports.getCompilingSchema = exports.resolveRef = exports.compileSchema = exports.SchemaEnv = void 0;
@@ -3092,9 +3092,9 @@ var require_compile = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/data.json
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/data.json
 var require_data = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/data.json"(exports, module) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/data.json"(exports, module) {
     module.exports = {
       $id: "https://raw.githubusercontent.com/ajv-validator/ajv/master/lib/refs/data.json#",
       description: "Meta-schema for $data reference (JSON AnySchema extension proposal)",
@@ -3111,9 +3111,9 @@ var require_data = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-uri/lib/utils.js
+// node_modules/fast-uri/lib/utils.js
 var require_utils = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-uri/lib/utils.js"(exports, module) {
+  "node_modules/fast-uri/lib/utils.js"(exports, module) {
     "use strict";
     var isUUID = RegExp.prototype.test.bind(/^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/iu);
     var isIPv4 = RegExp.prototype.test.bind(/^(?:(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)$/u);
@@ -3368,9 +3368,9 @@ var require_utils = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-uri/lib/schemes.js
+// node_modules/fast-uri/lib/schemes.js
 var require_schemes = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-uri/lib/schemes.js"(exports, module) {
+  "node_modules/fast-uri/lib/schemes.js"(exports, module) {
     "use strict";
     var { isUUID } = require_utils();
     var URN_REG = /([\da-z][\d\-a-z]{0,31}):((?:[\w!$'()*+,\-.:;=@]|%[\da-f]{2})+)/iu;
@@ -3578,9 +3578,9 @@ var require_schemes = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-uri/index.js
+// node_modules/fast-uri/index.js
 var require_fast_uri = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-uri/index.js"(exports, module) {
+  "node_modules/fast-uri/index.js"(exports, module) {
     "use strict";
     var { normalizeIPv6, removeDotSegments, recomposeAuthority, normalizeComponentEncoding, isIPv4, nonSimpleDomain } = require_utils();
     var { SCHEMES, getSchemeHandler } = require_schemes();
@@ -3833,9 +3833,9 @@ var require_fast_uri = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/uri.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/uri.js
 var require_uri = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/uri.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/uri.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var uri = require_fast_uri();
@@ -3844,9 +3844,9 @@ var require_uri = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/core.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/core.js
 var require_core = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/core.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/core.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = void 0;
@@ -4455,9 +4455,9 @@ var require_core = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/id.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/id.js
 var require_id = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/id.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/id.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var def = {
@@ -4470,9 +4470,9 @@ var require_id = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/ref.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/ref.js
 var require_ref = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/ref.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/ref.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.callRef = exports.getValidate = void 0;
@@ -4592,9 +4592,9 @@ var require_ref = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/index.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/index.js
 var require_core2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/index.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var id_1 = require_id();
@@ -4613,9 +4613,9 @@ var require_core2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitNumber.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitNumber.js
 var require_limitNumber = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitNumber.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitNumber.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4645,9 +4645,9 @@ var require_limitNumber = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/multipleOf.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/multipleOf.js
 var require_multipleOf = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/multipleOf.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/multipleOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4673,9 +4673,9 @@ var require_multipleOf = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/ucs2length.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/ucs2length.js
 var require_ucs2length = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/ucs2length.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/ucs2length.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     function ucs2length(str) {
@@ -4699,9 +4699,9 @@ var require_ucs2length = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitLength.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitLength.js
 var require_limitLength = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitLength.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitLength.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4731,9 +4731,9 @@ var require_limitLength = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/pattern.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/pattern.js
 var require_pattern = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/pattern.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/pattern.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -4768,9 +4768,9 @@ var require_pattern = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitProperties.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitProperties.js
 var require_limitProperties = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitProperties.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4797,9 +4797,9 @@ var require_limitProperties = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/required.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/required.js
 var require_required = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/required.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/required.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -4879,9 +4879,9 @@ var require_required = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitItems.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitItems.js
 var require_limitItems = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitItems.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4908,9 +4908,9 @@ var require_limitItems = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/equal.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/equal.js
 var require_equal = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/equal.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/equal.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var equal = require_fast_deep_equal();
@@ -4919,9 +4919,9 @@ var require_equal = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js
 var require_uniqueItems = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var dataType_1 = require_dataType();
@@ -4986,9 +4986,9 @@ var require_uniqueItems = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/const.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/const.js
 var require_const = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/const.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/const.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5015,9 +5015,9 @@ var require_const = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/enum.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/enum.js
 var require_enum = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/enum.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/enum.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5064,9 +5064,9 @@ var require_enum = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/index.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/index.js
 var require_validation = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/index.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var limitNumber_1 = require_limitNumber();
@@ -5102,9 +5102,9 @@ var require_validation = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js
 var require_additionalItems = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateAdditionalItems = void 0;
@@ -5155,9 +5155,9 @@ var require_additionalItems = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items.js
 var require_items = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateTuple = void 0;
@@ -5212,9 +5212,9 @@ var require_items = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js
 var require_prefixItems = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var items_1 = require_items();
@@ -5229,9 +5229,9 @@ var require_prefixItems = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items2020.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items2020.js
 var require_items2020 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items2020.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items2020.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5264,9 +5264,9 @@ var require_items2020 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/contains.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/contains.js
 var require_contains = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/contains.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/contains.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5358,9 +5358,9 @@ var require_contains = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/dependencies.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/dependencies.js
 var require_dependencies = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/dependencies.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/dependencies.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateSchemaDeps = exports.validatePropertyDeps = exports.error = void 0;
@@ -5452,9 +5452,9 @@ var require_dependencies = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js
 var require_propertyNames = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5495,9 +5495,9 @@ var require_propertyNames = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js
 var require_additionalProperties = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -5601,9 +5601,9 @@ var require_additionalProperties = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/properties.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/properties.js
 var require_properties = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/properties.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/properties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var validate_1 = require_validate();
@@ -5659,9 +5659,9 @@ var require_properties = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js
 var require_patternProperties = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -5733,9 +5733,9 @@ var require_patternProperties = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/not.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/not.js
 var require_not = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/not.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/not.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util();
@@ -5764,9 +5764,9 @@ var require_not = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/anyOf.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/anyOf.js
 var require_anyOf = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/anyOf.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/anyOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -5781,9 +5781,9 @@ var require_anyOf = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/oneOf.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/oneOf.js
 var require_oneOf = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/oneOf.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/oneOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5839,9 +5839,9 @@ var require_oneOf = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/allOf.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/allOf.js
 var require_allOf = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/allOf.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/allOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util();
@@ -5866,9 +5866,9 @@ var require_allOf = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/if.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/if.js
 var require_if = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/if.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/if.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5935,9 +5935,9 @@ var require_if = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/thenElse.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/thenElse.js
 var require_thenElse = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/thenElse.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/thenElse.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util();
@@ -5953,9 +5953,9 @@ var require_thenElse = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/index.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/index.js
 var require_applicator = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/index.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var additionalItems_1 = require_additionalItems();
@@ -6001,9 +6001,9 @@ var require_applicator = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/format.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/format.js
 var require_format = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/format.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/format.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -6091,9 +6091,9 @@ var require_format = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/index.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/index.js
 var require_format2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/index.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var format_1 = require_format();
@@ -6102,9 +6102,9 @@ var require_format2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/metadata.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/metadata.js
 var require_metadata = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/metadata.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/metadata.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.contentVocabulary = exports.metadataVocabulary = void 0;
@@ -6125,9 +6125,9 @@ var require_metadata = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/draft7.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/draft7.js
 var require_draft7 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/draft7.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/draft7.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var core_1 = require_core2();
@@ -6147,9 +6147,9 @@ var require_draft7 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/types.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/types.js
 var require_types = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/types.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/types.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.DiscrError = void 0;
@@ -6161,9 +6161,9 @@ var require_types = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/index.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/index.js
 var require_discriminator = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/index.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -6266,9 +6266,9 @@ var require_discriminator = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/json-schema-draft-07.json
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/json-schema-draft-07.json
 var require_json_schema_draft_07 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/json-schema-draft-07.json"(exports, module) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/json-schema-draft-07.json"(exports, module) {
     module.exports = {
       $schema: "http://json-schema.org/draft-07/schema#",
       $id: "http://json-schema.org/draft-07/schema#",
@@ -6423,9 +6423,9 @@ var require_json_schema_draft_07 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/ajv.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/ajv.js
 var require_ajv = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/ajv.js"(exports, module) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/ajv.js"(exports, module) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.MissingRefError = exports.ValidationError = exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = exports.Ajv = void 0;
@@ -6493,9 +6493,9 @@ var require_ajv = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/dist/formats.js
+// node_modules/ajv-formats/dist/formats.js
 var require_formats = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/dist/formats.js"(exports) {
+  "node_modules/ajv-formats/dist/formats.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.formatNames = exports.fastFormats = exports.fullFormats = void 0;
@@ -6696,9 +6696,9 @@ var require_formats = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/code.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/code.js
 var require_code3 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/code.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/code.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.regexpCode = exports.getEsmExportName = exports.getProperty = exports.safeStringify = exports.stringify = exports.strConcat = exports.addCodeArg = exports.str = exports._ = exports.nil = exports._Code = exports.Name = exports.IDENTIFIER = exports._CodeOrName = void 0;
@@ -6850,9 +6850,9 @@ var require_code3 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/scope.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/scope.js
 var require_scope2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/scope.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/scope.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.ValueScope = exports.ValueScopeName = exports.Scope = exports.varKinds = exports.UsedValueState = void 0;
@@ -6995,9 +6995,9 @@ var require_scope2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/index.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/index.js
 var require_codegen2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/index.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.or = exports.and = exports.not = exports.CodeGen = exports.operators = exports.varKinds = exports.ValueScopeName = exports.ValueScope = exports.Scope = exports.Name = exports.regexpCode = exports.stringify = exports.getProperty = exports.nil = exports.strConcat = exports.str = exports._ = void 0;
@@ -7715,9 +7715,9 @@ var require_codegen2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/util.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/util.js
 var require_util2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/util.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/util.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.checkStrictMode = exports.getErrorPath = exports.Type = exports.useFunc = exports.setEvaluated = exports.evaluatedPropsToName = exports.mergeEvaluated = exports.eachItem = exports.unescapeJsonPointer = exports.escapeJsonPointer = exports.escapeFragment = exports.unescapeFragment = exports.schemaRefOrVal = exports.schemaHasRulesButRef = exports.schemaHasRules = exports.checkUnknownRules = exports.alwaysValidSchema = exports.toHash = void 0;
@@ -7882,9 +7882,9 @@ var require_util2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/names.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/names.js
 var require_names2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/names.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/names.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -7921,9 +7921,9 @@ var require_names2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/errors.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/errors.js
 var require_errors2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/errors.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/errors.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.extendErrors = exports.resetErrorsCount = exports.reportExtraError = exports.reportError = exports.keyword$DataError = exports.keywordError = void 0;
@@ -8043,9 +8043,9 @@ var require_errors2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/boolSchema.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/boolSchema.js
 var require_boolSchema2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/boolSchema.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/boolSchema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.boolOrEmptySchema = exports.topBoolOrEmptySchema = void 0;
@@ -8094,9 +8094,9 @@ var require_boolSchema2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/rules.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/rules.js
 var require_rules2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/rules.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/rules.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getRules = exports.isJSONType = void 0;
@@ -8125,9 +8125,9 @@ var require_rules2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/applicability.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/applicability.js
 var require_applicability2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/applicability.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/applicability.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.shouldUseRule = exports.shouldUseGroup = exports.schemaHasRulesForType = void 0;
@@ -8148,9 +8148,9 @@ var require_applicability2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/dataType.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/dataType.js
 var require_dataType2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/dataType.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/dataType.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.reportTypeError = exports.checkDataTypes = exports.checkDataType = exports.coerceAndCheckDataType = exports.getJSONTypes = exports.getSchemaTypes = exports.DataType = void 0;
@@ -8332,9 +8332,9 @@ var require_dataType2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/defaults.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/defaults.js
 var require_defaults2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/defaults.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/defaults.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.assignDefaults = void 0;
@@ -8369,9 +8369,9 @@ var require_defaults2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/code.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/code.js
 var require_code4 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/code.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/code.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateUnion = exports.validateArray = exports.usePattern = exports.callValidateCode = exports.schemaProperties = exports.allSchemaProperties = exports.noPropertyInData = exports.propertyInData = exports.isOwnProperty = exports.hasPropFunc = exports.reportMissingProp = exports.checkMissingProp = exports.checkReportMissingProp = void 0;
@@ -8502,9 +8502,9 @@ var require_code4 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/keyword.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/keyword.js
 var require_keyword2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/keyword.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/keyword.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateKeywordUsage = exports.validSchemaType = exports.funcKeywordCode = exports.macroKeywordCode = void 0;
@@ -8620,9 +8620,9 @@ var require_keyword2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/subschema.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/subschema.js
 var require_subschema2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/subschema.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/subschema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.extendSubschemaMode = exports.extendSubschemaData = exports.getSubschema = void 0;
@@ -8703,9 +8703,9 @@ var require_subschema2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/json-schema-traverse/index.js
+// node_modules/ajv-formats/node_modules/json-schema-traverse/index.js
 var require_json_schema_traverse2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/json-schema-traverse/index.js"(exports, module) {
+  "node_modules/ajv-formats/node_modules/json-schema-traverse/index.js"(exports, module) {
     "use strict";
     var traverse = module.exports = function(schema, opts, cb) {
       if (typeof opts == "function") {
@@ -8791,9 +8791,9 @@ var require_json_schema_traverse2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/resolve.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/resolve.js
 var require_resolve2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/resolve.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/resolve.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getSchemaRefs = exports.resolveUrl = exports.normalizeId = exports._getFullPath = exports.getFullPath = exports.inlineRef = void 0;
@@ -8947,9 +8947,9 @@ var require_resolve2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/index.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/index.js
 var require_validate2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/index.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getData = exports.KeywordCxt = exports.validateFunctionCode = void 0;
@@ -9455,9 +9455,9 @@ var require_validate2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/validation_error.js
+// node_modules/ajv-formats/node_modules/ajv/dist/runtime/validation_error.js
 var require_validation_error2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/validation_error.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/runtime/validation_error.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var ValidationError = class extends Error {
@@ -9471,9 +9471,9 @@ var require_validation_error2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/ref_error.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/ref_error.js
 var require_ref_error2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/ref_error.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/ref_error.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var resolve_1 = require_resolve2();
@@ -9488,9 +9488,9 @@ var require_ref_error2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/index.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/index.js
 var require_compile2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/index.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.resolveSchema = exports.getCompilingSchema = exports.resolveRef = exports.compileSchema = exports.SchemaEnv = void 0;
@@ -9712,9 +9712,9 @@ var require_compile2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/refs/data.json
+// node_modules/ajv-formats/node_modules/ajv/dist/refs/data.json
 var require_data2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/refs/data.json"(exports, module) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/refs/data.json"(exports, module) {
     module.exports = {
       $id: "https://raw.githubusercontent.com/ajv-validator/ajv/master/lib/refs/data.json#",
       description: "Meta-schema for $data reference (JSON AnySchema extension proposal)",
@@ -9731,9 +9731,9 @@ var require_data2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/uri.js
+// node_modules/ajv-formats/node_modules/ajv/dist/runtime/uri.js
 var require_uri2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/uri.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/runtime/uri.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var uri = require_fast_uri();
@@ -9742,9 +9742,9 @@ var require_uri2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/core.js
+// node_modules/ajv-formats/node_modules/ajv/dist/core.js
 var require_core3 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/core.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/core.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = void 0;
@@ -10353,9 +10353,9 @@ var require_core3 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/id.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/id.js
 var require_id2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/id.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/id.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var def = {
@@ -10368,9 +10368,9 @@ var require_id2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/ref.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/ref.js
 var require_ref2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/ref.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/ref.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.callRef = exports.getValidate = void 0;
@@ -10490,9 +10490,9 @@ var require_ref2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/index.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/index.js
 var require_core4 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/index.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var id_1 = require_id2();
@@ -10511,9 +10511,9 @@ var require_core4 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitNumber.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitNumber.js
 var require_limitNumber2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitNumber.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitNumber.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -10543,9 +10543,9 @@ var require_limitNumber2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/multipleOf.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/multipleOf.js
 var require_multipleOf2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/multipleOf.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/multipleOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -10571,9 +10571,9 @@ var require_multipleOf2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/ucs2length.js
+// node_modules/ajv-formats/node_modules/ajv/dist/runtime/ucs2length.js
 var require_ucs2length2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/ucs2length.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/runtime/ucs2length.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     function ucs2length(str) {
@@ -10597,9 +10597,9 @@ var require_ucs2length2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitLength.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitLength.js
 var require_limitLength2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitLength.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitLength.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -10629,9 +10629,9 @@ var require_limitLength2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/pattern.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/pattern.js
 var require_pattern2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/pattern.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/pattern.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code4();
@@ -10666,9 +10666,9 @@ var require_pattern2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitProperties.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitProperties.js
 var require_limitProperties2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitProperties.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -10695,9 +10695,9 @@ var require_limitProperties2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/required.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/required.js
 var require_required2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/required.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/required.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code4();
@@ -10777,9 +10777,9 @@ var require_required2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitItems.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitItems.js
 var require_limitItems2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitItems.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -10806,9 +10806,9 @@ var require_limitItems2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/equal.js
+// node_modules/ajv-formats/node_modules/ajv/dist/runtime/equal.js
 var require_equal2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/equal.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/runtime/equal.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var equal = require_fast_deep_equal();
@@ -10817,9 +10817,9 @@ var require_equal2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js
 var require_uniqueItems2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var dataType_1 = require_dataType2();
@@ -10884,9 +10884,9 @@ var require_uniqueItems2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/const.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/const.js
 var require_const2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/const.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/const.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -10913,9 +10913,9 @@ var require_const2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/enum.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/enum.js
 var require_enum2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/enum.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/enum.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -10962,9 +10962,9 @@ var require_enum2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/index.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/index.js
 var require_validation2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/index.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var limitNumber_1 = require_limitNumber2();
@@ -11000,9 +11000,9 @@ var require_validation2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js
 var require_additionalItems2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateAdditionalItems = void 0;
@@ -11053,9 +11053,9 @@ var require_additionalItems2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items.js
 var require_items2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateTuple = void 0;
@@ -11110,9 +11110,9 @@ var require_items2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js
 var require_prefixItems2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var items_1 = require_items2();
@@ -11127,9 +11127,9 @@ var require_prefixItems2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items2020.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items2020.js
 var require_items20202 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items2020.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items2020.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -11162,9 +11162,9 @@ var require_items20202 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/contains.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/contains.js
 var require_contains2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/contains.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/contains.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -11256,9 +11256,9 @@ var require_contains2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/dependencies.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/dependencies.js
 var require_dependencies2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/dependencies.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/dependencies.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateSchemaDeps = exports.validatePropertyDeps = exports.error = void 0;
@@ -11350,9 +11350,9 @@ var require_dependencies2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js
 var require_propertyNames2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -11393,9 +11393,9 @@ var require_propertyNames2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js
 var require_additionalProperties2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code4();
@@ -11499,9 +11499,9 @@ var require_additionalProperties2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/properties.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/properties.js
 var require_properties2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/properties.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/properties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var validate_1 = require_validate2();
@@ -11557,9 +11557,9 @@ var require_properties2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js
 var require_patternProperties2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code4();
@@ -11631,9 +11631,9 @@ var require_patternProperties2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/not.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/not.js
 var require_not2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/not.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/not.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util2();
@@ -11662,9 +11662,9 @@ var require_not2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/anyOf.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/anyOf.js
 var require_anyOf2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/anyOf.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/anyOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code4();
@@ -11679,9 +11679,9 @@ var require_anyOf2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/oneOf.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/oneOf.js
 var require_oneOf2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/oneOf.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/oneOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -11737,9 +11737,9 @@ var require_oneOf2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/allOf.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/allOf.js
 var require_allOf2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/allOf.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/allOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util2();
@@ -11764,9 +11764,9 @@ var require_allOf2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/if.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/if.js
 var require_if2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/if.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/if.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -11833,9 +11833,9 @@ var require_if2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/thenElse.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/thenElse.js
 var require_thenElse2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/thenElse.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/thenElse.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util2();
@@ -11851,9 +11851,9 @@ var require_thenElse2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/index.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/index.js
 var require_applicator2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/index.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var additionalItems_1 = require_additionalItems2();
@@ -11899,9 +11899,9 @@ var require_applicator2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/format.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/format.js
 var require_format3 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/format.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/format.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -11989,9 +11989,9 @@ var require_format3 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/index.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/index.js
 var require_format4 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/index.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var format_1 = require_format3();
@@ -12000,9 +12000,9 @@ var require_format4 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/metadata.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/metadata.js
 var require_metadata2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/metadata.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/metadata.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.contentVocabulary = exports.metadataVocabulary = void 0;
@@ -12023,9 +12023,9 @@ var require_metadata2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/draft7.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/draft7.js
 var require_draft72 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/draft7.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/draft7.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var core_1 = require_core4();
@@ -12045,9 +12045,9 @@ var require_draft72 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/types.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/types.js
 var require_types2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/types.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/types.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.DiscrError = void 0;
@@ -12059,9 +12059,9 @@ var require_types2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/index.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/index.js
 var require_discriminator2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/index.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -12164,9 +12164,9 @@ var require_discriminator2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/refs/json-schema-draft-07.json
+// node_modules/ajv-formats/node_modules/ajv/dist/refs/json-schema-draft-07.json
 var require_json_schema_draft_072 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/refs/json-schema-draft-07.json"(exports, module) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/refs/json-schema-draft-07.json"(exports, module) {
     module.exports = {
       $schema: "http://json-schema.org/draft-07/schema#",
       $id: "http://json-schema.org/draft-07/schema#",
@@ -12321,9 +12321,9 @@ var require_json_schema_draft_072 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/ajv.js
+// node_modules/ajv-formats/node_modules/ajv/dist/ajv.js
 var require_ajv2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/ajv.js"(exports, module) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/ajv.js"(exports, module) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.MissingRefError = exports.ValidationError = exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = exports.Ajv = void 0;
@@ -12391,9 +12391,9 @@ var require_ajv2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/dist/limit.js
+// node_modules/ajv-formats/dist/limit.js
 var require_limit = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/dist/limit.js"(exports) {
+  "node_modules/ajv-formats/dist/limit.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.formatLimitDefinition = void 0;
@@ -12463,9 +12463,9 @@ var require_limit = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/dist/index.js
+// node_modules/ajv-formats/dist/index.js
 var require_dist = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/dist/index.js"(exports, module) {
+  "node_modules/ajv-formats/dist/index.js"(exports, module) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var formats_1 = require_formats();
@@ -12505,9 +12505,9 @@ var require_dist = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/isexe/windows.js
+// node_modules/isexe/windows.js
 var require_windows = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/isexe/windows.js"(exports, module) {
+  "node_modules/isexe/windows.js"(exports, module) {
     module.exports = isexe;
     isexe.sync = sync;
     var fs27 = __require("fs");
@@ -12545,9 +12545,9 @@ var require_windows = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/isexe/mode.js
+// node_modules/isexe/mode.js
 var require_mode = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/isexe/mode.js"(exports, module) {
+  "node_modules/isexe/mode.js"(exports, module) {
     module.exports = isexe;
     isexe.sync = sync;
     var fs27 = __require("fs");
@@ -12578,9 +12578,9 @@ var require_mode = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/isexe/index.js
+// node_modules/isexe/index.js
 var require_isexe = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/isexe/index.js"(exports, module) {
+  "node_modules/isexe/index.js"(exports, module) {
     var fs27 = __require("fs");
     var core;
     if (process.platform === "win32" || global.TESTING_WINDOWS) {
@@ -12633,9 +12633,9 @@ var require_isexe = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/which/which.js
+// node_modules/which/which.js
 var require_which = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/which/which.js"(exports, module) {
+  "node_modules/which/which.js"(exports, module) {
     var isWindows = process.platform === "win32" || process.env.OSTYPE === "cygwin" || process.env.OSTYPE === "msys";
     var path29 = __require("path");
     var COLON = isWindows ? ";" : ":";
@@ -12729,9 +12729,9 @@ var require_which = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/path-key/index.js
+// node_modules/path-key/index.js
 var require_path_key = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/path-key/index.js"(exports, module) {
+  "node_modules/path-key/index.js"(exports, module) {
     "use strict";
     var pathKey = (options = {}) => {
       const environment = options.env || process.env;
@@ -12746,9 +12746,9 @@ var require_path_key = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/util/resolveCommand.js
+// node_modules/cross-spawn/lib/util/resolveCommand.js
 var require_resolveCommand = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/util/resolveCommand.js"(exports, module) {
+  "node_modules/cross-spawn/lib/util/resolveCommand.js"(exports, module) {
     "use strict";
     var path29 = __require("path");
     var which = require_which();
@@ -12788,9 +12788,9 @@ var require_resolveCommand = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/util/escape.js
+// node_modules/cross-spawn/lib/util/escape.js
 var require_escape = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/util/escape.js"(exports, module) {
+  "node_modules/cross-spawn/lib/util/escape.js"(exports, module) {
     "use strict";
     var metaCharsRegExp = /([()\][%!^"`<>&|;, *?])/g;
     function escapeCommand(arg) {
@@ -12813,17 +12813,17 @@ var require_escape = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/shebang-regex/index.js
+// node_modules/shebang-regex/index.js
 var require_shebang_regex = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/shebang-regex/index.js"(exports, module) {
+  "node_modules/shebang-regex/index.js"(exports, module) {
     "use strict";
     module.exports = /^#!(.*)/;
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/shebang-command/index.js
+// node_modules/shebang-command/index.js
 var require_shebang_command = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/shebang-command/index.js"(exports, module) {
+  "node_modules/shebang-command/index.js"(exports, module) {
     "use strict";
     var shebangRegex = require_shebang_regex();
     module.exports = (string4 = "") => {
@@ -12841,9 +12841,9 @@ var require_shebang_command = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/util/readShebang.js
+// node_modules/cross-spawn/lib/util/readShebang.js
 var require_readShebang = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/util/readShebang.js"(exports, module) {
+  "node_modules/cross-spawn/lib/util/readShebang.js"(exports, module) {
     "use strict";
     var fs27 = __require("fs");
     var shebangCommand = require_shebang_command();
@@ -12863,9 +12863,9 @@ var require_readShebang = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/parse.js
+// node_modules/cross-spawn/lib/parse.js
 var require_parse = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/parse.js"(exports, module) {
+  "node_modules/cross-spawn/lib/parse.js"(exports, module) {
     "use strict";
     var path29 = __require("path");
     var resolveCommand = require_resolveCommand();
@@ -12925,9 +12925,9 @@ var require_parse = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/enoent.js
+// node_modules/cross-spawn/lib/enoent.js
 var require_enoent = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/enoent.js"(exports, module) {
+  "node_modules/cross-spawn/lib/enoent.js"(exports, module) {
     "use strict";
     var isWin = process.platform === "win32";
     function notFoundError(original, syscall) {
@@ -12975,9 +12975,9 @@ var require_enoent = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/index.js
+// node_modules/cross-spawn/index.js
 var require_cross_spawn = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/index.js"(exports, module) {
+  "node_modules/cross-spawn/index.js"(exports, module) {
     "use strict";
     var cp = __require("child_process");
     var parse3 = require_parse();
@@ -13002,9 +13002,9 @@ var require_cross_spawn = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/identity.js
+// node_modules/yaml/dist/nodes/identity.js
 var require_identity = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/identity.js"(exports) {
+  "node_modules/yaml/dist/nodes/identity.js"(exports) {
     "use strict";
     var ALIAS = Symbol.for("yaml.alias");
     var DOC = Symbol.for("yaml.document");
@@ -13059,9 +13059,9 @@ var require_identity = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/visit.js
+// node_modules/yaml/dist/visit.js
 var require_visit = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/visit.js"(exports) {
+  "node_modules/yaml/dist/visit.js"(exports) {
     "use strict";
     var identity = require_identity();
     var BREAK = Symbol("break visit");
@@ -13218,9 +13218,9 @@ var require_visit = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/directives.js
+// node_modules/yaml/dist/doc/directives.js
 var require_directives = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/directives.js"(exports) {
+  "node_modules/yaml/dist/doc/directives.js"(exports) {
     "use strict";
     var identity = require_identity();
     var visit = require_visit();
@@ -13389,9 +13389,9 @@ var require_directives = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/anchors.js
+// node_modules/yaml/dist/doc/anchors.js
 var require_anchors = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/anchors.js"(exports) {
+  "node_modules/yaml/dist/doc/anchors.js"(exports) {
     "use strict";
     var identity = require_identity();
     var visit = require_visit();
@@ -13459,9 +13459,9 @@ var require_anchors = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/applyReviver.js
+// node_modules/yaml/dist/doc/applyReviver.js
 var require_applyReviver = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/applyReviver.js"(exports) {
+  "node_modules/yaml/dist/doc/applyReviver.js"(exports) {
     "use strict";
     function applyReviver(reviver, obj, key, val) {
       if (val && typeof val === "object") {
@@ -13509,9 +13509,9 @@ var require_applyReviver = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/toJS.js
+// node_modules/yaml/dist/nodes/toJS.js
 var require_toJS = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/toJS.js"(exports) {
+  "node_modules/yaml/dist/nodes/toJS.js"(exports) {
     "use strict";
     var identity = require_identity();
     function toJS(value, arg, ctx) {
@@ -13539,9 +13539,9 @@ var require_toJS = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Node.js
+// node_modules/yaml/dist/nodes/Node.js
 var require_Node = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Node.js"(exports) {
+  "node_modules/yaml/dist/nodes/Node.js"(exports) {
     "use strict";
     var applyReviver = require_applyReviver();
     var identity = require_identity();
@@ -13580,9 +13580,9 @@ var require_Node = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Alias.js
+// node_modules/yaml/dist/nodes/Alias.js
 var require_Alias = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Alias.js"(exports) {
+  "node_modules/yaml/dist/nodes/Alias.js"(exports) {
     "use strict";
     var anchors = require_anchors();
     var visit = require_visit();
@@ -13694,9 +13694,9 @@ var require_Alias = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Scalar.js
+// node_modules/yaml/dist/nodes/Scalar.js
 var require_Scalar = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Scalar.js"(exports) {
+  "node_modules/yaml/dist/nodes/Scalar.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Node = require_Node();
@@ -13724,9 +13724,9 @@ var require_Scalar = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/createNode.js
+// node_modules/yaml/dist/doc/createNode.js
 var require_createNode = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/createNode.js"(exports) {
+  "node_modules/yaml/dist/doc/createNode.js"(exports) {
     "use strict";
     var Alias = require_Alias();
     var identity = require_identity();
@@ -13803,9 +13803,9 @@ var require_createNode = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Collection.js
+// node_modules/yaml/dist/nodes/Collection.js
 var require_Collection = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Collection.js"(exports) {
+  "node_modules/yaml/dist/nodes/Collection.js"(exports) {
     "use strict";
     var createNode = require_createNode();
     var identity = require_identity();
@@ -13946,9 +13946,9 @@ var require_Collection = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyComment.js
+// node_modules/yaml/dist/stringify/stringifyComment.js
 var require_stringifyComment = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyComment.js"(exports) {
+  "node_modules/yaml/dist/stringify/stringifyComment.js"(exports) {
     "use strict";
     var stringifyComment = (str) => str.replace(/^(?!$)(?: $)?/gm, "#");
     function indentComment(comment, indent4) {
@@ -13963,9 +13963,9 @@ var require_stringifyComment = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/foldFlowLines.js
+// node_modules/yaml/dist/stringify/foldFlowLines.js
 var require_foldFlowLines = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/foldFlowLines.js"(exports) {
+  "node_modules/yaml/dist/stringify/foldFlowLines.js"(exports) {
     "use strict";
     var FOLD_FLOW = "flow";
     var FOLD_BLOCK = "block";
@@ -14099,9 +14099,9 @@ ${indent4}${text.slice(fold + 1, end2)}`;
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyString.js
+// node_modules/yaml/dist/stringify/stringifyString.js
 var require_stringifyString = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyString.js"(exports) {
+  "node_modules/yaml/dist/stringify/stringifyString.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var foldFlowLines = require_foldFlowLines();
@@ -14385,9 +14385,9 @@ ${indent4}`);
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringify.js
+// node_modules/yaml/dist/stringify/stringify.js
 var require_stringify = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringify.js"(exports) {
+  "node_modules/yaml/dist/stringify/stringify.js"(exports) {
     "use strict";
     var anchors = require_anchors();
     var identity = require_identity();
@@ -14513,9 +14513,9 @@ ${ctx.indent}${str}`;
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyPair.js
+// node_modules/yaml/dist/stringify/stringifyPair.js
 var require_stringifyPair = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyPair.js"(exports) {
+  "node_modules/yaml/dist/stringify/stringifyPair.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -14646,9 +14646,9 @@ ${ctx.indent}`;
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/log.js
+// node_modules/yaml/dist/log.js
 var require_log = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/log.js"(exports) {
+  "node_modules/yaml/dist/log.js"(exports) {
     "use strict";
     var node_process = __require("process");
     function debug(logLevel, ...messages) {
@@ -14668,9 +14668,9 @@ var require_log = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/merge.js
+// node_modules/yaml/dist/schema/yaml-1.1/merge.js
 var require_merge = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/merge.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/merge.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -14725,9 +14725,9 @@ var require_merge = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/addPairToJSMap.js
+// node_modules/yaml/dist/nodes/addPairToJSMap.js
 var require_addPairToJSMap = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/addPairToJSMap.js"(exports) {
+  "node_modules/yaml/dist/nodes/addPairToJSMap.js"(exports) {
     "use strict";
     var log = require_log();
     var merge2 = require_merge();
@@ -14789,9 +14789,9 @@ var require_addPairToJSMap = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Pair.js
+// node_modules/yaml/dist/nodes/Pair.js
 var require_Pair = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Pair.js"(exports) {
+  "node_modules/yaml/dist/nodes/Pair.js"(exports) {
     "use strict";
     var createNode = require_createNode();
     var stringifyPair = require_stringifyPair();
@@ -14829,9 +14829,9 @@ var require_Pair = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyCollection.js
+// node_modules/yaml/dist/stringify/stringifyCollection.js
 var require_stringifyCollection = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyCollection.js"(exports) {
+  "node_modules/yaml/dist/stringify/stringifyCollection.js"(exports) {
     "use strict";
     var identity = require_identity();
     var stringify = require_stringify();
@@ -14973,9 +14973,9 @@ ${indent4}${end}`;
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/YAMLMap.js
+// node_modules/yaml/dist/nodes/YAMLMap.js
 var require_YAMLMap = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/YAMLMap.js"(exports) {
+  "node_modules/yaml/dist/nodes/YAMLMap.js"(exports) {
     "use strict";
     var stringifyCollection = require_stringifyCollection();
     var addPairToJSMap = require_addPairToJSMap();
@@ -15118,9 +15118,9 @@ var require_YAMLMap = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/map.js
+// node_modules/yaml/dist/schema/common/map.js
 var require_map = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/map.js"(exports) {
+  "node_modules/yaml/dist/schema/common/map.js"(exports) {
     "use strict";
     var identity = require_identity();
     var YAMLMap = require_YAMLMap();
@@ -15140,9 +15140,9 @@ var require_map = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/YAMLSeq.js
+// node_modules/yaml/dist/nodes/YAMLSeq.js
 var require_YAMLSeq = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/YAMLSeq.js"(exports) {
+  "node_modules/yaml/dist/nodes/YAMLSeq.js"(exports) {
     "use strict";
     var createNode = require_createNode();
     var stringifyCollection = require_stringifyCollection();
@@ -15256,9 +15256,9 @@ var require_YAMLSeq = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/seq.js
+// node_modules/yaml/dist/schema/common/seq.js
 var require_seq = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/seq.js"(exports) {
+  "node_modules/yaml/dist/schema/common/seq.js"(exports) {
     "use strict";
     var identity = require_identity();
     var YAMLSeq = require_YAMLSeq();
@@ -15278,9 +15278,9 @@ var require_seq = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/string.js
+// node_modules/yaml/dist/schema/common/string.js
 var require_string = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/string.js"(exports) {
+  "node_modules/yaml/dist/schema/common/string.js"(exports) {
     "use strict";
     var stringifyString = require_stringifyString();
     var string4 = {
@@ -15297,9 +15297,9 @@ var require_string = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/null.js
+// node_modules/yaml/dist/schema/common/null.js
 var require_null = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/null.js"(exports) {
+  "node_modules/yaml/dist/schema/common/null.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var nullTag = {
@@ -15315,9 +15315,9 @@ var require_null = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/bool.js
+// node_modules/yaml/dist/schema/core/bool.js
 var require_bool = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/bool.js"(exports) {
+  "node_modules/yaml/dist/schema/core/bool.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var boolTag = {
@@ -15339,9 +15339,9 @@ var require_bool = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyNumber.js
+// node_modules/yaml/dist/stringify/stringifyNumber.js
 var require_stringifyNumber = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyNumber.js"(exports) {
+  "node_modules/yaml/dist/stringify/stringifyNumber.js"(exports) {
     "use strict";
     function stringifyNumber({ format, minFractionDigits, tag, value }) {
       if (typeof value === "bigint")
@@ -15366,9 +15366,9 @@ var require_stringifyNumber = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/float.js
+// node_modules/yaml/dist/schema/core/float.js
 var require_float = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/float.js"(exports) {
+  "node_modules/yaml/dist/schema/core/float.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var stringifyNumber = require_stringifyNumber();
@@ -15412,9 +15412,9 @@ var require_float = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/int.js
+// node_modules/yaml/dist/schema/core/int.js
 var require_int = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/int.js"(exports) {
+  "node_modules/yaml/dist/schema/core/int.js"(exports) {
     "use strict";
     var stringifyNumber = require_stringifyNumber();
     var intIdentify = (value) => typeof value === "bigint" || Number.isInteger(value);
@@ -15457,9 +15457,9 @@ var require_int = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/schema.js
+// node_modules/yaml/dist/schema/core/schema.js
 var require_schema = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/schema.js"(exports) {
+  "node_modules/yaml/dist/schema/core/schema.js"(exports) {
     "use strict";
     var map2 = require_map();
     var _null4 = require_null();
@@ -15485,9 +15485,9 @@ var require_schema = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/json/schema.js
+// node_modules/yaml/dist/schema/json/schema.js
 var require_schema2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/json/schema.js"(exports) {
+  "node_modules/yaml/dist/schema/json/schema.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var map2 = require_map();
@@ -15552,9 +15552,9 @@ var require_schema2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/binary.js
+// node_modules/yaml/dist/schema/yaml-1.1/binary.js
 var require_binary = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/binary.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/binary.js"(exports) {
     "use strict";
     var node_buffer = __require("buffer");
     var Scalar = require_Scalar();
@@ -15618,9 +15618,9 @@ var require_binary = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/pairs.js
+// node_modules/yaml/dist/schema/yaml-1.1/pairs.js
 var require_pairs = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/pairs.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/pairs.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Pair = require_Pair();
@@ -15696,9 +15696,9 @@ ${cn.comment}` : item.comment;
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/omap.js
+// node_modules/yaml/dist/schema/yaml-1.1/omap.js
 var require_omap = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/omap.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/omap.js"(exports) {
     "use strict";
     var identity = require_identity();
     var toJS = require_toJS();
@@ -15774,9 +15774,9 @@ var require_omap = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/bool.js
+// node_modules/yaml/dist/schema/yaml-1.1/bool.js
 var require_bool2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/bool.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/bool.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     function boolStringify({ value, source }, ctx) {
@@ -15806,9 +15806,9 @@ var require_bool2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/float.js
+// node_modules/yaml/dist/schema/yaml-1.1/float.js
 var require_float2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/float.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/float.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var stringifyNumber = require_stringifyNumber();
@@ -15855,9 +15855,9 @@ var require_float2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/int.js
+// node_modules/yaml/dist/schema/yaml-1.1/int.js
 var require_int2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/int.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/int.js"(exports) {
     "use strict";
     var stringifyNumber = require_stringifyNumber();
     var intIdentify = (value) => typeof value === "bigint" || Number.isInteger(value);
@@ -15934,9 +15934,9 @@ var require_int2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/set.js
+// node_modules/yaml/dist/schema/yaml-1.1/set.js
 var require_set = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/set.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/set.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Pair = require_Pair();
@@ -16023,9 +16023,9 @@ var require_set = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/timestamp.js
+// node_modules/yaml/dist/schema/yaml-1.1/timestamp.js
 var require_timestamp = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/timestamp.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/timestamp.js"(exports) {
     "use strict";
     var stringifyNumber = require_stringifyNumber();
     function parseSexagesimal(str, asBigInt) {
@@ -16111,9 +16111,9 @@ var require_timestamp = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/schema.js
+// node_modules/yaml/dist/schema/yaml-1.1/schema.js
 var require_schema3 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/schema.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/schema.js"(exports) {
     "use strict";
     var map2 = require_map();
     var _null4 = require_null();
@@ -16155,9 +16155,9 @@ var require_schema3 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/tags.js
+// node_modules/yaml/dist/schema/tags.js
 var require_tags = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/tags.js"(exports) {
+  "node_modules/yaml/dist/schema/tags.js"(exports) {
     "use strict";
     var map2 = require_map();
     var _null4 = require_null();
@@ -16249,9 +16249,9 @@ var require_tags = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/Schema.js
+// node_modules/yaml/dist/schema/Schema.js
 var require_Schema = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/Schema.js"(exports) {
+  "node_modules/yaml/dist/schema/Schema.js"(exports) {
     "use strict";
     var identity = require_identity();
     var map2 = require_map();
@@ -16281,9 +16281,9 @@ var require_Schema = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyDocument.js
+// node_modules/yaml/dist/stringify/stringifyDocument.js
 var require_stringifyDocument = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyDocument.js"(exports) {
+  "node_modules/yaml/dist/stringify/stringifyDocument.js"(exports) {
     "use strict";
     var identity = require_identity();
     var stringify = require_stringify();
@@ -16362,9 +16362,9 @@ var require_stringifyDocument = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/Document.js
+// node_modules/yaml/dist/doc/Document.js
 var require_Document = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/Document.js"(exports) {
+  "node_modules/yaml/dist/doc/Document.js"(exports) {
     "use strict";
     var Alias = require_Alias();
     var Collection = require_Collection();
@@ -16671,9 +16671,9 @@ var require_Document = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/errors.js
+// node_modules/yaml/dist/errors.js
 var require_errors3 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/errors.js"(exports) {
+  "node_modules/yaml/dist/errors.js"(exports) {
     "use strict";
     var YAMLError = class extends Error {
       constructor(name, pos, code, message) {
@@ -16736,9 +16736,9 @@ ${pointer}
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-props.js
+// node_modules/yaml/dist/compose/resolve-props.js
 var require_resolve_props = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-props.js"(exports) {
+  "node_modules/yaml/dist/compose/resolve-props.js"(exports) {
     "use strict";
     function resolveProps(tokens, { flow, indicator, next, offset, onError, parentIndent, startOnNewline }) {
       let spaceBefore = false;
@@ -16870,9 +16870,9 @@ var require_resolve_props = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-contains-newline.js
+// node_modules/yaml/dist/compose/util-contains-newline.js
 var require_util_contains_newline = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-contains-newline.js"(exports) {
+  "node_modules/yaml/dist/compose/util-contains-newline.js"(exports) {
     "use strict";
     function containsNewline(key) {
       if (!key)
@@ -16912,9 +16912,9 @@ var require_util_contains_newline = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-flow-indent-check.js
+// node_modules/yaml/dist/compose/util-flow-indent-check.js
 var require_util_flow_indent_check = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-flow-indent-check.js"(exports) {
+  "node_modules/yaml/dist/compose/util-flow-indent-check.js"(exports) {
     "use strict";
     var utilContainsNewline = require_util_contains_newline();
     function flowIndentCheck(indent4, fc, onError) {
@@ -16930,9 +16930,9 @@ var require_util_flow_indent_check = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-map-includes.js
+// node_modules/yaml/dist/compose/util-map-includes.js
 var require_util_map_includes = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-map-includes.js"(exports) {
+  "node_modules/yaml/dist/compose/util-map-includes.js"(exports) {
     "use strict";
     var identity = require_identity();
     function mapIncludes(ctx, items, search) {
@@ -16946,9 +16946,9 @@ var require_util_map_includes = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-block-map.js
+// node_modules/yaml/dist/compose/resolve-block-map.js
 var require_resolve_block_map = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-block-map.js"(exports) {
+  "node_modules/yaml/dist/compose/resolve-block-map.js"(exports) {
     "use strict";
     var Pair = require_Pair();
     var YAMLMap = require_YAMLMap();
@@ -17055,9 +17055,9 @@ var require_resolve_block_map = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-block-seq.js
+// node_modules/yaml/dist/compose/resolve-block-seq.js
 var require_resolve_block_seq = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-block-seq.js"(exports) {
+  "node_modules/yaml/dist/compose/resolve-block-seq.js"(exports) {
     "use strict";
     var YAMLSeq = require_YAMLSeq();
     var resolveProps = require_resolve_props();
@@ -17106,9 +17106,9 @@ var require_resolve_block_seq = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-end.js
+// node_modules/yaml/dist/compose/resolve-end.js
 var require_resolve_end = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-end.js"(exports) {
+  "node_modules/yaml/dist/compose/resolve-end.js"(exports) {
     "use strict";
     function resolveEnd(end, offset, reqSpace, onError) {
       let comment = "";
@@ -17149,9 +17149,9 @@ var require_resolve_end = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-flow-collection.js
+// node_modules/yaml/dist/compose/resolve-flow-collection.js
 var require_resolve_flow_collection = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-flow-collection.js"(exports) {
+  "node_modules/yaml/dist/compose/resolve-flow-collection.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Pair = require_Pair();
@@ -17344,9 +17344,9 @@ var require_resolve_flow_collection = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-collection.js
+// node_modules/yaml/dist/compose/compose-collection.js
 var require_compose_collection = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-collection.js"(exports) {
+  "node_modules/yaml/dist/compose/compose-collection.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -17410,9 +17410,9 @@ var require_compose_collection = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-block-scalar.js
+// node_modules/yaml/dist/compose/resolve-block-scalar.js
 var require_resolve_block_scalar = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-block-scalar.js"(exports) {
+  "node_modules/yaml/dist/compose/resolve-block-scalar.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     function resolveBlockScalar(ctx, scalar, onError) {
@@ -17593,9 +17593,9 @@ var require_resolve_block_scalar = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-flow-scalar.js
+// node_modules/yaml/dist/compose/resolve-flow-scalar.js
 var require_resolve_flow_scalar = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-flow-scalar.js"(exports) {
+  "node_modules/yaml/dist/compose/resolve-flow-scalar.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var resolveEnd = require_resolve_end();
@@ -17812,9 +17812,9 @@ var require_resolve_flow_scalar = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-scalar.js
+// node_modules/yaml/dist/compose/compose-scalar.js
 var require_compose_scalar = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-scalar.js"(exports) {
+  "node_modules/yaml/dist/compose/compose-scalar.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -17900,9 +17900,9 @@ var require_compose_scalar = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-empty-scalar-position.js
+// node_modules/yaml/dist/compose/util-empty-scalar-position.js
 var require_util_empty_scalar_position = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-empty-scalar-position.js"(exports) {
+  "node_modules/yaml/dist/compose/util-empty-scalar-position.js"(exports) {
     "use strict";
     function emptyScalarPosition(offset, before, pos) {
       if (before) {
@@ -17930,9 +17930,9 @@ var require_util_empty_scalar_position = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-node.js
+// node_modules/yaml/dist/compose/compose-node.js
 var require_compose_node = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-node.js"(exports) {
+  "node_modules/yaml/dist/compose/compose-node.js"(exports) {
     "use strict";
     var Alias = require_Alias();
     var identity = require_identity();
@@ -18031,9 +18031,9 @@ var require_compose_node = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-doc.js
+// node_modules/yaml/dist/compose/compose-doc.js
 var require_compose_doc = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-doc.js"(exports) {
+  "node_modules/yaml/dist/compose/compose-doc.js"(exports) {
     "use strict";
     var Document = require_Document();
     var composeNode = require_compose_node();
@@ -18074,9 +18074,9 @@ var require_compose_doc = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/composer.js
+// node_modules/yaml/dist/compose/composer.js
 var require_composer = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/composer.js"(exports) {
+  "node_modules/yaml/dist/compose/composer.js"(exports) {
     "use strict";
     var node_process = __require("process");
     var directives = require_directives();
@@ -18281,9 +18281,9 @@ ${end.comment}` : end.comment;
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst-scalar.js
+// node_modules/yaml/dist/parse/cst-scalar.js
 var require_cst_scalar = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst-scalar.js"(exports) {
+  "node_modules/yaml/dist/parse/cst-scalar.js"(exports) {
     "use strict";
     var resolveBlockScalar = require_resolve_block_scalar();
     var resolveFlowScalar = require_resolve_flow_scalar();
@@ -18466,9 +18466,9 @@ var require_cst_scalar = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst-stringify.js
+// node_modules/yaml/dist/parse/cst-stringify.js
 var require_cst_stringify = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst-stringify.js"(exports) {
+  "node_modules/yaml/dist/parse/cst-stringify.js"(exports) {
     "use strict";
     var stringify = (cst) => "type" in cst ? stringifyToken(cst) : stringifyItem(cst);
     function stringifyToken(token) {
@@ -18527,9 +18527,9 @@ var require_cst_stringify = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst-visit.js
+// node_modules/yaml/dist/parse/cst-visit.js
 var require_cst_visit = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst-visit.js"(exports) {
+  "node_modules/yaml/dist/parse/cst-visit.js"(exports) {
     "use strict";
     var BREAK = Symbol("break visit");
     var SKIP = Symbol("skip children");
@@ -18589,9 +18589,9 @@ var require_cst_visit = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst.js
+// node_modules/yaml/dist/parse/cst.js
 var require_cst = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst.js"(exports) {
+  "node_modules/yaml/dist/parse/cst.js"(exports) {
     "use strict";
     var cstScalar = require_cst_scalar();
     var cstStringify = require_cst_stringify();
@@ -18691,9 +18691,9 @@ var require_cst = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/lexer.js
+// node_modules/yaml/dist/parse/lexer.js
 var require_lexer = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/lexer.js"(exports) {
+  "node_modules/yaml/dist/parse/lexer.js"(exports) {
     "use strict";
     var cst = require_cst();
     function isEmpty(ch) {
@@ -19270,9 +19270,9 @@ var require_lexer = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/line-counter.js
+// node_modules/yaml/dist/parse/line-counter.js
 var require_line_counter = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/line-counter.js"(exports) {
+  "node_modules/yaml/dist/parse/line-counter.js"(exports) {
     "use strict";
     var LineCounter = class {
       constructor() {
@@ -19301,9 +19301,9 @@ var require_line_counter = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/parser.js
+// node_modules/yaml/dist/parse/parser.js
 var require_parser = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/parser.js"(exports) {
+  "node_modules/yaml/dist/parse/parser.js"(exports) {
     "use strict";
     var node_process = __require("process");
     var cst = require_cst();
@@ -20171,9 +20171,9 @@ var require_parser = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/public-api.js
+// node_modules/yaml/dist/public-api.js
 var require_public_api = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/public-api.js"(exports) {
+  "node_modules/yaml/dist/public-api.js"(exports) {
     "use strict";
     var composer = require_composer();
     var Document = require_Document();
@@ -20268,9 +20268,9 @@ var require_public_api = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/index.js
+// node_modules/yaml/dist/index.js
 var require_dist2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/index.js"(exports) {
+  "node_modules/yaml/dist/index.js"(exports) {
     "use strict";
     var composer = require_composer();
     var Document = require_Document();
@@ -20326,7 +20326,7 @@ import fs17 from "node:fs";
 import path18 from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v3/helpers/util.js
+// node_modules/zod/v3/helpers/util.js
 var util;
 (function(util2) {
   util2.assertEqual = (_) => {
@@ -20460,7 +20460,7 @@ var getParsedType = (data) => {
   }
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v3/ZodError.js
+// node_modules/zod/v3/ZodError.js
 var ZodIssueCode = util.arrayToEnum([
   "invalid_type",
   "invalid_literal",
@@ -20574,7 +20574,7 @@ ZodError.create = (issues) => {
   return error2;
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v3/locales/en.js
+// node_modules/zod/v3/locales/en.js
 var errorMap = (issue3, _ctx) => {
   let message;
   switch (issue3.code) {
@@ -20677,13 +20677,13 @@ var errorMap = (issue3, _ctx) => {
 };
 var en_default = errorMap;
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v3/errors.js
+// node_modules/zod/v3/errors.js
 var overrideErrorMap = en_default;
 function getErrorMap() {
   return overrideErrorMap;
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v3/helpers/parseUtil.js
+// node_modules/zod/v3/helpers/parseUtil.js
 var makeIssue = (params) => {
   const { data, path: path29, errorMaps, issueData } = params;
   const fullPath = [...path29, ...issueData.path || []];
@@ -20792,14 +20792,14 @@ var isDirty = (x) => x.status === "dirty";
 var isValid = (x) => x.status === "valid";
 var isAsync = (x) => typeof Promise !== "undefined" && x instanceof Promise;
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v3/helpers/errorUtil.js
+// node_modules/zod/v3/helpers/errorUtil.js
 var errorUtil;
 (function(errorUtil2) {
   errorUtil2.errToObj = (message) => typeof message === "string" ? { message } : message || {};
   errorUtil2.toString = (message) => typeof message === "string" ? message : message == null ? void 0 : message.message;
 })(errorUtil || (errorUtil = {}));
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v3/types.js
+// node_modules/zod/v3/types.js
 var ParseInputLazyPath = class {
   constructor(parent, value, path29, key) {
     this._cachedPath = [];
@@ -24205,7 +24205,7 @@ var nullableType = ZodNullable.create;
 var preprocessType = ZodEffects.createWithPreprocess;
 var pipelineType = ZodPipeline.create;
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/core.js
+// node_modules/zod/v4/core/core.js
 var NEVER = Object.freeze({
   status: "aborted"
 });
@@ -24281,7 +24281,7 @@ function config(newConfig) {
   return globalConfig;
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/util.js
+// node_modules/zod/v4/core/util.js
 var util_exports = {};
 __export(util_exports, {
   BIGINT_FORMAT_RANGES: () => BIGINT_FORMAT_RANGES,
@@ -24963,7 +24963,7 @@ var Class = class {
   }
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/errors.js
+// node_modules/zod/v4/core/errors.js
 var initializer = (inst, def) => {
   inst.name = "$ZodError";
   Object.defineProperty(inst, "_zod", {
@@ -25029,7 +25029,7 @@ function formatError(error2, mapper = (issue3) => issue3.message) {
   return fieldErrors;
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/parse.js
+// node_modules/zod/v4/core/parse.js
 var _parse = (_Err) => (schema, value, _ctx, _params) => {
   const ctx = _ctx ? Object.assign(_ctx, { async: false }) : { async: false };
   const result = schema._zod.run({ value, issues: [] }, ctx);
@@ -25109,7 +25109,7 @@ var _safeDecodeAsync = (_Err) => async (schema, value, _ctx) => {
   return _safeParseAsync(_Err)(schema, value, _ctx);
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/regexes.js
+// node_modules/zod/v4/core/regexes.js
 var regexes_exports = {};
 __export(regexes_exports, {
   base64: () => base64,
@@ -25266,7 +25266,7 @@ var sha512_hex = /^[0-9a-fA-F]{128}$/;
 var sha512_base64 = /* @__PURE__ */ fixedBase64(86, "==");
 var sha512_base64url = /* @__PURE__ */ fixedBase64url(86);
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/checks.js
+// node_modules/zod/v4/core/checks.js
 var $ZodCheck = /* @__PURE__ */ $constructor("$ZodCheck", (inst, def) => {
   var _a3;
   inst._zod ?? (inst._zod = {});
@@ -25815,7 +25815,7 @@ var $ZodCheckOverwrite = /* @__PURE__ */ $constructor("$ZodCheckOverwrite", (ins
   };
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/doc.js
+// node_modules/zod/v4/core/doc.js
 var Doc = class {
   constructor(args = []) {
     this.content = [];
@@ -25851,14 +25851,14 @@ var Doc = class {
   }
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/versions.js
+// node_modules/zod/v4/core/versions.js
 var version = {
   major: 4,
   minor: 3,
   patch: 6
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/schemas.js
+// node_modules/zod/v4/core/schemas.js
 var $ZodType = /* @__PURE__ */ $constructor("$ZodType", (inst, def) => {
   var _a4;
   var _a3;
@@ -27856,7 +27856,7 @@ function handleRefineResult(result, payload, input2, inst) {
   }
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/locales/en.js
+// node_modules/zod/v4/locales/en.js
 var error = () => {
   const Sizable = {
     string: { unit: "characters", verb: "to have" },
@@ -27965,7 +27965,7 @@ function en_default2() {
   };
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/registries.js
+// node_modules/zod/v4/core/registries.js
 var _a;
 var $output = Symbol("ZodOutput");
 var $input = Symbol("ZodInput");
@@ -28015,7 +28015,7 @@ function registry() {
 (_a = globalThis).__zod_globalRegistry ?? (_a.__zod_globalRegistry = registry());
 var globalRegistry = globalThis.__zod_globalRegistry;
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/api.js
+// node_modules/zod/v4/core/api.js
 // @__NO_SIDE_EFFECTS__
 function _string(Class2, params) {
   return new Class2({
@@ -28860,7 +28860,7 @@ function _stringFormat(Class2, format, fnOrRegex, _params = {}) {
   return inst;
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/to-json-schema.js
+// node_modules/zod/v4/core/to-json-schema.js
 function initializeContext(params) {
   let target = (params == null ? void 0 : params.target) ?? "draft-2020-12";
   if (target === "draft-4")
@@ -29216,7 +29216,7 @@ var createStandardJSONSchemaMethod = (schema, io, processors = {}) => (params) =
   return finalize(ctx, schema);
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/json-schema-processors.js
+// node_modules/zod/v4/core/json-schema-processors.js
 var formatMap = {
   guid: "uuid",
   url: "uri",
@@ -29693,7 +29693,7 @@ var lazyProcessor = (schema, ctx, _json, params) => {
   seen.ref = innerType;
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-compat.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-compat.js
 function isZ4Schema(s) {
   const schema = s;
   return !!schema._zod;
@@ -29758,7 +29758,7 @@ function getLiteralValue(schema) {
   return void 0;
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/schemas.js
+// node_modules/zod/v4/classic/schemas.js
 var schemas_exports3 = {};
 __export(schemas_exports3, {
   ZodAny: () => ZodAny2,
@@ -29927,7 +29927,7 @@ __export(schemas_exports3, {
   xor: () => xor
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/checks.js
+// node_modules/zod/v4/classic/checks.js
 var checks_exports2 = {};
 __export(checks_exports2, {
   endsWith: () => _endsWith,
@@ -29961,7 +29961,7 @@ __export(checks_exports2, {
   uppercase: () => _uppercase
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/iso.js
+// node_modules/zod/v4/classic/iso.js
 var iso_exports2 = {};
 __export(iso_exports2, {
   ZodISODate: () => ZodISODate,
@@ -30002,7 +30002,7 @@ function duration2(params) {
   return _isoDuration(ZodISODuration, params);
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/errors.js
+// node_modules/zod/v4/classic/errors.js
 var initializer2 = (inst, issues) => {
   $ZodError.init(inst, issues);
   inst.name = "ZodError";
@@ -30042,7 +30042,7 @@ var ZodRealError = $constructor("ZodError", initializer2, {
   Parent: Error
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/parse.js
+// node_modules/zod/v4/classic/parse.js
 var parse2 = /* @__PURE__ */ _parse(ZodRealError);
 var parseAsync2 = /* @__PURE__ */ _parseAsync(ZodRealError);
 var safeParse3 = /* @__PURE__ */ _safeParse(ZodRealError);
@@ -30056,7 +30056,7 @@ var safeDecode2 = /* @__PURE__ */ _safeDecode(ZodRealError);
 var safeEncodeAsync2 = /* @__PURE__ */ _safeEncodeAsync(ZodRealError);
 var safeDecodeAsync2 = /* @__PURE__ */ _safeDecodeAsync(ZodRealError);
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/schemas.js
+// node_modules/zod/v4/classic/schemas.js
 var ZodType2 = /* @__PURE__ */ $constructor("ZodType", (inst, def) => {
   $ZodType.init(inst, def);
   Object.assign(inst["~standard"], {
@@ -31136,7 +31136,7 @@ function preprocess(fn, schema) {
   return pipe(transform(fn), schema);
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/compat.js
+// node_modules/zod/v4/classic/compat.js
 var ZodIssueCode2 = {
   invalid_type: "invalid_type",
   too_big: "too_big",
@@ -31154,14 +31154,14 @@ var ZodFirstPartyTypeKind2;
 /* @__PURE__ */ (function(ZodFirstPartyTypeKind3) {
 })(ZodFirstPartyTypeKind2 || (ZodFirstPartyTypeKind2 = {}));
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/from-json-schema.js
+// node_modules/zod/v4/classic/from-json-schema.js
 var z = {
   ...schemas_exports3,
   ...checks_exports2,
   iso: iso_exports2
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/coerce.js
+// node_modules/zod/v4/classic/coerce.js
 var coerce_exports2 = {};
 __export(coerce_exports2, {
   bigint: () => bigint3,
@@ -31186,10 +31186,10 @@ function date4(params) {
   return _coercedDate(ZodDate2, params);
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/external.js
+// node_modules/zod/v4/classic/external.js
 config(en_default2());
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/types.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/types.js
 var LATEST_PROTOCOL_VERSION = "2025-11-25";
 var SUPPORTED_PROTOCOL_VERSIONS = [LATEST_PROTOCOL_VERSION, "2025-06-18", "2025-03-26", "2024-11-05", "2024-10-07"];
 var RELATED_TASK_META_KEY = "io.modelcontextprotocol/related-task";
@@ -32697,18 +32697,18 @@ var UrlElicitationRequiredError = class extends McpError {
   }
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/interfaces.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/interfaces.js
 function isTerminal(status) {
   return status === "completed" || status === "failed" || status === "cancelled";
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod-to-json-schema/dist/esm/Options.js
+// node_modules/zod-to-json-schema/dist/esm/Options.js
 var ignoreOverride = Symbol("Let zodToJsonSchema decide on which parser to use");
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod-to-json-schema/dist/esm/parsers/string.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/string.js
 var ALPHA_NUMERIC = new Set("ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvxyz0123456789");
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-json-schema-compat.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-json-schema-compat.js
 function getMethodLiteral(schema) {
   const shape = getObjectShape(schema);
   const methodSchema = shape == null ? void 0 : shape.method;
@@ -32729,7 +32729,7 @@ function parseWithCompat(schema, data) {
   return result.data;
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/protocol.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/protocol.js
 var DEFAULT_REQUEST_TIMEOUT_MSEC = 6e4;
 var Protocol = class {
   constructor(_options) {
@@ -33694,7 +33694,7 @@ function mergeCapabilities(base, additional) {
   return result;
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/validation/ajv-provider.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/validation/ajv-provider.js
 var import_ajv = __toESM(require_ajv(), 1);
 var import_ajv_formats = __toESM(require_dist(), 1);
 function createDefaultAjvInstance() {
@@ -33762,7 +33762,7 @@ var AjvJsonSchemaValidator = class {
   }
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/server.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/server.js
 var ExperimentalServerTasks = class {
   constructor(_server) {
     this._server = _server;
@@ -33977,7 +33977,7 @@ var ExperimentalServerTasks = class {
   }
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/helpers.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/helpers.js
 function assertToolsCallTaskCapability(requests, method, entityName) {
   var _a3;
   if (!requests) {
@@ -34014,7 +34014,7 @@ function assertClientRequestTaskCapability(requests, method, entityName) {
   }
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/index.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/index.js
 var Server = class extends Protocol {
   /**
    * Initializes this server with the given name and version information.
@@ -34406,10 +34406,10 @@ var Server = class extends Protocol {
   }
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js
 import process3 from "node:process";
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/stdio.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/stdio.js
 var ReadBuffer = class {
   append(chunk) {
     this._buffer = this._buffer ? Buffer.concat([this._buffer, chunk]) : chunk;
@@ -34437,7 +34437,7 @@ function serializeMessage(message) {
   return JSON.stringify(message) + "\n";
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js
 var StdioServerTransport = class {
   constructor(_stdin = process3.stdin, _stdout = process3.stdout) {
     this._stdin = _stdin;
@@ -34501,7 +34501,7 @@ var StdioServerTransport = class {
   }
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/client.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/client.js
 var ExperimentalClientTasks = class {
   constructor(_client) {
     this._client = _client;
@@ -34655,7 +34655,7 @@ var ExperimentalClientTasks = class {
   }
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/client/index.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/client/index.js
 function applyElicitationDefaults(schema, data) {
   if (!schema || data === null || typeof data !== "object")
     return;
@@ -35185,7 +35185,7 @@ var Client = class extends Protocol {
   }
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/client/stdio.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/client/stdio.js
 var import_cross_spawn = __toESM(require_cross_spawn(), 1);
 import process4 from "node:process";
 import { PassThrough } from "node:stream";
@@ -52377,7 +52377,7 @@ function formatCliError(error2) {
   return error2 instanceof Error ? error2.message : String(error2);
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/transport.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/transport.js
 function normalizeHeaders(headers) {
   if (!headers)
     return {};
@@ -52404,7 +52404,7 @@ function createFetchWithInit(baseFetch = fetch, baseInit) {
   };
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/pkce-challenge/dist/index.node.js
+// node_modules/pkce-challenge/dist/index.node.js
 var crypto6;
 var _a2;
 crypto6 = ((_a2 = globalThis.crypto) == null ? void 0 : _a2.webcrypto) ?? // Node.js [18-16] REPL
@@ -52444,7 +52444,7 @@ async function pkceChallenge(length) {
   };
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/auth.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/auth.js
 var SafeUrlSchema = url().superRefine((val, ctx) => {
   if (!URL.canParse(val)) {
     ctx.addIssue({
@@ -52588,7 +52588,7 @@ var OAuthTokenRevocationRequestSchema = object2({
   token_type_hint: string2().optional()
 }).strip();
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/auth-utils.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/auth-utils.js
 function resourceUrlFromServerUrl(url2) {
   const resourceURL = typeof url2 === "string" ? new URL(url2) : new URL(url2.href);
   resourceURL.hash = "";
@@ -52608,7 +52608,7 @@ function checkResourceAllowed({ requestedResource, configuredResource }) {
   return requestedPath.startsWith(configuredPath);
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/auth/errors.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/auth/errors.js
 var OAuthError = class extends Error {
   constructor(message, errorUri) {
     super(message);
@@ -52703,7 +52703,7 @@ var OAUTH_ERRORS = {
   [InvalidTargetError.errorCode]: InvalidTargetError
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/client/auth.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/client/auth.js
 var UnauthorizedError = class extends Error {
   constructor(message) {
     super(message ?? "Unauthorized");
@@ -53243,7 +53243,7 @@ async function registerClient(authorizationServerUrl, { metadata, clientMetadata
   return OAuthClientInformationFullSchema.parse(await response.json());
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/eventsource-parser/dist/index.js
+// node_modules/eventsource-parser/dist/index.js
 var ParseError = class extends Error {
   constructor(message, options) {
     super(message), this.name = "ParseError", this.type = options.type, this.field = options.field, this.value = options.value, this.line = options.line;
@@ -53346,7 +53346,7 @@ function splitLines(chunk) {
   return [lines, incompleteLine];
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/eventsource-parser/dist/stream.js
+// node_modules/eventsource-parser/dist/stream.js
 var EventSourceParserStream = class extends TransformStream {
   constructor({ onError, onRetry, onComment } = {}) {
     let parser;
@@ -53370,7 +53370,7 @@ var EventSourceParserStream = class extends TransformStream {
   }
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/client/streamableHttp.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/client/streamableHttp.js
 var DEFAULT_STREAMABLE_HTTP_RECONNECTION_OPTIONS = {
   initialReconnectionDelay: 1e3,
   maxReconnectionDelay: 3e4,

--- a/plugins/taptap-maker/dist/maker.js
+++ b/plugins/taptap-maker/dist/maker.js
@@ -41,9 +41,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/code.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/code.js
 var require_code = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/code.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/code.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.regexpCode = exports.getEsmExportName = exports.getProperty = exports.safeStringify = exports.stringify = exports.strConcat = exports.addCodeArg = exports.str = exports._ = exports.nil = exports._Code = exports.Name = exports.IDENTIFIER = exports._CodeOrName = void 0;
@@ -195,9 +195,9 @@ var require_code = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/scope.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/scope.js
 var require_scope = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/scope.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/scope.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.ValueScope = exports.ValueScopeName = exports.Scope = exports.varKinds = exports.UsedValueState = void 0;
@@ -340,9 +340,9 @@ var require_scope = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/index.js
 var require_codegen = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.or = exports.and = exports.not = exports.CodeGen = exports.operators = exports.varKinds = exports.ValueScopeName = exports.ValueScope = exports.Scope = exports.Name = exports.regexpCode = exports.stringify = exports.getProperty = exports.nil = exports.strConcat = exports.str = exports._ = void 0;
@@ -1060,9 +1060,9 @@ var require_codegen = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/util.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/util.js
 var require_util = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/util.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/util.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.checkStrictMode = exports.getErrorPath = exports.Type = exports.useFunc = exports.setEvaluated = exports.evaluatedPropsToName = exports.mergeEvaluated = exports.eachItem = exports.unescapeJsonPointer = exports.escapeJsonPointer = exports.escapeFragment = exports.unescapeFragment = exports.schemaRefOrVal = exports.schemaHasRulesButRef = exports.schemaHasRules = exports.checkUnknownRules = exports.alwaysValidSchema = exports.toHash = void 0;
@@ -1227,9 +1227,9 @@ var require_util = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/names.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/names.js
 var require_names = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/names.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/names.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -1266,9 +1266,9 @@ var require_names = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/errors.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/errors.js
 var require_errors = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/errors.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/errors.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.extendErrors = exports.resetErrorsCount = exports.reportExtraError = exports.reportError = exports.keyword$DataError = exports.keywordError = void 0;
@@ -1388,9 +1388,9 @@ var require_errors = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/boolSchema.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/boolSchema.js
 var require_boolSchema = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/boolSchema.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/boolSchema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.boolOrEmptySchema = exports.topBoolOrEmptySchema = void 0;
@@ -1439,9 +1439,9 @@ var require_boolSchema = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/rules.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/rules.js
 var require_rules = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/rules.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/rules.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getRules = exports.isJSONType = void 0;
@@ -1470,9 +1470,9 @@ var require_rules = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/applicability.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/applicability.js
 var require_applicability = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/applicability.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/applicability.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.shouldUseRule = exports.shouldUseGroup = exports.schemaHasRulesForType = void 0;
@@ -1493,9 +1493,9 @@ var require_applicability = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/dataType.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/dataType.js
 var require_dataType = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/dataType.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/dataType.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.reportTypeError = exports.checkDataTypes = exports.checkDataType = exports.coerceAndCheckDataType = exports.getJSONTypes = exports.getSchemaTypes = exports.DataType = void 0;
@@ -1677,9 +1677,9 @@ var require_dataType = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/defaults.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/defaults.js
 var require_defaults = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/defaults.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/defaults.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.assignDefaults = void 0;
@@ -1714,9 +1714,9 @@ var require_defaults = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/code.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/code.js
 var require_code2 = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/code.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/code.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateUnion = exports.validateArray = exports.usePattern = exports.callValidateCode = exports.schemaProperties = exports.allSchemaProperties = exports.noPropertyInData = exports.propertyInData = exports.isOwnProperty = exports.hasPropFunc = exports.reportMissingProp = exports.checkMissingProp = exports.checkReportMissingProp = void 0;
@@ -1847,9 +1847,9 @@ var require_code2 = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/keyword.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/keyword.js
 var require_keyword = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/keyword.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/keyword.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateKeywordUsage = exports.validSchemaType = exports.funcKeywordCode = exports.macroKeywordCode = void 0;
@@ -1965,9 +1965,9 @@ var require_keyword = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/subschema.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/subschema.js
 var require_subschema = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/subschema.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/subschema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.extendSubschemaMode = exports.extendSubschemaData = exports.getSubschema = void 0;
@@ -2048,9 +2048,9 @@ var require_subschema = __commonJS({
   }
 });
 
-// node_modules/fast-deep-equal/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-deep-equal/index.js
 var require_fast_deep_equal = __commonJS({
-  "node_modules/fast-deep-equal/index.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-deep-equal/index.js"(exports, module) {
     "use strict";
     module.exports = function equal(a, b) {
       if (a === b) return true;
@@ -2083,9 +2083,9 @@ var require_fast_deep_equal = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse/index.js
 var require_json_schema_traverse = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse/index.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse/index.js"(exports, module) {
     "use strict";
     var traverse = module.exports = function(schema, opts, cb) {
       if (typeof opts == "function") {
@@ -2171,9 +2171,9 @@ var require_json_schema_traverse = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/resolve.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/resolve.js
 var require_resolve = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/resolve.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/resolve.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getSchemaRefs = exports.resolveUrl = exports.normalizeId = exports._getFullPath = exports.getFullPath = exports.inlineRef = void 0;
@@ -2327,9 +2327,9 @@ var require_resolve = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/index.js
 var require_validate = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getData = exports.KeywordCxt = exports.validateFunctionCode = void 0;
@@ -2835,9 +2835,9 @@ var require_validate = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/validation_error.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/validation_error.js
 var require_validation_error = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/validation_error.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/validation_error.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var ValidationError = class extends Error {
@@ -2851,9 +2851,9 @@ var require_validation_error = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/ref_error.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/ref_error.js
 var require_ref_error = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/ref_error.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/ref_error.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var resolve_1 = require_resolve();
@@ -2868,9 +2868,9 @@ var require_ref_error = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/index.js
 var require_compile = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.resolveSchema = exports.getCompilingSchema = exports.resolveRef = exports.compileSchema = exports.SchemaEnv = void 0;
@@ -3092,9 +3092,9 @@ var require_compile = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/data.json
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/data.json
 var require_data = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/data.json"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/data.json"(exports, module) {
     module.exports = {
       $id: "https://raw.githubusercontent.com/ajv-validator/ajv/master/lib/refs/data.json#",
       description: "Meta-schema for $data reference (JSON AnySchema extension proposal)",
@@ -3111,9 +3111,9 @@ var require_data = __commonJS({
   }
 });
 
-// node_modules/fast-uri/lib/utils.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-uri/lib/utils.js
 var require_utils = __commonJS({
-  "node_modules/fast-uri/lib/utils.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-uri/lib/utils.js"(exports, module) {
     "use strict";
     var isUUID = RegExp.prototype.test.bind(/^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/iu);
     var isIPv4 = RegExp.prototype.test.bind(/^(?:(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)$/u);
@@ -3234,8 +3234,8 @@ var require_utils = __commonJS({
       }
       return ind;
     }
-    function removeDotSegments(path28) {
-      let input2 = path28;
+    function removeDotSegments(path29) {
+      let input2 = path29;
       const output2 = [];
       let nextSlash = -1;
       let len = 0;
@@ -3368,9 +3368,9 @@ var require_utils = __commonJS({
   }
 });
 
-// node_modules/fast-uri/lib/schemes.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-uri/lib/schemes.js
 var require_schemes = __commonJS({
-  "node_modules/fast-uri/lib/schemes.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-uri/lib/schemes.js"(exports, module) {
     "use strict";
     var { isUUID } = require_utils();
     var URN_REG = /([\da-z][\d\-a-z]{0,31}):((?:[\w!$'()*+,\-.:;=@]|%[\da-f]{2})+)/iu;
@@ -3434,8 +3434,8 @@ var require_schemes = __commonJS({
         wsComponent.secure = void 0;
       }
       if (wsComponent.resourceName) {
-        const [path28, query] = wsComponent.resourceName.split("?");
-        wsComponent.path = path28 && path28 !== "/" ? path28 : void 0;
+        const [path29, query] = wsComponent.resourceName.split("?");
+        wsComponent.path = path29 && path29 !== "/" ? path29 : void 0;
         wsComponent.query = query;
         wsComponent.resourceName = void 0;
       }
@@ -3578,9 +3578,9 @@ var require_schemes = __commonJS({
   }
 });
 
-// node_modules/fast-uri/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-uri/index.js
 var require_fast_uri = __commonJS({
-  "node_modules/fast-uri/index.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-uri/index.js"(exports, module) {
     "use strict";
     var { normalizeIPv6, removeDotSegments, recomposeAuthority, normalizeComponentEncoding, isIPv4, nonSimpleDomain } = require_utils();
     var { SCHEMES, getSchemeHandler } = require_schemes();
@@ -3833,9 +3833,9 @@ var require_fast_uri = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/uri.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/uri.js
 var require_uri = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/uri.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/uri.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var uri = require_fast_uri();
@@ -3844,9 +3844,9 @@ var require_uri = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/core.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/core.js
 var require_core = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/core.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/core.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = void 0;
@@ -4455,9 +4455,9 @@ var require_core = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/id.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/id.js
 var require_id = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/id.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/id.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var def = {
@@ -4470,9 +4470,9 @@ var require_id = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/ref.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/ref.js
 var require_ref = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/ref.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/ref.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.callRef = exports.getValidate = void 0;
@@ -4592,9 +4592,9 @@ var require_ref = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/index.js
 var require_core2 = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var id_1 = require_id();
@@ -4613,9 +4613,9 @@ var require_core2 = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitNumber.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitNumber.js
 var require_limitNumber = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitNumber.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitNumber.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4645,9 +4645,9 @@ var require_limitNumber = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/multipleOf.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/multipleOf.js
 var require_multipleOf = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/multipleOf.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/multipleOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4673,9 +4673,9 @@ var require_multipleOf = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/ucs2length.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/ucs2length.js
 var require_ucs2length = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/ucs2length.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/ucs2length.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     function ucs2length(str) {
@@ -4699,9 +4699,9 @@ var require_ucs2length = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitLength.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitLength.js
 var require_limitLength = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitLength.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitLength.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4731,9 +4731,9 @@ var require_limitLength = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/pattern.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/pattern.js
 var require_pattern = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/pattern.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/pattern.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -4768,9 +4768,9 @@ var require_pattern = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitProperties.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitProperties.js
 var require_limitProperties = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitProperties.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4797,9 +4797,9 @@ var require_limitProperties = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/required.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/required.js
 var require_required = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/required.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/required.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -4879,9 +4879,9 @@ var require_required = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitItems.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitItems.js
 var require_limitItems = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitItems.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4908,9 +4908,9 @@ var require_limitItems = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/equal.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/equal.js
 var require_equal = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/equal.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/equal.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var equal = require_fast_deep_equal();
@@ -4919,9 +4919,9 @@ var require_equal = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js
 var require_uniqueItems = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var dataType_1 = require_dataType();
@@ -4986,9 +4986,9 @@ var require_uniqueItems = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/const.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/const.js
 var require_const = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/const.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/const.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5015,9 +5015,9 @@ var require_const = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/enum.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/enum.js
 var require_enum = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/enum.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/enum.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5064,9 +5064,9 @@ var require_enum = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/index.js
 var require_validation = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var limitNumber_1 = require_limitNumber();
@@ -5102,9 +5102,9 @@ var require_validation = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js
 var require_additionalItems = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateAdditionalItems = void 0;
@@ -5155,9 +5155,9 @@ var require_additionalItems = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items.js
 var require_items = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateTuple = void 0;
@@ -5212,9 +5212,9 @@ var require_items = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js
 var require_prefixItems = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var items_1 = require_items();
@@ -5229,9 +5229,9 @@ var require_prefixItems = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items2020.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items2020.js
 var require_items2020 = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items2020.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items2020.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5264,9 +5264,9 @@ var require_items2020 = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/contains.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/contains.js
 var require_contains = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/contains.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/contains.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5358,9 +5358,9 @@ var require_contains = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/dependencies.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/dependencies.js
 var require_dependencies = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/dependencies.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/dependencies.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateSchemaDeps = exports.validatePropertyDeps = exports.error = void 0;
@@ -5452,9 +5452,9 @@ var require_dependencies = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js
 var require_propertyNames = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5495,9 +5495,9 @@ var require_propertyNames = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js
 var require_additionalProperties = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -5601,9 +5601,9 @@ var require_additionalProperties = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/properties.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/properties.js
 var require_properties = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/properties.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/properties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var validate_1 = require_validate();
@@ -5659,9 +5659,9 @@ var require_properties = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js
 var require_patternProperties = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -5733,9 +5733,9 @@ var require_patternProperties = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/not.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/not.js
 var require_not = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/not.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/not.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util();
@@ -5764,9 +5764,9 @@ var require_not = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/anyOf.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/anyOf.js
 var require_anyOf = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/anyOf.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/anyOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -5781,9 +5781,9 @@ var require_anyOf = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/oneOf.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/oneOf.js
 var require_oneOf = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/oneOf.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/oneOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5839,9 +5839,9 @@ var require_oneOf = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/allOf.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/allOf.js
 var require_allOf = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/allOf.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/allOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util();
@@ -5866,9 +5866,9 @@ var require_allOf = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/if.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/if.js
 var require_if = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/if.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/if.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5935,9 +5935,9 @@ var require_if = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/thenElse.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/thenElse.js
 var require_thenElse = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/thenElse.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/thenElse.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util();
@@ -5953,9 +5953,9 @@ var require_thenElse = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/index.js
 var require_applicator = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var additionalItems_1 = require_additionalItems();
@@ -6001,9 +6001,9 @@ var require_applicator = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/format.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/format.js
 var require_format = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/format.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/format.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -6091,9 +6091,9 @@ var require_format = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/index.js
 var require_format2 = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var format_1 = require_format();
@@ -6102,9 +6102,9 @@ var require_format2 = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/metadata.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/metadata.js
 var require_metadata = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/metadata.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/metadata.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.contentVocabulary = exports.metadataVocabulary = void 0;
@@ -6125,9 +6125,9 @@ var require_metadata = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/draft7.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/draft7.js
 var require_draft7 = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/draft7.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/draft7.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var core_1 = require_core2();
@@ -6147,9 +6147,9 @@ var require_draft7 = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/types.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/types.js
 var require_types = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/types.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/types.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.DiscrError = void 0;
@@ -6161,9 +6161,9 @@ var require_types = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/index.js
 var require_discriminator = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -6266,9 +6266,9 @@ var require_discriminator = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/json-schema-draft-07.json
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/json-schema-draft-07.json
 var require_json_schema_draft_07 = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/json-schema-draft-07.json"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/json-schema-draft-07.json"(exports, module) {
     module.exports = {
       $schema: "http://json-schema.org/draft-07/schema#",
       $id: "http://json-schema.org/draft-07/schema#",
@@ -6423,9 +6423,9 @@ var require_json_schema_draft_07 = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/ajv.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/ajv.js
 var require_ajv = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/ajv.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/ajv.js"(exports, module) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.MissingRefError = exports.ValidationError = exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = exports.Ajv = void 0;
@@ -6493,9 +6493,9 @@ var require_ajv = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/dist/formats.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/dist/formats.js
 var require_formats = __commonJS({
-  "node_modules/ajv-formats/dist/formats.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/dist/formats.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.formatNames = exports.fastFormats = exports.fullFormats = void 0;
@@ -6696,9 +6696,9 @@ var require_formats = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/code.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/code.js
 var require_code3 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/code.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/code.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.regexpCode = exports.getEsmExportName = exports.getProperty = exports.safeStringify = exports.stringify = exports.strConcat = exports.addCodeArg = exports.str = exports._ = exports.nil = exports._Code = exports.Name = exports.IDENTIFIER = exports._CodeOrName = void 0;
@@ -6850,9 +6850,9 @@ var require_code3 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/scope.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/scope.js
 var require_scope2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/scope.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/scope.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.ValueScope = exports.ValueScopeName = exports.Scope = exports.varKinds = exports.UsedValueState = void 0;
@@ -6995,9 +6995,9 @@ var require_scope2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/index.js
 var require_codegen2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.or = exports.and = exports.not = exports.CodeGen = exports.operators = exports.varKinds = exports.ValueScopeName = exports.ValueScope = exports.Scope = exports.Name = exports.regexpCode = exports.stringify = exports.getProperty = exports.nil = exports.strConcat = exports.str = exports._ = void 0;
@@ -7715,9 +7715,9 @@ var require_codegen2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/util.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/util.js
 var require_util2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/util.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/util.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.checkStrictMode = exports.getErrorPath = exports.Type = exports.useFunc = exports.setEvaluated = exports.evaluatedPropsToName = exports.mergeEvaluated = exports.eachItem = exports.unescapeJsonPointer = exports.escapeJsonPointer = exports.escapeFragment = exports.unescapeFragment = exports.schemaRefOrVal = exports.schemaHasRulesButRef = exports.schemaHasRules = exports.checkUnknownRules = exports.alwaysValidSchema = exports.toHash = void 0;
@@ -7882,9 +7882,9 @@ var require_util2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/names.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/names.js
 var require_names2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/names.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/names.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -7921,9 +7921,9 @@ var require_names2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/errors.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/errors.js
 var require_errors2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/errors.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/errors.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.extendErrors = exports.resetErrorsCount = exports.reportExtraError = exports.reportError = exports.keyword$DataError = exports.keywordError = void 0;
@@ -8043,9 +8043,9 @@ var require_errors2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/boolSchema.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/boolSchema.js
 var require_boolSchema2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/boolSchema.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/boolSchema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.boolOrEmptySchema = exports.topBoolOrEmptySchema = void 0;
@@ -8094,9 +8094,9 @@ var require_boolSchema2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/rules.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/rules.js
 var require_rules2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/rules.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/rules.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getRules = exports.isJSONType = void 0;
@@ -8125,9 +8125,9 @@ var require_rules2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/applicability.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/applicability.js
 var require_applicability2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/applicability.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/applicability.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.shouldUseRule = exports.shouldUseGroup = exports.schemaHasRulesForType = void 0;
@@ -8148,9 +8148,9 @@ var require_applicability2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/dataType.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/dataType.js
 var require_dataType2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/dataType.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/dataType.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.reportTypeError = exports.checkDataTypes = exports.checkDataType = exports.coerceAndCheckDataType = exports.getJSONTypes = exports.getSchemaTypes = exports.DataType = void 0;
@@ -8332,9 +8332,9 @@ var require_dataType2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/defaults.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/defaults.js
 var require_defaults2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/defaults.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/defaults.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.assignDefaults = void 0;
@@ -8369,9 +8369,9 @@ var require_defaults2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/code.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/code.js
 var require_code4 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/code.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/code.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateUnion = exports.validateArray = exports.usePattern = exports.callValidateCode = exports.schemaProperties = exports.allSchemaProperties = exports.noPropertyInData = exports.propertyInData = exports.isOwnProperty = exports.hasPropFunc = exports.reportMissingProp = exports.checkMissingProp = exports.checkReportMissingProp = void 0;
@@ -8502,9 +8502,9 @@ var require_code4 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/keyword.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/keyword.js
 var require_keyword2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/keyword.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/keyword.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateKeywordUsage = exports.validSchemaType = exports.funcKeywordCode = exports.macroKeywordCode = void 0;
@@ -8620,9 +8620,9 @@ var require_keyword2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/subschema.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/subschema.js
 var require_subschema2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/subschema.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/subschema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.extendSubschemaMode = exports.extendSubschemaData = exports.getSubschema = void 0;
@@ -8703,9 +8703,9 @@ var require_subschema2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/json-schema-traverse/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/json-schema-traverse/index.js
 var require_json_schema_traverse2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/json-schema-traverse/index.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/json-schema-traverse/index.js"(exports, module) {
     "use strict";
     var traverse = module.exports = function(schema, opts, cb) {
       if (typeof opts == "function") {
@@ -8791,9 +8791,9 @@ var require_json_schema_traverse2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/resolve.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/resolve.js
 var require_resolve2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/resolve.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/resolve.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getSchemaRefs = exports.resolveUrl = exports.normalizeId = exports._getFullPath = exports.getFullPath = exports.inlineRef = void 0;
@@ -8947,9 +8947,9 @@ var require_resolve2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/index.js
 var require_validate2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getData = exports.KeywordCxt = exports.validateFunctionCode = void 0;
@@ -9455,9 +9455,9 @@ var require_validate2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/runtime/validation_error.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/validation_error.js
 var require_validation_error2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/runtime/validation_error.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/validation_error.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var ValidationError = class extends Error {
@@ -9471,9 +9471,9 @@ var require_validation_error2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/ref_error.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/ref_error.js
 var require_ref_error2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/ref_error.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/ref_error.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var resolve_1 = require_resolve2();
@@ -9488,9 +9488,9 @@ var require_ref_error2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/index.js
 var require_compile2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.resolveSchema = exports.getCompilingSchema = exports.resolveRef = exports.compileSchema = exports.SchemaEnv = void 0;
@@ -9712,9 +9712,9 @@ var require_compile2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/refs/data.json
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/refs/data.json
 var require_data2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/refs/data.json"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/refs/data.json"(exports, module) {
     module.exports = {
       $id: "https://raw.githubusercontent.com/ajv-validator/ajv/master/lib/refs/data.json#",
       description: "Meta-schema for $data reference (JSON AnySchema extension proposal)",
@@ -9731,9 +9731,9 @@ var require_data2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/runtime/uri.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/uri.js
 var require_uri2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/runtime/uri.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/uri.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var uri = require_fast_uri();
@@ -9742,9 +9742,9 @@ var require_uri2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/core.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/core.js
 var require_core3 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/core.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/core.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = void 0;
@@ -10353,9 +10353,9 @@ var require_core3 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/id.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/id.js
 var require_id2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/id.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/id.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var def = {
@@ -10368,9 +10368,9 @@ var require_id2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/ref.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/ref.js
 var require_ref2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/ref.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/ref.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.callRef = exports.getValidate = void 0;
@@ -10490,9 +10490,9 @@ var require_ref2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/index.js
 var require_core4 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var id_1 = require_id2();
@@ -10511,9 +10511,9 @@ var require_core4 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitNumber.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitNumber.js
 var require_limitNumber2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitNumber.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitNumber.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -10543,9 +10543,9 @@ var require_limitNumber2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/multipleOf.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/multipleOf.js
 var require_multipleOf2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/multipleOf.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/multipleOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -10571,9 +10571,9 @@ var require_multipleOf2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/runtime/ucs2length.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/ucs2length.js
 var require_ucs2length2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/runtime/ucs2length.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/ucs2length.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     function ucs2length(str) {
@@ -10597,9 +10597,9 @@ var require_ucs2length2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitLength.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitLength.js
 var require_limitLength2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitLength.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitLength.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -10629,9 +10629,9 @@ var require_limitLength2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/pattern.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/pattern.js
 var require_pattern2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/pattern.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/pattern.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code4();
@@ -10666,9 +10666,9 @@ var require_pattern2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitProperties.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitProperties.js
 var require_limitProperties2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitProperties.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -10695,9 +10695,9 @@ var require_limitProperties2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/required.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/required.js
 var require_required2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/required.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/required.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code4();
@@ -10777,9 +10777,9 @@ var require_required2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitItems.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitItems.js
 var require_limitItems2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitItems.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -10806,9 +10806,9 @@ var require_limitItems2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/runtime/equal.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/equal.js
 var require_equal2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/runtime/equal.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/equal.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var equal = require_fast_deep_equal();
@@ -10817,9 +10817,9 @@ var require_equal2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js
 var require_uniqueItems2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var dataType_1 = require_dataType2();
@@ -10884,9 +10884,9 @@ var require_uniqueItems2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/const.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/const.js
 var require_const2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/const.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/const.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -10913,9 +10913,9 @@ var require_const2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/enum.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/enum.js
 var require_enum2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/enum.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/enum.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -10962,9 +10962,9 @@ var require_enum2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/index.js
 var require_validation2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var limitNumber_1 = require_limitNumber2();
@@ -11000,9 +11000,9 @@ var require_validation2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js
 var require_additionalItems2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateAdditionalItems = void 0;
@@ -11053,9 +11053,9 @@ var require_additionalItems2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items.js
 var require_items2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateTuple = void 0;
@@ -11110,9 +11110,9 @@ var require_items2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js
 var require_prefixItems2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var items_1 = require_items2();
@@ -11127,9 +11127,9 @@ var require_prefixItems2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items2020.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items2020.js
 var require_items20202 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items2020.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items2020.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -11162,9 +11162,9 @@ var require_items20202 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/contains.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/contains.js
 var require_contains2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/contains.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/contains.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -11256,9 +11256,9 @@ var require_contains2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/dependencies.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/dependencies.js
 var require_dependencies2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/dependencies.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/dependencies.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateSchemaDeps = exports.validatePropertyDeps = exports.error = void 0;
@@ -11350,9 +11350,9 @@ var require_dependencies2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js
 var require_propertyNames2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -11393,9 +11393,9 @@ var require_propertyNames2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js
 var require_additionalProperties2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code4();
@@ -11499,9 +11499,9 @@ var require_additionalProperties2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/properties.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/properties.js
 var require_properties2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/properties.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/properties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var validate_1 = require_validate2();
@@ -11557,9 +11557,9 @@ var require_properties2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js
 var require_patternProperties2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code4();
@@ -11631,9 +11631,9 @@ var require_patternProperties2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/not.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/not.js
 var require_not2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/not.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/not.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util2();
@@ -11662,9 +11662,9 @@ var require_not2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/anyOf.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/anyOf.js
 var require_anyOf2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/anyOf.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/anyOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code4();
@@ -11679,9 +11679,9 @@ var require_anyOf2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/oneOf.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/oneOf.js
 var require_oneOf2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/oneOf.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/oneOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -11737,9 +11737,9 @@ var require_oneOf2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/allOf.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/allOf.js
 var require_allOf2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/allOf.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/allOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util2();
@@ -11764,9 +11764,9 @@ var require_allOf2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/if.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/if.js
 var require_if2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/if.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/if.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -11833,9 +11833,9 @@ var require_if2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/thenElse.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/thenElse.js
 var require_thenElse2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/thenElse.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/thenElse.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util2();
@@ -11851,9 +11851,9 @@ var require_thenElse2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/index.js
 var require_applicator2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var additionalItems_1 = require_additionalItems2();
@@ -11899,9 +11899,9 @@ var require_applicator2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/format.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/format.js
 var require_format3 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/format.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/format.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -11989,9 +11989,9 @@ var require_format3 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/index.js
 var require_format4 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var format_1 = require_format3();
@@ -12000,9 +12000,9 @@ var require_format4 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/metadata.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/metadata.js
 var require_metadata2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/metadata.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/metadata.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.contentVocabulary = exports.metadataVocabulary = void 0;
@@ -12023,9 +12023,9 @@ var require_metadata2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/draft7.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/draft7.js
 var require_draft72 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/draft7.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/draft7.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var core_1 = require_core4();
@@ -12045,9 +12045,9 @@ var require_draft72 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/types.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/types.js
 var require_types2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/types.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/types.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.DiscrError = void 0;
@@ -12059,9 +12059,9 @@ var require_types2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/index.js
 var require_discriminator2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -12164,9 +12164,9 @@ var require_discriminator2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/refs/json-schema-draft-07.json
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/refs/json-schema-draft-07.json
 var require_json_schema_draft_072 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/refs/json-schema-draft-07.json"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/refs/json-schema-draft-07.json"(exports, module) {
     module.exports = {
       $schema: "http://json-schema.org/draft-07/schema#",
       $id: "http://json-schema.org/draft-07/schema#",
@@ -12321,9 +12321,9 @@ var require_json_schema_draft_072 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/ajv.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/ajv.js
 var require_ajv2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/ajv.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/ajv.js"(exports, module) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.MissingRefError = exports.ValidationError = exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = exports.Ajv = void 0;
@@ -12391,9 +12391,9 @@ var require_ajv2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/dist/limit.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/dist/limit.js
 var require_limit = __commonJS({
-  "node_modules/ajv-formats/dist/limit.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/dist/limit.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.formatLimitDefinition = void 0;
@@ -12463,9 +12463,9 @@ var require_limit = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/dist/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/dist/index.js
 var require_dist = __commonJS({
-  "node_modules/ajv-formats/dist/index.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/dist/index.js"(exports, module) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var formats_1 = require_formats();
@@ -12492,12 +12492,12 @@ var require_dist = __commonJS({
         throw new Error(`Unknown format "${name}"`);
       return f;
     };
-    function addFormats(ajv, list, fs26, exportName) {
+    function addFormats(ajv, list, fs27, exportName) {
       var _a3;
       var _b;
       (_a3 = (_b = ajv.opts.code).formats) !== null && _a3 !== void 0 ? _a3 : _b.formats = (0, codegen_1._)`require("ajv-formats/dist/formats").${exportName}`;
       for (const f of list)
-        ajv.addFormat(f, fs26[f]);
+        ajv.addFormat(f, fs27[f]);
     }
     module.exports = exports = formatsPlugin;
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -12505,13 +12505,13 @@ var require_dist = __commonJS({
   }
 });
 
-// node_modules/isexe/windows.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/isexe/windows.js
 var require_windows = __commonJS({
-  "node_modules/isexe/windows.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/isexe/windows.js"(exports, module) {
     module.exports = isexe;
     isexe.sync = sync;
-    var fs26 = __require("fs");
-    function checkPathExt(path28, options) {
+    var fs27 = __require("fs");
+    function checkPathExt(path29, options) {
       var pathext = options.pathExt !== void 0 ? options.pathExt : process.env.PATHEXT;
       if (!pathext) {
         return true;
@@ -12522,42 +12522,42 @@ var require_windows = __commonJS({
       }
       for (var i = 0; i < pathext.length; i++) {
         var p = pathext[i].toLowerCase();
-        if (p && path28.substr(-p.length).toLowerCase() === p) {
+        if (p && path29.substr(-p.length).toLowerCase() === p) {
           return true;
         }
       }
       return false;
     }
-    function checkStat(stat, path28, options) {
+    function checkStat(stat, path29, options) {
       if (!stat.isSymbolicLink() && !stat.isFile()) {
         return false;
       }
-      return checkPathExt(path28, options);
+      return checkPathExt(path29, options);
     }
-    function isexe(path28, options, cb) {
-      fs26.stat(path28, function(er, stat) {
-        cb(er, er ? false : checkStat(stat, path28, options));
+    function isexe(path29, options, cb) {
+      fs27.stat(path29, function(er, stat) {
+        cb(er, er ? false : checkStat(stat, path29, options));
       });
     }
-    function sync(path28, options) {
-      return checkStat(fs26.statSync(path28), path28, options);
+    function sync(path29, options) {
+      return checkStat(fs27.statSync(path29), path29, options);
     }
   }
 });
 
-// node_modules/isexe/mode.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/isexe/mode.js
 var require_mode = __commonJS({
-  "node_modules/isexe/mode.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/isexe/mode.js"(exports, module) {
     module.exports = isexe;
     isexe.sync = sync;
-    var fs26 = __require("fs");
-    function isexe(path28, options, cb) {
-      fs26.stat(path28, function(er, stat) {
+    var fs27 = __require("fs");
+    function isexe(path29, options, cb) {
+      fs27.stat(path29, function(er, stat) {
         cb(er, er ? false : checkStat(stat, options));
       });
     }
-    function sync(path28, options) {
-      return checkStat(fs26.statSync(path28), options);
+    function sync(path29, options) {
+      return checkStat(fs27.statSync(path29), options);
     }
     function checkStat(stat, options) {
       return stat.isFile() && checkMode(stat, options);
@@ -12578,10 +12578,10 @@ var require_mode = __commonJS({
   }
 });
 
-// node_modules/isexe/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/isexe/index.js
 var require_isexe = __commonJS({
-  "node_modules/isexe/index.js"(exports, module) {
-    var fs26 = __require("fs");
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/isexe/index.js"(exports, module) {
+    var fs27 = __require("fs");
     var core;
     if (process.platform === "win32" || global.TESTING_WINDOWS) {
       core = require_windows();
@@ -12590,7 +12590,7 @@ var require_isexe = __commonJS({
     }
     module.exports = isexe;
     isexe.sync = sync;
-    function isexe(path28, options, cb) {
+    function isexe(path29, options, cb) {
       if (typeof options === "function") {
         cb = options;
         options = {};
@@ -12600,7 +12600,7 @@ var require_isexe = __commonJS({
           throw new TypeError("callback not provided");
         }
         return new Promise(function(resolve, reject) {
-          isexe(path28, options || {}, function(er, is) {
+          isexe(path29, options || {}, function(er, is) {
             if (er) {
               reject(er);
             } else {
@@ -12609,7 +12609,7 @@ var require_isexe = __commonJS({
           });
         });
       }
-      core(path28, options || {}, function(er, is) {
+      core(path29, options || {}, function(er, is) {
         if (er) {
           if (er.code === "EACCES" || options && options.ignoreErrors) {
             er = null;
@@ -12619,9 +12619,9 @@ var require_isexe = __commonJS({
         cb(er, is);
       });
     }
-    function sync(path28, options) {
+    function sync(path29, options) {
       try {
-        return core.sync(path28, options || {});
+        return core.sync(path29, options || {});
       } catch (er) {
         if (options && options.ignoreErrors || er.code === "EACCES") {
           return false;
@@ -12633,11 +12633,11 @@ var require_isexe = __commonJS({
   }
 });
 
-// node_modules/which/which.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/which/which.js
 var require_which = __commonJS({
-  "node_modules/which/which.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/which/which.js"(exports, module) {
     var isWindows = process.platform === "win32" || process.env.OSTYPE === "cygwin" || process.env.OSTYPE === "msys";
-    var path28 = __require("path");
+    var path29 = __require("path");
     var COLON = isWindows ? ";" : ":";
     var isexe = require_isexe();
     var getNotFoundError = (cmd) => Object.assign(new Error(`not found: ${cmd}`), { code: "ENOENT" });
@@ -12675,7 +12675,7 @@ var require_which = __commonJS({
           return opt.all && found.length ? resolve(found) : reject(getNotFoundError(cmd));
         const ppRaw = pathEnv[i];
         const pathPart = /^".*"$/.test(ppRaw) ? ppRaw.slice(1, -1) : ppRaw;
-        const pCmd = path28.join(pathPart, cmd);
+        const pCmd = path29.join(pathPart, cmd);
         const p = !pathPart && /^\.[\\\/]/.test(cmd) ? cmd.slice(0, 2) + pCmd : pCmd;
         resolve(subStep(p, i, 0));
       });
@@ -12702,7 +12702,7 @@ var require_which = __commonJS({
       for (let i = 0; i < pathEnv.length; i++) {
         const ppRaw = pathEnv[i];
         const pathPart = /^".*"$/.test(ppRaw) ? ppRaw.slice(1, -1) : ppRaw;
-        const pCmd = path28.join(pathPart, cmd);
+        const pCmd = path29.join(pathPart, cmd);
         const p = !pathPart && /^\.[\\\/]/.test(cmd) ? cmd.slice(0, 2) + pCmd : pCmd;
         for (let j = 0; j < pathExt.length; j++) {
           const cur = p + pathExt[j];
@@ -12729,9 +12729,9 @@ var require_which = __commonJS({
   }
 });
 
-// node_modules/path-key/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/path-key/index.js
 var require_path_key = __commonJS({
-  "node_modules/path-key/index.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/path-key/index.js"(exports, module) {
     "use strict";
     var pathKey = (options = {}) => {
       const environment = options.env || process.env;
@@ -12746,11 +12746,11 @@ var require_path_key = __commonJS({
   }
 });
 
-// node_modules/cross-spawn/lib/util/resolveCommand.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/util/resolveCommand.js
 var require_resolveCommand = __commonJS({
-  "node_modules/cross-spawn/lib/util/resolveCommand.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/util/resolveCommand.js"(exports, module) {
     "use strict";
-    var path28 = __require("path");
+    var path29 = __require("path");
     var which = require_which();
     var getPathKey = require_path_key();
     function resolveCommandAttempt(parsed, withoutPathExt) {
@@ -12768,7 +12768,7 @@ var require_resolveCommand = __commonJS({
       try {
         resolved = which.sync(parsed.command, {
           path: env[getPathKey({ env })],
-          pathExt: withoutPathExt ? path28.delimiter : void 0
+          pathExt: withoutPathExt ? path29.delimiter : void 0
         });
       } catch (e) {
       } finally {
@@ -12777,7 +12777,7 @@ var require_resolveCommand = __commonJS({
         }
       }
       if (resolved) {
-        resolved = path28.resolve(hasCustomCwd ? parsed.options.cwd : "", resolved);
+        resolved = path29.resolve(hasCustomCwd ? parsed.options.cwd : "", resolved);
       }
       return resolved;
     }
@@ -12788,9 +12788,9 @@ var require_resolveCommand = __commonJS({
   }
 });
 
-// node_modules/cross-spawn/lib/util/escape.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/util/escape.js
 var require_escape = __commonJS({
-  "node_modules/cross-spawn/lib/util/escape.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/util/escape.js"(exports, module) {
     "use strict";
     var metaCharsRegExp = /([()\][%!^"`<>&|;, *?])/g;
     function escapeCommand(arg) {
@@ -12813,17 +12813,17 @@ var require_escape = __commonJS({
   }
 });
 
-// node_modules/shebang-regex/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/shebang-regex/index.js
 var require_shebang_regex = __commonJS({
-  "node_modules/shebang-regex/index.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/shebang-regex/index.js"(exports, module) {
     "use strict";
     module.exports = /^#!(.*)/;
   }
 });
 
-// node_modules/shebang-command/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/shebang-command/index.js
 var require_shebang_command = __commonJS({
-  "node_modules/shebang-command/index.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/shebang-command/index.js"(exports, module) {
     "use strict";
     var shebangRegex = require_shebang_regex();
     module.exports = (string4 = "") => {
@@ -12831,8 +12831,8 @@ var require_shebang_command = __commonJS({
       if (!match) {
         return null;
       }
-      const [path28, argument] = match[0].replace(/#! ?/, "").split(" ");
-      const binary = path28.split("/").pop();
+      const [path29, argument] = match[0].replace(/#! ?/, "").split(" ");
+      const binary = path29.split("/").pop();
       if (binary === "env") {
         return argument;
       }
@@ -12841,20 +12841,20 @@ var require_shebang_command = __commonJS({
   }
 });
 
-// node_modules/cross-spawn/lib/util/readShebang.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/util/readShebang.js
 var require_readShebang = __commonJS({
-  "node_modules/cross-spawn/lib/util/readShebang.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/util/readShebang.js"(exports, module) {
     "use strict";
-    var fs26 = __require("fs");
+    var fs27 = __require("fs");
     var shebangCommand = require_shebang_command();
     function readShebang(command) {
       const size = 150;
       const buffer = Buffer.alloc(size);
       let fd;
       try {
-        fd = fs26.openSync(command, "r");
-        fs26.readSync(fd, buffer, 0, size, 0);
-        fs26.closeSync(fd);
+        fd = fs27.openSync(command, "r");
+        fs27.readSync(fd, buffer, 0, size, 0);
+        fs27.closeSync(fd);
       } catch (e) {
       }
       return shebangCommand(buffer.toString());
@@ -12863,11 +12863,11 @@ var require_readShebang = __commonJS({
   }
 });
 
-// node_modules/cross-spawn/lib/parse.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/parse.js
 var require_parse = __commonJS({
-  "node_modules/cross-spawn/lib/parse.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/parse.js"(exports, module) {
     "use strict";
-    var path28 = __require("path");
+    var path29 = __require("path");
     var resolveCommand = require_resolveCommand();
     var escape2 = require_escape();
     var readShebang = require_readShebang();
@@ -12892,7 +12892,7 @@ var require_parse = __commonJS({
       const needsShell = !isExecutableRegExp.test(commandFile);
       if (parsed.options.forceShell || needsShell) {
         const needsDoubleEscapeMetaChars = isCmdShimRegExp.test(commandFile);
-        parsed.command = path28.normalize(parsed.command);
+        parsed.command = path29.normalize(parsed.command);
         parsed.command = escape2.command(parsed.command);
         parsed.args = parsed.args.map((arg) => escape2.argument(arg, needsDoubleEscapeMetaChars));
         const shellCommand = [parsed.command].concat(parsed.args).join(" ");
@@ -12925,9 +12925,9 @@ var require_parse = __commonJS({
   }
 });
 
-// node_modules/cross-spawn/lib/enoent.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/enoent.js
 var require_enoent = __commonJS({
-  "node_modules/cross-spawn/lib/enoent.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/enoent.js"(exports, module) {
     "use strict";
     var isWin = process.platform === "win32";
     function notFoundError(original, syscall) {
@@ -12975,9 +12975,9 @@ var require_enoent = __commonJS({
   }
 });
 
-// node_modules/cross-spawn/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/index.js
 var require_cross_spawn = __commonJS({
-  "node_modules/cross-spawn/index.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/index.js"(exports, module) {
     "use strict";
     var cp = __require("child_process");
     var parse3 = require_parse();
@@ -13002,9 +13002,9 @@ var require_cross_spawn = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/identity.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/identity.js
 var require_identity = __commonJS({
-  "node_modules/yaml/dist/nodes/identity.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/identity.js"(exports) {
     "use strict";
     var ALIAS = Symbol.for("yaml.alias");
     var DOC = Symbol.for("yaml.document");
@@ -13015,10 +13015,10 @@ var require_identity = __commonJS({
     var NODE_TYPE = Symbol.for("yaml.node.type");
     var isAlias = (node) => !!node && typeof node === "object" && node[NODE_TYPE] === ALIAS;
     var isDocument = (node) => !!node && typeof node === "object" && node[NODE_TYPE] === DOC;
-    var isMap2 = (node) => !!node && typeof node === "object" && node[NODE_TYPE] === MAP;
+    var isMap3 = (node) => !!node && typeof node === "object" && node[NODE_TYPE] === MAP;
     var isPair = (node) => !!node && typeof node === "object" && node[NODE_TYPE] === PAIR;
     var isScalar = (node) => !!node && typeof node === "object" && node[NODE_TYPE] === SCALAR;
-    var isSeq2 = (node) => !!node && typeof node === "object" && node[NODE_TYPE] === SEQ;
+    var isSeq3 = (node) => !!node && typeof node === "object" && node[NODE_TYPE] === SEQ;
     function isCollection(node) {
       if (node && typeof node === "object")
         switch (node[NODE_TYPE]) {
@@ -13051,17 +13051,17 @@ var require_identity = __commonJS({
     exports.isAlias = isAlias;
     exports.isCollection = isCollection;
     exports.isDocument = isDocument;
-    exports.isMap = isMap2;
+    exports.isMap = isMap3;
     exports.isNode = isNode;
     exports.isPair = isPair;
     exports.isScalar = isScalar;
-    exports.isSeq = isSeq2;
+    exports.isSeq = isSeq3;
   }
 });
 
-// node_modules/yaml/dist/visit.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/visit.js
 var require_visit = __commonJS({
-  "node_modules/yaml/dist/visit.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/visit.js"(exports) {
     "use strict";
     var identity = require_identity();
     var BREAK = Symbol("break visit");
@@ -13079,17 +13079,17 @@ var require_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    function visit_(key, node, visitor, path28) {
-      const ctrl = callVisitor(key, node, visitor, path28);
+    function visit_(key, node, visitor, path29) {
+      const ctrl = callVisitor(key, node, visitor, path29);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path28, ctrl);
-        return visit_(key, ctrl, visitor, path28);
+        replaceNode(key, path29, ctrl);
+        return visit_(key, ctrl, visitor, path29);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path28 = Object.freeze(path28.concat(node));
+          path29 = Object.freeze(path29.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = visit_(i, node.items[i], visitor, path28);
+            const ci = visit_(i, node.items[i], visitor, path29);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -13100,13 +13100,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path28 = Object.freeze(path28.concat(node));
-          const ck = visit_("key", node.key, visitor, path28);
+          path29 = Object.freeze(path29.concat(node));
+          const ck = visit_("key", node.key, visitor, path29);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = visit_("value", node.value, visitor, path28);
+          const cv = visit_("value", node.value, visitor, path29);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -13127,17 +13127,17 @@ var require_visit = __commonJS({
     visitAsync.BREAK = BREAK;
     visitAsync.SKIP = SKIP;
     visitAsync.REMOVE = REMOVE;
-    async function visitAsync_(key, node, visitor, path28) {
-      const ctrl = await callVisitor(key, node, visitor, path28);
+    async function visitAsync_(key, node, visitor, path29) {
+      const ctrl = await callVisitor(key, node, visitor, path29);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path28, ctrl);
-        return visitAsync_(key, ctrl, visitor, path28);
+        replaceNode(key, path29, ctrl);
+        return visitAsync_(key, ctrl, visitor, path29);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path28 = Object.freeze(path28.concat(node));
+          path29 = Object.freeze(path29.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = await visitAsync_(i, node.items[i], visitor, path28);
+            const ci = await visitAsync_(i, node.items[i], visitor, path29);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -13148,13 +13148,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path28 = Object.freeze(path28.concat(node));
-          const ck = await visitAsync_("key", node.key, visitor, path28);
+          path29 = Object.freeze(path29.concat(node));
+          const ck = await visitAsync_("key", node.key, visitor, path29);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = await visitAsync_("value", node.value, visitor, path28);
+          const cv = await visitAsync_("value", node.value, visitor, path29);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -13181,24 +13181,24 @@ var require_visit = __commonJS({
       }
       return visitor;
     }
-    function callVisitor(key, node, visitor, path28) {
+    function callVisitor(key, node, visitor, path29) {
       var _a3, _b, _c, _d, _e;
       if (typeof visitor === "function")
-        return visitor(key, node, path28);
+        return visitor(key, node, path29);
       if (identity.isMap(node))
-        return (_a3 = visitor.Map) == null ? void 0 : _a3.call(visitor, key, node, path28);
+        return (_a3 = visitor.Map) == null ? void 0 : _a3.call(visitor, key, node, path29);
       if (identity.isSeq(node))
-        return (_b = visitor.Seq) == null ? void 0 : _b.call(visitor, key, node, path28);
+        return (_b = visitor.Seq) == null ? void 0 : _b.call(visitor, key, node, path29);
       if (identity.isPair(node))
-        return (_c = visitor.Pair) == null ? void 0 : _c.call(visitor, key, node, path28);
+        return (_c = visitor.Pair) == null ? void 0 : _c.call(visitor, key, node, path29);
       if (identity.isScalar(node))
-        return (_d = visitor.Scalar) == null ? void 0 : _d.call(visitor, key, node, path28);
+        return (_d = visitor.Scalar) == null ? void 0 : _d.call(visitor, key, node, path29);
       if (identity.isAlias(node))
-        return (_e = visitor.Alias) == null ? void 0 : _e.call(visitor, key, node, path28);
+        return (_e = visitor.Alias) == null ? void 0 : _e.call(visitor, key, node, path29);
       return void 0;
     }
-    function replaceNode(key, path28, node) {
-      const parent = path28[path28.length - 1];
+    function replaceNode(key, path29, node) {
+      const parent = path29[path29.length - 1];
       if (identity.isCollection(parent)) {
         parent.items[key] = node;
       } else if (identity.isPair(parent)) {
@@ -13218,9 +13218,9 @@ var require_visit = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/directives.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/directives.js
 var require_directives = __commonJS({
-  "node_modules/yaml/dist/doc/directives.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/directives.js"(exports) {
     "use strict";
     var identity = require_identity();
     var visit = require_visit();
@@ -13389,9 +13389,9 @@ var require_directives = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/anchors.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/anchors.js
 var require_anchors = __commonJS({
-  "node_modules/yaml/dist/doc/anchors.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/anchors.js"(exports) {
     "use strict";
     var identity = require_identity();
     var visit = require_visit();
@@ -13459,9 +13459,9 @@ var require_anchors = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/applyReviver.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/applyReviver.js
 var require_applyReviver = __commonJS({
-  "node_modules/yaml/dist/doc/applyReviver.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/applyReviver.js"(exports) {
     "use strict";
     function applyReviver(reviver, obj, key, val) {
       if (val && typeof val === "object") {
@@ -13509,9 +13509,9 @@ var require_applyReviver = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/toJS.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/toJS.js
 var require_toJS = __commonJS({
-  "node_modules/yaml/dist/nodes/toJS.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/toJS.js"(exports) {
     "use strict";
     var identity = require_identity();
     function toJS(value, arg, ctx) {
@@ -13539,9 +13539,9 @@ var require_toJS = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Node.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Node.js
 var require_Node = __commonJS({
-  "node_modules/yaml/dist/nodes/Node.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Node.js"(exports) {
     "use strict";
     var applyReviver = require_applyReviver();
     var identity = require_identity();
@@ -13580,9 +13580,9 @@ var require_Node = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Alias.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Alias.js
 var require_Alias = __commonJS({
-  "node_modules/yaml/dist/nodes/Alias.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Alias.js"(exports) {
     "use strict";
     var anchors = require_anchors();
     var visit = require_visit();
@@ -13694,9 +13694,9 @@ var require_Alias = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Scalar.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Scalar.js
 var require_Scalar = __commonJS({
-  "node_modules/yaml/dist/nodes/Scalar.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Scalar.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Node = require_Node();
@@ -13724,9 +13724,9 @@ var require_Scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/createNode.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/createNode.js
 var require_createNode = __commonJS({
-  "node_modules/yaml/dist/doc/createNode.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/createNode.js"(exports) {
     "use strict";
     var Alias = require_Alias();
     var identity = require_identity();
@@ -13803,17 +13803,17 @@ var require_createNode = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Collection.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Collection.js
 var require_Collection = __commonJS({
-  "node_modules/yaml/dist/nodes/Collection.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Collection.js"(exports) {
     "use strict";
     var createNode = require_createNode();
     var identity = require_identity();
     var Node = require_Node();
-    function collectionFromPath(schema, path28, value) {
+    function collectionFromPath(schema, path29, value) {
       let v = value;
-      for (let i = path28.length - 1; i >= 0; --i) {
-        const k = path28[i];
+      for (let i = path29.length - 1; i >= 0; --i) {
+        const k = path29[i];
         if (typeof k === "number" && Number.isInteger(k) && k >= 0) {
           const a = [];
           a[k] = v;
@@ -13832,7 +13832,7 @@ var require_Collection = __commonJS({
         sourceObjects: /* @__PURE__ */ new Map()
       });
     }
-    var isEmptyPath = (path28) => path28 == null || typeof path28 === "object" && !!path28[Symbol.iterator]().next().done;
+    var isEmptyPath = (path29) => path29 == null || typeof path29 === "object" && !!path29[Symbol.iterator]().next().done;
     var Collection = class extends Node.NodeBase {
       constructor(type, schema) {
         super(type);
@@ -13862,11 +13862,11 @@ var require_Collection = __commonJS({
        * be a Pair instance or a `{ key, value }` object, which may not have a key
        * that already exists in the map.
        */
-      addIn(path28, value) {
-        if (isEmptyPath(path28))
+      addIn(path29, value) {
+        if (isEmptyPath(path29))
           this.add(value);
         else {
-          const [key, ...rest] = path28;
+          const [key, ...rest] = path29;
           const node = this.get(key, true);
           if (identity.isCollection(node))
             node.addIn(rest, value);
@@ -13880,8 +13880,8 @@ var require_Collection = __commonJS({
        * Removes a value from the collection.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path28) {
-        const [key, ...rest] = path28;
+      deleteIn(path29) {
+        const [key, ...rest] = path29;
         if (rest.length === 0)
           return this.delete(key);
         const node = this.get(key, true);
@@ -13895,8 +13895,8 @@ var require_Collection = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path28, keepScalar) {
-        const [key, ...rest] = path28;
+      getIn(path29, keepScalar) {
+        const [key, ...rest] = path29;
         const node = this.get(key, true);
         if (rest.length === 0)
           return !keepScalar && identity.isScalar(node) ? node.value : node;
@@ -13914,8 +13914,8 @@ var require_Collection = __commonJS({
       /**
        * Checks if the collection includes a value with the key `key`.
        */
-      hasIn(path28) {
-        const [key, ...rest] = path28;
+      hasIn(path29) {
+        const [key, ...rest] = path29;
         if (rest.length === 0)
           return this.has(key);
         const node = this.get(key, true);
@@ -13925,8 +13925,8 @@ var require_Collection = __commonJS({
        * Sets a value in this collection. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path28, value) {
-        const [key, ...rest] = path28;
+      setIn(path29, value) {
+        const [key, ...rest] = path29;
         if (rest.length === 0) {
           this.set(key, value);
         } else {
@@ -13946,9 +13946,9 @@ var require_Collection = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyComment.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyComment.js
 var require_stringifyComment = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyComment.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyComment.js"(exports) {
     "use strict";
     var stringifyComment = (str) => str.replace(/^(?!$)(?: $)?/gm, "#");
     function indentComment(comment, indent4) {
@@ -13963,9 +13963,9 @@ var require_stringifyComment = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/foldFlowLines.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/foldFlowLines.js
 var require_foldFlowLines = __commonJS({
-  "node_modules/yaml/dist/stringify/foldFlowLines.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/foldFlowLines.js"(exports) {
     "use strict";
     var FOLD_FLOW = "flow";
     var FOLD_BLOCK = "block";
@@ -14099,9 +14099,9 @@ ${indent4}${text.slice(fold + 1, end2)}`;
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyString.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyString.js
 var require_stringifyString = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyString.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyString.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var foldFlowLines = require_foldFlowLines();
@@ -14385,9 +14385,9 @@ ${indent4}`);
   }
 });
 
-// node_modules/yaml/dist/stringify/stringify.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringify.js
 var require_stringify = __commonJS({
-  "node_modules/yaml/dist/stringify/stringify.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringify.js"(exports) {
     "use strict";
     var anchors = require_anchors();
     var identity = require_identity();
@@ -14513,9 +14513,9 @@ ${ctx.indent}${str}`;
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyPair.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyPair.js
 var require_stringifyPair = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyPair.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyPair.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -14646,9 +14646,9 @@ ${ctx.indent}`;
   }
 });
 
-// node_modules/yaml/dist/log.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/log.js
 var require_log = __commonJS({
-  "node_modules/yaml/dist/log.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/log.js"(exports) {
     "use strict";
     var node_process = __require("process");
     function debug(logLevel, ...messages) {
@@ -14668,9 +14668,9 @@ var require_log = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/merge.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/merge.js
 var require_merge = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/merge.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/merge.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -14725,9 +14725,9 @@ var require_merge = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/addPairToJSMap.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/addPairToJSMap.js
 var require_addPairToJSMap = __commonJS({
-  "node_modules/yaml/dist/nodes/addPairToJSMap.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/addPairToJSMap.js"(exports) {
     "use strict";
     var log = require_log();
     var merge2 = require_merge();
@@ -14789,9 +14789,9 @@ var require_addPairToJSMap = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Pair.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Pair.js
 var require_Pair = __commonJS({
-  "node_modules/yaml/dist/nodes/Pair.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Pair.js"(exports) {
     "use strict";
     var createNode = require_createNode();
     var stringifyPair = require_stringifyPair();
@@ -14829,9 +14829,9 @@ var require_Pair = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyCollection.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyCollection.js
 var require_stringifyCollection = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyCollection.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyCollection.js"(exports) {
     "use strict";
     var identity = require_identity();
     var stringify = require_stringify();
@@ -14973,9 +14973,9 @@ ${indent4}${end}`;
   }
 });
 
-// node_modules/yaml/dist/nodes/YAMLMap.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/YAMLMap.js
 var require_YAMLMap = __commonJS({
-  "node_modules/yaml/dist/nodes/YAMLMap.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/YAMLMap.js"(exports) {
     "use strict";
     var stringifyCollection = require_stringifyCollection();
     var addPairToJSMap = require_addPairToJSMap();
@@ -15118,9 +15118,9 @@ var require_YAMLMap = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/common/map.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/map.js
 var require_map = __commonJS({
-  "node_modules/yaml/dist/schema/common/map.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/map.js"(exports) {
     "use strict";
     var identity = require_identity();
     var YAMLMap = require_YAMLMap();
@@ -15140,9 +15140,9 @@ var require_map = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/YAMLSeq.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/YAMLSeq.js
 var require_YAMLSeq = __commonJS({
-  "node_modules/yaml/dist/nodes/YAMLSeq.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/YAMLSeq.js"(exports) {
     "use strict";
     var createNode = require_createNode();
     var stringifyCollection = require_stringifyCollection();
@@ -15256,9 +15256,9 @@ var require_YAMLSeq = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/common/seq.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/seq.js
 var require_seq = __commonJS({
-  "node_modules/yaml/dist/schema/common/seq.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/seq.js"(exports) {
     "use strict";
     var identity = require_identity();
     var YAMLSeq = require_YAMLSeq();
@@ -15278,9 +15278,9 @@ var require_seq = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/common/string.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/string.js
 var require_string = __commonJS({
-  "node_modules/yaml/dist/schema/common/string.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/string.js"(exports) {
     "use strict";
     var stringifyString = require_stringifyString();
     var string4 = {
@@ -15297,9 +15297,9 @@ var require_string = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/common/null.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/null.js
 var require_null = __commonJS({
-  "node_modules/yaml/dist/schema/common/null.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/null.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var nullTag = {
@@ -15315,9 +15315,9 @@ var require_null = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/core/bool.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/bool.js
 var require_bool = __commonJS({
-  "node_modules/yaml/dist/schema/core/bool.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/bool.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var boolTag = {
@@ -15339,9 +15339,9 @@ var require_bool = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyNumber.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyNumber.js
 var require_stringifyNumber = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyNumber.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyNumber.js"(exports) {
     "use strict";
     function stringifyNumber({ format, minFractionDigits, tag, value }) {
       if (typeof value === "bigint")
@@ -15366,9 +15366,9 @@ var require_stringifyNumber = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/core/float.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/float.js
 var require_float = __commonJS({
-  "node_modules/yaml/dist/schema/core/float.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/float.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var stringifyNumber = require_stringifyNumber();
@@ -15412,9 +15412,9 @@ var require_float = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/core/int.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/int.js
 var require_int = __commonJS({
-  "node_modules/yaml/dist/schema/core/int.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/int.js"(exports) {
     "use strict";
     var stringifyNumber = require_stringifyNumber();
     var intIdentify = (value) => typeof value === "bigint" || Number.isInteger(value);
@@ -15457,9 +15457,9 @@ var require_int = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/core/schema.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/schema.js
 var require_schema = __commonJS({
-  "node_modules/yaml/dist/schema/core/schema.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/schema.js"(exports) {
     "use strict";
     var map2 = require_map();
     var _null4 = require_null();
@@ -15485,9 +15485,9 @@ var require_schema = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/json/schema.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/json/schema.js
 var require_schema2 = __commonJS({
-  "node_modules/yaml/dist/schema/json/schema.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/json/schema.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var map2 = require_map();
@@ -15552,9 +15552,9 @@ var require_schema2 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/binary.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/binary.js
 var require_binary = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/binary.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/binary.js"(exports) {
     "use strict";
     var node_buffer = __require("buffer");
     var Scalar = require_Scalar();
@@ -15618,9 +15618,9 @@ var require_binary = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/pairs.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/pairs.js
 var require_pairs = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/pairs.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/pairs.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Pair = require_Pair();
@@ -15696,9 +15696,9 @@ ${cn.comment}` : item.comment;
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/omap.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/omap.js
 var require_omap = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/omap.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/omap.js"(exports) {
     "use strict";
     var identity = require_identity();
     var toJS = require_toJS();
@@ -15774,9 +15774,9 @@ var require_omap = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/bool.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/bool.js
 var require_bool2 = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/bool.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/bool.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     function boolStringify({ value, source }, ctx) {
@@ -15806,9 +15806,9 @@ var require_bool2 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/float.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/float.js
 var require_float2 = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/float.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/float.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var stringifyNumber = require_stringifyNumber();
@@ -15855,9 +15855,9 @@ var require_float2 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/int.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/int.js
 var require_int2 = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/int.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/int.js"(exports) {
     "use strict";
     var stringifyNumber = require_stringifyNumber();
     var intIdentify = (value) => typeof value === "bigint" || Number.isInteger(value);
@@ -15934,9 +15934,9 @@ var require_int2 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/set.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/set.js
 var require_set = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/set.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/set.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Pair = require_Pair();
@@ -16023,9 +16023,9 @@ var require_set = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/timestamp.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/timestamp.js
 var require_timestamp = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/timestamp.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/timestamp.js"(exports) {
     "use strict";
     var stringifyNumber = require_stringifyNumber();
     function parseSexagesimal(str, asBigInt) {
@@ -16111,9 +16111,9 @@ var require_timestamp = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/schema.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/schema.js
 var require_schema3 = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/schema.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/schema.js"(exports) {
     "use strict";
     var map2 = require_map();
     var _null4 = require_null();
@@ -16155,9 +16155,9 @@ var require_schema3 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/tags.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/tags.js
 var require_tags = __commonJS({
-  "node_modules/yaml/dist/schema/tags.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/tags.js"(exports) {
     "use strict";
     var map2 = require_map();
     var _null4 = require_null();
@@ -16249,9 +16249,9 @@ var require_tags = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/Schema.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/Schema.js
 var require_Schema = __commonJS({
-  "node_modules/yaml/dist/schema/Schema.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/Schema.js"(exports) {
     "use strict";
     var identity = require_identity();
     var map2 = require_map();
@@ -16281,9 +16281,9 @@ var require_Schema = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyDocument.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyDocument.js
 var require_stringifyDocument = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyDocument.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyDocument.js"(exports) {
     "use strict";
     var identity = require_identity();
     var stringify = require_stringify();
@@ -16362,9 +16362,9 @@ var require_stringifyDocument = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/Document.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/Document.js
 var require_Document = __commonJS({
-  "node_modules/yaml/dist/doc/Document.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/Document.js"(exports) {
     "use strict";
     var Alias = require_Alias();
     var Collection = require_Collection();
@@ -16440,9 +16440,9 @@ var require_Document = __commonJS({
           this.contents.add(value);
       }
       /** Adds a value to the document. */
-      addIn(path28, value) {
+      addIn(path29, value) {
         if (assertCollection(this.contents))
-          this.contents.addIn(path28, value);
+          this.contents.addIn(path29, value);
       }
       /**
        * Create a new `Alias` node, ensuring that the target `node` has the required anchor.
@@ -16517,14 +16517,14 @@ var require_Document = __commonJS({
        * Removes a value from the document.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path28) {
-        if (Collection.isEmptyPath(path28)) {
+      deleteIn(path29) {
+        if (Collection.isEmptyPath(path29)) {
           if (this.contents == null)
             return false;
           this.contents = null;
           return true;
         }
-        return assertCollection(this.contents) ? this.contents.deleteIn(path28) : false;
+        return assertCollection(this.contents) ? this.contents.deleteIn(path29) : false;
       }
       /**
        * Returns item at `key`, or `undefined` if not found. By default unwraps
@@ -16539,10 +16539,10 @@ var require_Document = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path28, keepScalar) {
-        if (Collection.isEmptyPath(path28))
+      getIn(path29, keepScalar) {
+        if (Collection.isEmptyPath(path29))
           return !keepScalar && identity.isScalar(this.contents) ? this.contents.value : this.contents;
-        return identity.isCollection(this.contents) ? this.contents.getIn(path28, keepScalar) : void 0;
+        return identity.isCollection(this.contents) ? this.contents.getIn(path29, keepScalar) : void 0;
       }
       /**
        * Checks if the document includes a value with the key `key`.
@@ -16553,10 +16553,10 @@ var require_Document = __commonJS({
       /**
        * Checks if the document includes a value at `path`.
        */
-      hasIn(path28) {
-        if (Collection.isEmptyPath(path28))
+      hasIn(path29) {
+        if (Collection.isEmptyPath(path29))
           return this.contents !== void 0;
-        return identity.isCollection(this.contents) ? this.contents.hasIn(path28) : false;
+        return identity.isCollection(this.contents) ? this.contents.hasIn(path29) : false;
       }
       /**
        * Sets a value in this document. For `!!set`, `value` needs to be a
@@ -16573,13 +16573,13 @@ var require_Document = __commonJS({
        * Sets a value in this document. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path28, value) {
-        if (Collection.isEmptyPath(path28)) {
+      setIn(path29, value) {
+        if (Collection.isEmptyPath(path29)) {
           this.contents = value;
         } else if (this.contents == null) {
-          this.contents = Collection.collectionFromPath(this.schema, Array.from(path28), value);
+          this.contents = Collection.collectionFromPath(this.schema, Array.from(path29), value);
         } else if (assertCollection(this.contents)) {
-          this.contents.setIn(path28, value);
+          this.contents.setIn(path29, value);
         }
       }
       /**
@@ -16671,9 +16671,9 @@ var require_Document = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/errors.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/errors.js
 var require_errors3 = __commonJS({
-  "node_modules/yaml/dist/errors.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/errors.js"(exports) {
     "use strict";
     var YAMLError = class extends Error {
       constructor(name, pos, code, message) {
@@ -16736,9 +16736,9 @@ ${pointer}
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-props.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-props.js
 var require_resolve_props = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-props.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-props.js"(exports) {
     "use strict";
     function resolveProps(tokens, { flow, indicator, next, offset, onError, parentIndent, startOnNewline }) {
       let spaceBefore = false;
@@ -16870,9 +16870,9 @@ var require_resolve_props = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/util-contains-newline.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-contains-newline.js
 var require_util_contains_newline = __commonJS({
-  "node_modules/yaml/dist/compose/util-contains-newline.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-contains-newline.js"(exports) {
     "use strict";
     function containsNewline(key) {
       if (!key)
@@ -16912,9 +16912,9 @@ var require_util_contains_newline = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/util-flow-indent-check.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-flow-indent-check.js
 var require_util_flow_indent_check = __commonJS({
-  "node_modules/yaml/dist/compose/util-flow-indent-check.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-flow-indent-check.js"(exports) {
     "use strict";
     var utilContainsNewline = require_util_contains_newline();
     function flowIndentCheck(indent4, fc, onError) {
@@ -16930,9 +16930,9 @@ var require_util_flow_indent_check = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/util-map-includes.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-map-includes.js
 var require_util_map_includes = __commonJS({
-  "node_modules/yaml/dist/compose/util-map-includes.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-map-includes.js"(exports) {
     "use strict";
     var identity = require_identity();
     function mapIncludes(ctx, items, search) {
@@ -16946,9 +16946,9 @@ var require_util_map_includes = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-block-map.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-block-map.js
 var require_resolve_block_map = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-block-map.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-block-map.js"(exports) {
     "use strict";
     var Pair = require_Pair();
     var YAMLMap = require_YAMLMap();
@@ -17055,9 +17055,9 @@ var require_resolve_block_map = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-block-seq.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-block-seq.js
 var require_resolve_block_seq = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-block-seq.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-block-seq.js"(exports) {
     "use strict";
     var YAMLSeq = require_YAMLSeq();
     var resolveProps = require_resolve_props();
@@ -17106,9 +17106,9 @@ var require_resolve_block_seq = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-end.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-end.js
 var require_resolve_end = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-end.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-end.js"(exports) {
     "use strict";
     function resolveEnd(end, offset, reqSpace, onError) {
       let comment = "";
@@ -17149,9 +17149,9 @@ var require_resolve_end = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-flow-collection.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-flow-collection.js
 var require_resolve_flow_collection = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-flow-collection.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-flow-collection.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Pair = require_Pair();
@@ -17165,9 +17165,9 @@ var require_resolve_flow_collection = __commonJS({
     var isBlock = (token) => token && (token.type === "block-map" || token.type === "block-seq");
     function resolveFlowCollection({ composeNode, composeEmptyNode }, ctx, fc, onError, tag) {
       var _a3;
-      const isMap2 = fc.start.source === "{";
-      const fcName = isMap2 ? "flow map" : "flow sequence";
-      const NodeClass = (tag == null ? void 0 : tag.nodeClass) ?? (isMap2 ? YAMLMap.YAMLMap : YAMLSeq.YAMLSeq);
+      const isMap3 = fc.start.source === "{";
+      const fcName = isMap3 ? "flow map" : "flow sequence";
+      const NodeClass = (tag == null ? void 0 : tag.nodeClass) ?? (isMap3 ? YAMLMap.YAMLMap : YAMLSeq.YAMLSeq);
       const coll = new NodeClass(ctx.schema);
       coll.flow = true;
       const atRoot = ctx.atRoot;
@@ -17203,7 +17203,7 @@ var require_resolve_flow_collection = __commonJS({
             offset = props.end;
             continue;
           }
-          if (!isMap2 && ctx.options.strict && utilContainsNewline.containsNewline(key))
+          if (!isMap3 && ctx.options.strict && utilContainsNewline.containsNewline(key))
             onError(
               key,
               // checked by containsNewline()
@@ -17243,7 +17243,7 @@ var require_resolve_flow_collection = __commonJS({
             }
           }
         }
-        if (!isMap2 && !sep && !props.found) {
+        if (!isMap3 && !sep && !props.found) {
           const valueNode = value ? composeNode(ctx, value, props, onError) : composeEmptyNode(ctx, props.end, sep, null, props, onError);
           coll.items.push(valueNode);
           offset = valueNode.range[2];
@@ -17266,7 +17266,7 @@ var require_resolve_flow_collection = __commonJS({
             startOnNewline: false
           });
           if (valueProps.found) {
-            if (!isMap2 && !props.found && ctx.options.strict) {
+            if (!isMap3 && !props.found && ctx.options.strict) {
               if (sep)
                 for (const st of sep) {
                   if (st === valueProps.found)
@@ -17298,7 +17298,7 @@ var require_resolve_flow_collection = __commonJS({
           const pair = new Pair.Pair(keyNode, valueNode);
           if (ctx.options.keepSourceTokens)
             pair.srcToken = collItem;
-          if (isMap2) {
+          if (isMap3) {
             const map2 = coll;
             if (utilMapIncludes.mapIncludes(ctx, map2.items, keyNode))
               onError(keyStart, "DUPLICATE_KEY", "Map keys must be unique");
@@ -17314,7 +17314,7 @@ var require_resolve_flow_collection = __commonJS({
           offset = valueNode ? valueNode.range[2] : valueProps.end;
         }
       }
-      const expectedEnd = isMap2 ? "}" : "]";
+      const expectedEnd = isMap3 ? "}" : "]";
       const [ce, ...ee] = fc.end;
       let cePos = offset;
       if ((ce == null ? void 0 : ce.source) === expectedEnd)
@@ -17344,9 +17344,9 @@ var require_resolve_flow_collection = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/compose-collection.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-collection.js
 var require_compose_collection = __commonJS({
-  "node_modules/yaml/dist/compose/compose-collection.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-collection.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -17410,9 +17410,9 @@ var require_compose_collection = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-block-scalar.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-block-scalar.js
 var require_resolve_block_scalar = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-block-scalar.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-block-scalar.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     function resolveBlockScalar(ctx, scalar, onError) {
@@ -17593,9 +17593,9 @@ var require_resolve_block_scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-flow-scalar.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-flow-scalar.js
 var require_resolve_flow_scalar = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-flow-scalar.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-flow-scalar.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var resolveEnd = require_resolve_end();
@@ -17812,9 +17812,9 @@ var require_resolve_flow_scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/compose-scalar.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-scalar.js
 var require_compose_scalar = __commonJS({
-  "node_modules/yaml/dist/compose/compose-scalar.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-scalar.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -17900,9 +17900,9 @@ var require_compose_scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/util-empty-scalar-position.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-empty-scalar-position.js
 var require_util_empty_scalar_position = __commonJS({
-  "node_modules/yaml/dist/compose/util-empty-scalar-position.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-empty-scalar-position.js"(exports) {
     "use strict";
     function emptyScalarPosition(offset, before, pos) {
       if (before) {
@@ -17930,9 +17930,9 @@ var require_util_empty_scalar_position = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/compose-node.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-node.js
 var require_compose_node = __commonJS({
-  "node_modules/yaml/dist/compose/compose-node.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-node.js"(exports) {
     "use strict";
     var Alias = require_Alias();
     var identity = require_identity();
@@ -18031,9 +18031,9 @@ var require_compose_node = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/compose-doc.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-doc.js
 var require_compose_doc = __commonJS({
-  "node_modules/yaml/dist/compose/compose-doc.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-doc.js"(exports) {
     "use strict";
     var Document = require_Document();
     var composeNode = require_compose_node();
@@ -18074,9 +18074,9 @@ var require_compose_doc = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/composer.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/composer.js
 var require_composer = __commonJS({
-  "node_modules/yaml/dist/compose/composer.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/composer.js"(exports) {
     "use strict";
     var node_process = __require("process");
     var directives = require_directives();
@@ -18281,9 +18281,9 @@ ${end.comment}` : end.comment;
   }
 });
 
-// node_modules/yaml/dist/parse/cst-scalar.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst-scalar.js
 var require_cst_scalar = __commonJS({
-  "node_modules/yaml/dist/parse/cst-scalar.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst-scalar.js"(exports) {
     "use strict";
     var resolveBlockScalar = require_resolve_block_scalar();
     var resolveFlowScalar = require_resolve_flow_scalar();
@@ -18466,9 +18466,9 @@ var require_cst_scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/cst-stringify.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst-stringify.js
 var require_cst_stringify = __commonJS({
-  "node_modules/yaml/dist/parse/cst-stringify.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst-stringify.js"(exports) {
     "use strict";
     var stringify = (cst) => "type" in cst ? stringifyToken(cst) : stringifyItem(cst);
     function stringifyToken(token) {
@@ -18527,9 +18527,9 @@ var require_cst_stringify = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/cst-visit.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst-visit.js
 var require_cst_visit = __commonJS({
-  "node_modules/yaml/dist/parse/cst-visit.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst-visit.js"(exports) {
     "use strict";
     var BREAK = Symbol("break visit");
     var SKIP = Symbol("skip children");
@@ -18542,9 +18542,9 @@ var require_cst_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    visit.itemAtPath = (cst, path28) => {
+    visit.itemAtPath = (cst, path29) => {
       let item = cst;
-      for (const [field, index] of path28) {
+      for (const [field, index] of path29) {
         const tok = item == null ? void 0 : item[field];
         if (tok && "items" in tok) {
           item = tok.items[index];
@@ -18553,23 +18553,23 @@ var require_cst_visit = __commonJS({
       }
       return item;
     };
-    visit.parentCollection = (cst, path28) => {
-      const parent = visit.itemAtPath(cst, path28.slice(0, -1));
-      const field = path28[path28.length - 1][0];
+    visit.parentCollection = (cst, path29) => {
+      const parent = visit.itemAtPath(cst, path29.slice(0, -1));
+      const field = path29[path29.length - 1][0];
       const coll = parent == null ? void 0 : parent[field];
       if (coll && "items" in coll)
         return coll;
       throw new Error("Parent collection not found");
     };
-    function _visit(path28, item, visitor) {
-      let ctrl = visitor(item, path28);
+    function _visit(path29, item, visitor) {
+      let ctrl = visitor(item, path29);
       if (typeof ctrl === "symbol")
         return ctrl;
       for (const field of ["key", "value"]) {
         const token = item[field];
         if (token && "items" in token) {
           for (let i = 0; i < token.items.length; ++i) {
-            const ci = _visit(Object.freeze(path28.concat([[field, i]])), token.items[i], visitor);
+            const ci = _visit(Object.freeze(path29.concat([[field, i]])), token.items[i], visitor);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -18580,18 +18580,18 @@ var require_cst_visit = __commonJS({
             }
           }
           if (typeof ctrl === "function" && field === "key")
-            ctrl = ctrl(item, path28);
+            ctrl = ctrl(item, path29);
         }
       }
-      return typeof ctrl === "function" ? ctrl(item, path28) : ctrl;
+      return typeof ctrl === "function" ? ctrl(item, path29) : ctrl;
     }
     exports.visit = visit;
   }
 });
 
-// node_modules/yaml/dist/parse/cst.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst.js
 var require_cst = __commonJS({
-  "node_modules/yaml/dist/parse/cst.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst.js"(exports) {
     "use strict";
     var cstScalar = require_cst_scalar();
     var cstStringify = require_cst_stringify();
@@ -18691,9 +18691,9 @@ var require_cst = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/lexer.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/lexer.js
 var require_lexer = __commonJS({
-  "node_modules/yaml/dist/parse/lexer.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/lexer.js"(exports) {
     "use strict";
     var cst = require_cst();
     function isEmpty(ch) {
@@ -19270,9 +19270,9 @@ var require_lexer = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/line-counter.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/line-counter.js
 var require_line_counter = __commonJS({
-  "node_modules/yaml/dist/parse/line-counter.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/line-counter.js"(exports) {
     "use strict";
     var LineCounter = class {
       constructor() {
@@ -19301,9 +19301,9 @@ var require_line_counter = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/parser.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/parser.js
 var require_parser = __commonJS({
-  "node_modules/yaml/dist/parse/parser.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/parser.js"(exports) {
     "use strict";
     var node_process = __require("process");
     var cst = require_cst();
@@ -19870,14 +19870,14 @@ var require_parser = __commonJS({
             case "scalar":
             case "single-quoted-scalar":
             case "double-quoted-scalar": {
-              const fs26 = this.flowScalar(this.type);
+              const fs27 = this.flowScalar(this.type);
               if (atNextItem || it.value) {
-                map2.items.push({ start, key: fs26, sep: [] });
+                map2.items.push({ start, key: fs27, sep: [] });
                 this.onKeyLine = true;
               } else if (it.sep) {
-                this.stack.push(fs26);
+                this.stack.push(fs27);
               } else {
-                Object.assign(it, { key: fs26, sep: [] });
+                Object.assign(it, { key: fs27, sep: [] });
                 this.onKeyLine = true;
               }
               return;
@@ -20006,13 +20006,13 @@ var require_parser = __commonJS({
             case "scalar":
             case "single-quoted-scalar":
             case "double-quoted-scalar": {
-              const fs26 = this.flowScalar(this.type);
+              const fs27 = this.flowScalar(this.type);
               if (!it || it.value)
-                fc.items.push({ start: [], key: fs26, sep: [] });
+                fc.items.push({ start: [], key: fs27, sep: [] });
               else if (it.sep)
-                this.stack.push(fs26);
+                this.stack.push(fs27);
               else
-                Object.assign(it, { key: fs26, sep: [] });
+                Object.assign(it, { key: fs27, sep: [] });
               return;
             }
             case "flow-map-end":
@@ -20171,9 +20171,9 @@ var require_parser = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/public-api.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/public-api.js
 var require_public_api = __commonJS({
-  "node_modules/yaml/dist/public-api.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/public-api.js"(exports) {
     "use strict";
     var composer = require_composer();
     var Document = require_Document();
@@ -20201,7 +20201,7 @@ var require_public_api = __commonJS({
         return docs;
       return Object.assign([], { empty: true }, composer$1.streamInfo());
     }
-    function parseDocument2(source, options = {}) {
+    function parseDocument3(source, options = {}) {
       const { lineCounter: lineCounter2, prettyErrors } = parseOptions(options);
       const parser$1 = new parser.Parser(lineCounter2 == null ? void 0 : lineCounter2.addNewLine);
       const composer$1 = new composer.Composer(options);
@@ -20227,7 +20227,7 @@ var require_public_api = __commonJS({
       } else if (options === void 0 && reviver && typeof reviver === "object") {
         options = reviver;
       }
-      const doc = parseDocument2(src, options);
+      const doc = parseDocument3(src, options);
       if (!doc)
         return null;
       doc.warnings.forEach((warning) => log.warn(doc.options.logLevel, warning));
@@ -20263,14 +20263,14 @@ var require_public_api = __commonJS({
     }
     exports.parse = parse3;
     exports.parseAllDocuments = parseAllDocuments;
-    exports.parseDocument = parseDocument2;
+    exports.parseDocument = parseDocument3;
     exports.stringify = stringify;
   }
 });
 
-// node_modules/yaml/dist/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/index.js
 var require_dist2 = __commonJS({
-  "node_modules/yaml/dist/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/index.js"(exports) {
     "use strict";
     var composer = require_composer();
     var Document = require_Document();
@@ -20326,7 +20326,7 @@ import fs17 from "node:fs";
 import path18 from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 
-// node_modules/zod/v3/helpers/util.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v3/helpers/util.js
 var util;
 (function(util2) {
   util2.assertEqual = (_) => {
@@ -20460,7 +20460,7 @@ var getParsedType = (data) => {
   }
 };
 
-// node_modules/zod/v3/ZodError.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v3/ZodError.js
 var ZodIssueCode = util.arrayToEnum([
   "invalid_type",
   "invalid_literal",
@@ -20574,7 +20574,7 @@ ZodError.create = (issues) => {
   return error2;
 };
 
-// node_modules/zod/v3/locales/en.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v3/locales/en.js
 var errorMap = (issue3, _ctx) => {
   let message;
   switch (issue3.code) {
@@ -20677,16 +20677,16 @@ var errorMap = (issue3, _ctx) => {
 };
 var en_default = errorMap;
 
-// node_modules/zod/v3/errors.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v3/errors.js
 var overrideErrorMap = en_default;
 function getErrorMap() {
   return overrideErrorMap;
 }
 
-// node_modules/zod/v3/helpers/parseUtil.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v3/helpers/parseUtil.js
 var makeIssue = (params) => {
-  const { data, path: path28, errorMaps, issueData } = params;
-  const fullPath = [...path28, ...issueData.path || []];
+  const { data, path: path29, errorMaps, issueData } = params;
+  const fullPath = [...path29, ...issueData.path || []];
   const fullIssue = {
     ...issueData,
     path: fullPath
@@ -20792,20 +20792,20 @@ var isDirty = (x) => x.status === "dirty";
 var isValid = (x) => x.status === "valid";
 var isAsync = (x) => typeof Promise !== "undefined" && x instanceof Promise;
 
-// node_modules/zod/v3/helpers/errorUtil.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v3/helpers/errorUtil.js
 var errorUtil;
 (function(errorUtil2) {
   errorUtil2.errToObj = (message) => typeof message === "string" ? { message } : message || {};
   errorUtil2.toString = (message) => typeof message === "string" ? message : message == null ? void 0 : message.message;
 })(errorUtil || (errorUtil = {}));
 
-// node_modules/zod/v3/types.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v3/types.js
 var ParseInputLazyPath = class {
-  constructor(parent, value, path28, key) {
+  constructor(parent, value, path29, key) {
     this._cachedPath = [];
     this.parent = parent;
     this.data = value;
-    this._path = path28;
+    this._path = path29;
     this._key = key;
   }
   get path() {
@@ -24205,7 +24205,7 @@ var nullableType = ZodNullable.create;
 var preprocessType = ZodEffects.createWithPreprocess;
 var pipelineType = ZodPipeline.create;
 
-// node_modules/zod/v4/core/core.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/core.js
 var NEVER = Object.freeze({
   status: "aborted"
 });
@@ -24281,7 +24281,7 @@ function config(newConfig) {
   return globalConfig;
 }
 
-// node_modules/zod/v4/core/util.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/util.js
 var util_exports = {};
 __export(util_exports, {
   BIGINT_FORMAT_RANGES: () => BIGINT_FORMAT_RANGES,
@@ -24454,10 +24454,10 @@ function mergeDefs(...defs) {
 function cloneDef(schema) {
   return mergeDefs(schema._zod.def);
 }
-function getElementAtPath(obj, path28) {
-  if (!path28)
+function getElementAtPath(obj, path29) {
+  if (!path29)
     return obj;
-  return path28.reduce((acc, key) => acc == null ? void 0 : acc[key], obj);
+  return path29.reduce((acc, key) => acc == null ? void 0 : acc[key], obj);
 }
 function promiseAllObject(promisesObj) {
   const keys = Object.keys(promisesObj);
@@ -24842,11 +24842,11 @@ function aborted(x, startIndex = 0) {
   }
   return false;
 }
-function prefixIssues(path28, issues) {
+function prefixIssues(path29, issues) {
   return issues.map((iss) => {
     var _a3;
     (_a3 = iss).path ?? (_a3.path = []);
-    iss.path.unshift(path28);
+    iss.path.unshift(path29);
     return iss;
   });
 }
@@ -24963,7 +24963,7 @@ var Class = class {
   }
 };
 
-// node_modules/zod/v4/core/errors.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/errors.js
 var initializer = (inst, def) => {
   inst.name = "$ZodError";
   Object.defineProperty(inst, "_zod", {
@@ -25029,7 +25029,7 @@ function formatError(error2, mapper = (issue3) => issue3.message) {
   return fieldErrors;
 }
 
-// node_modules/zod/v4/core/parse.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/parse.js
 var _parse = (_Err) => (schema, value, _ctx, _params) => {
   const ctx = _ctx ? Object.assign(_ctx, { async: false }) : { async: false };
   const result = schema._zod.run({ value, issues: [] }, ctx);
@@ -25109,7 +25109,7 @@ var _safeDecodeAsync = (_Err) => async (schema, value, _ctx) => {
   return _safeParseAsync(_Err)(schema, value, _ctx);
 };
 
-// node_modules/zod/v4/core/regexes.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/regexes.js
 var regexes_exports = {};
 __export(regexes_exports, {
   base64: () => base64,
@@ -25266,7 +25266,7 @@ var sha512_hex = /^[0-9a-fA-F]{128}$/;
 var sha512_base64 = /* @__PURE__ */ fixedBase64(86, "==");
 var sha512_base64url = /* @__PURE__ */ fixedBase64url(86);
 
-// node_modules/zod/v4/core/checks.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/checks.js
 var $ZodCheck = /* @__PURE__ */ $constructor("$ZodCheck", (inst, def) => {
   var _a3;
   inst._zod ?? (inst._zod = {});
@@ -25815,7 +25815,7 @@ var $ZodCheckOverwrite = /* @__PURE__ */ $constructor("$ZodCheckOverwrite", (ins
   };
 });
 
-// node_modules/zod/v4/core/doc.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/doc.js
 var Doc = class {
   constructor(args = []) {
     this.content = [];
@@ -25851,14 +25851,14 @@ var Doc = class {
   }
 };
 
-// node_modules/zod/v4/core/versions.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/versions.js
 var version = {
   major: 4,
   minor: 3,
   patch: 6
 };
 
-// node_modules/zod/v4/core/schemas.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/schemas.js
 var $ZodType = /* @__PURE__ */ $constructor("$ZodType", (inst, def) => {
   var _a4;
   var _a3;
@@ -27856,7 +27856,7 @@ function handleRefineResult(result, payload, input2, inst) {
   }
 }
 
-// node_modules/zod/v4/locales/en.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/locales/en.js
 var error = () => {
   const Sizable = {
     string: { unit: "characters", verb: "to have" },
@@ -27965,7 +27965,7 @@ function en_default2() {
   };
 }
 
-// node_modules/zod/v4/core/registries.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/registries.js
 var _a;
 var $output = Symbol("ZodOutput");
 var $input = Symbol("ZodInput");
@@ -28015,7 +28015,7 @@ function registry() {
 (_a = globalThis).__zod_globalRegistry ?? (_a.__zod_globalRegistry = registry());
 var globalRegistry = globalThis.__zod_globalRegistry;
 
-// node_modules/zod/v4/core/api.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/api.js
 // @__NO_SIDE_EFFECTS__
 function _string(Class2, params) {
   return new Class2({
@@ -28860,7 +28860,7 @@ function _stringFormat(Class2, format, fnOrRegex, _params = {}) {
   return inst;
 }
 
-// node_modules/zod/v4/core/to-json-schema.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/to-json-schema.js
 function initializeContext(params) {
   let target = (params == null ? void 0 : params.target) ?? "draft-2020-12";
   if (target === "draft-4")
@@ -29216,7 +29216,7 @@ var createStandardJSONSchemaMethod = (schema, io, processors = {}) => (params) =
   return finalize(ctx, schema);
 };
 
-// node_modules/zod/v4/core/json-schema-processors.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/json-schema-processors.js
 var formatMap = {
   guid: "uuid",
   url: "uri",
@@ -29693,7 +29693,7 @@ var lazyProcessor = (schema, ctx, _json, params) => {
   seen.ref = innerType;
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-compat.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-compat.js
 function isZ4Schema(s) {
   const schema = s;
   return !!schema._zod;
@@ -29758,7 +29758,7 @@ function getLiteralValue(schema) {
   return void 0;
 }
 
-// node_modules/zod/v4/classic/schemas.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/schemas.js
 var schemas_exports3 = {};
 __export(schemas_exports3, {
   ZodAny: () => ZodAny2,
@@ -29927,7 +29927,7 @@ __export(schemas_exports3, {
   xor: () => xor
 });
 
-// node_modules/zod/v4/classic/checks.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/checks.js
 var checks_exports2 = {};
 __export(checks_exports2, {
   endsWith: () => _endsWith,
@@ -29961,7 +29961,7 @@ __export(checks_exports2, {
   uppercase: () => _uppercase
 });
 
-// node_modules/zod/v4/classic/iso.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/iso.js
 var iso_exports2 = {};
 __export(iso_exports2, {
   ZodISODate: () => ZodISODate,
@@ -30002,7 +30002,7 @@ function duration2(params) {
   return _isoDuration(ZodISODuration, params);
 }
 
-// node_modules/zod/v4/classic/errors.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/errors.js
 var initializer2 = (inst, issues) => {
   $ZodError.init(inst, issues);
   inst.name = "ZodError";
@@ -30042,7 +30042,7 @@ var ZodRealError = $constructor("ZodError", initializer2, {
   Parent: Error
 });
 
-// node_modules/zod/v4/classic/parse.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/parse.js
 var parse2 = /* @__PURE__ */ _parse(ZodRealError);
 var parseAsync2 = /* @__PURE__ */ _parseAsync(ZodRealError);
 var safeParse3 = /* @__PURE__ */ _safeParse(ZodRealError);
@@ -30056,7 +30056,7 @@ var safeDecode2 = /* @__PURE__ */ _safeDecode(ZodRealError);
 var safeEncodeAsync2 = /* @__PURE__ */ _safeEncodeAsync(ZodRealError);
 var safeDecodeAsync2 = /* @__PURE__ */ _safeDecodeAsync(ZodRealError);
 
-// node_modules/zod/v4/classic/schemas.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/schemas.js
 var ZodType2 = /* @__PURE__ */ $constructor("ZodType", (inst, def) => {
   $ZodType.init(inst, def);
   Object.assign(inst["~standard"], {
@@ -31136,7 +31136,7 @@ function preprocess(fn, schema) {
   return pipe(transform(fn), schema);
 }
 
-// node_modules/zod/v4/classic/compat.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/compat.js
 var ZodIssueCode2 = {
   invalid_type: "invalid_type",
   too_big: "too_big",
@@ -31154,14 +31154,14 @@ var ZodFirstPartyTypeKind2;
 /* @__PURE__ */ (function(ZodFirstPartyTypeKind3) {
 })(ZodFirstPartyTypeKind2 || (ZodFirstPartyTypeKind2 = {}));
 
-// node_modules/zod/v4/classic/from-json-schema.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/from-json-schema.js
 var z = {
   ...schemas_exports3,
   ...checks_exports2,
   iso: iso_exports2
 };
 
-// node_modules/zod/v4/classic/coerce.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/coerce.js
 var coerce_exports2 = {};
 __export(coerce_exports2, {
   bigint: () => bigint3,
@@ -31186,10 +31186,10 @@ function date4(params) {
   return _coercedDate(ZodDate2, params);
 }
 
-// node_modules/zod/v4/classic/external.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/external.js
 config(en_default2());
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/types.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/types.js
 var LATEST_PROTOCOL_VERSION = "2025-11-25";
 var SUPPORTED_PROTOCOL_VERSIONS = [LATEST_PROTOCOL_VERSION, "2025-06-18", "2025-03-26", "2024-11-05", "2024-10-07"];
 var RELATED_TASK_META_KEY = "io.modelcontextprotocol/related-task";
@@ -32697,18 +32697,18 @@ var UrlElicitationRequiredError = class extends McpError {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/interfaces.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/interfaces.js
 function isTerminal(status) {
   return status === "completed" || status === "failed" || status === "cancelled";
 }
 
-// node_modules/zod-to-json-schema/dist/esm/Options.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod-to-json-schema/dist/esm/Options.js
 var ignoreOverride = Symbol("Let zodToJsonSchema decide on which parser to use");
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/string.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod-to-json-schema/dist/esm/parsers/string.js
 var ALPHA_NUMERIC = new Set("ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvxyz0123456789");
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-json-schema-compat.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-json-schema-compat.js
 function getMethodLiteral(schema) {
   const shape = getObjectShape(schema);
   const methodSchema = shape == null ? void 0 : shape.method;
@@ -32729,7 +32729,7 @@ function parseWithCompat(schema, data) {
   return result.data;
 }
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/protocol.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/protocol.js
 var DEFAULT_REQUEST_TIMEOUT_MSEC = 6e4;
 var Protocol = class {
   constructor(_options) {
@@ -33694,7 +33694,7 @@ function mergeCapabilities(base, additional) {
   return result;
 }
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/validation/ajv-provider.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/validation/ajv-provider.js
 var import_ajv = __toESM(require_ajv(), 1);
 var import_ajv_formats = __toESM(require_dist(), 1);
 function createDefaultAjvInstance() {
@@ -33762,7 +33762,7 @@ var AjvJsonSchemaValidator = class {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/server.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/server.js
 var ExperimentalServerTasks = class {
   constructor(_server) {
     this._server = _server;
@@ -33977,7 +33977,7 @@ var ExperimentalServerTasks = class {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/helpers.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/helpers.js
 function assertToolsCallTaskCapability(requests, method, entityName) {
   var _a3;
   if (!requests) {
@@ -34014,7 +34014,7 @@ function assertClientRequestTaskCapability(requests, method, entityName) {
   }
 }
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/server/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/index.js
 var Server = class extends Protocol {
   /**
    * Initializes this server with the given name and version information.
@@ -34406,10 +34406,10 @@ var Server = class extends Protocol {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js
 import process3 from "node:process";
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/stdio.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/stdio.js
 var ReadBuffer = class {
   append(chunk) {
     this._buffer = this._buffer ? Buffer.concat([this._buffer, chunk]) : chunk;
@@ -34437,7 +34437,7 @@ function serializeMessage(message) {
   return JSON.stringify(message) + "\n";
 }
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js
 var StdioServerTransport = class {
   constructor(_stdin = process3.stdin, _stdout = process3.stdout) {
     this._stdin = _stdin;
@@ -34501,7 +34501,7 @@ var StdioServerTransport = class {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/client.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/client.js
 var ExperimentalClientTasks = class {
   constructor(_client) {
     this._client = _client;
@@ -34655,7 +34655,7 @@ var ExperimentalClientTasks = class {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/client/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/client/index.js
 function applyElicitationDefaults(schema, data) {
   if (!schema || data === null || typeof data !== "object")
     return;
@@ -35185,7 +35185,7 @@ var Client = class extends Protocol {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/client/stdio.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/client/stdio.js
 var import_cross_spawn = __toESM(require_cross_spawn(), 1);
 import process4 from "node:process";
 import { PassThrough } from "node:stream";
@@ -37890,12 +37890,12 @@ function getBlockingRemoteSyncFailure(status) {
   };
 }
 function includeMandatoryMakerSubmitFiles(cwd, files) {
-  const unique = new Set(files);
+  const unique2 = new Set(files);
   const changedFiles = parseGitStatusFiles(readGitSync(["-C", cwd, "status", "--porcelain", "-z"]));
   if (changedFiles.includes(".gitignore")) {
-    unique.add(".gitignore");
+    unique2.add(".gitignore");
   }
-  return [...unique];
+  return [...unique2];
 }
 async function readMakerProjectLocalChanges(cwd) {
   ensureGitAvailable();
@@ -39693,9 +39693,15 @@ function resolveMakerPluginDistribution(distribution = process.env.TAPTAP_MAKER_
   if (distribution === "workbuddy_plugin") {
     return { id: distribution, client: "workbuddy", displayName: "WorkBuddy" };
   }
+  if (distribution === "dsh_plugin") {
+    return { id: distribution, client: "dsh", displayName: "DSH" };
+  }
   return void 0;
 }
 function formatMakerPluginUpdateAction(distribution) {
+  if (distribution.client === "dsh") {
+    return "Update the installed DSH plugin via `dsh plugin --profile <profile> update @taptap/dsh-maker`; do not install or upgrade the standalone npm package.";
+  }
   return `Update the installed ${distribution.displayName} plugin through its marketplace; do not install or upgrade the standalone npm package.`;
 }
 
@@ -39717,7 +39723,8 @@ var BUNDLED_SKILLS = [
 ];
 function formatMakerSkillStatus(_options = {}) {
   const pluginDistribution = resolveMakerPluginDistribution();
-  const bundledSkills = pluginDistribution ? [...BUNDLED_SKILLS, { name: MAKER_PLUGIN_LIFECYCLE_SKILL_NAME }] : BUNDLED_SKILLS;
+  const clientPluginDistribution = pluginDistribution && pluginDistribution.client !== "dsh" ? pluginDistribution : void 0;
+  const bundledSkills = clientPluginDistribution ? [...BUNDLED_SKILLS, { name: MAKER_PLUGIN_LIFECYCLE_SKILL_NAME }] : BUNDLED_SKILLS;
   const skillDocuments = bundledSkills.map((skill) => ({
     name: skill.name,
     path: path11.join(resolveMakerSkillSourceDir(skill.name), "SKILL.md")
@@ -39728,17 +39735,25 @@ function formatMakerSkillStatus(_options = {}) {
     ...skillDocuments.map((skill) => `- ${skill.name}: ${skill.path}`),
     "",
     "Use these documents as reading references for Maker local workflows.",
-    ...pluginDistribution ? [
+    ...clientPluginDistribution ? [
       "",
-      `Maker ${pluginDistribution.displayName} plugin lifecycle`,
+      `Maker ${clientPluginDistribution.displayName} plugin lifecycle`,
       `- entry: ${MAKER_PLUGIN_LIFECYCLE_SKILL_NAME}`,
-      `- Inspect a legacy ${pluginDistribution.displayName} Maker MCP registration before first use.`,
-      ...pluginDistribution.client === "codex" ? [
+      `- Inspect a legacy ${clientPluginDistribution.displayName} Maker MCP registration before first use.`,
+      ...clientPluginDistribution.client === "codex" ? [
         "- Automatically disable an active legacy Codex Maker MCP; the plugin installation request is the authorization.",
         "- Verify the legacy registration is disabled or absent before reporting the plugin ready.",
         "- Require explicit confirmation only when restoring the old MCP during plugin removal."
       ] : ["- Require explicit confirmation before disabling or restoring it."],
       "- Initialize with `taptap-maker init --skip-mcp-install`; the plugin already provides MCP.",
+      `- ${formatMakerPluginUpdateAction(clientPluginDistribution)}`
+    ] : [],
+    ...(pluginDistribution == null ? void 0 : pluginDistribution.client) === "dsh" ? [
+      "",
+      "Maker DSH plugin lifecycle",
+      "- Inspect a legacy DSH L1 MCP registration with `taptap-maker plugin inspect --client dsh` before first use.",
+      "- Migrate/disable it with `taptap-maker plugin migrate --client dsh --confirm`; restore with `taptap-maker plugin restore --client dsh --confirm`.",
+      "- Initialize with `taptap-maker init --skip-mcp-install`; the DSH plugin already provides MCP.",
       `- ${formatMakerPluginUpdateAction(pluginDistribution)}`
     ] : [],
     "",
@@ -47504,10 +47519,10 @@ function indent2(value) {
 
 // src/maker/cli/commands.ts
 import { spawnSync as spawnSync8 } from "node:child_process";
-import crypto4 from "node:crypto";
-import fs24 from "node:fs";
-import os7 from "node:os";
-import path25 from "node:path";
+import crypto5 from "node:crypto";
+import fs25 from "node:fs";
+import os8 from "node:os";
+import path26 from "node:path";
 import readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
 import { pathToFileURL } from "node:url";
@@ -49556,14 +49571,259 @@ function isRecord5(value) {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
-// src/maker/cli/workBuddyProjectSkills.ts
+// src/maker/cli/dshPluginMigration.ts
+var import_yaml2 = __toESM(require_dist2());
 import fs23 from "node:fs";
+import os7 from "node:os";
 import path24 from "node:path";
+import crypto4 from "node:crypto";
+var DSH_MAKER_MCP_NAME = "taptap-maker";
+function inspectDshLegacyMakerMcp(options = {}) {
+  const registrations = findDshMakerRegistrations(options.dshHome);
+  const configPaths = unique(registrations.map((entry) => entry.configPath));
+  if (registrations.length === 0) {
+    return createDshInspection("not_found", [], configPaths);
+  }
+  if (registrations.length > 1) {
+    return createDshInspection("ambiguous", configPaths, configPaths);
+  }
+  return createDshInspection("active", [registrations[0].configPath], configPaths);
+}
+function migrateDshLegacyMakerMcp(options = {}) {
+  const makerHome = getMakerHome();
+  const statePath = getDshPluginMigrationStatePath(makerHome);
+  const registrations = findDshMakerRegistrations(options.dshHome);
+  const inspection = inspectDshLegacyMakerMcp(options);
+  if (inspection.status === "not_found") {
+    return { ...inspection, action: "not_found", changed: false };
+  }
+  if (inspection.status === "ambiguous") {
+    throw new Error(
+      `DSH Maker MCP migration found ${inspection.registration_count} registrations in ${inspection.config_paths.join(", ")}; resolve the duplicates before migrating.`
+    );
+  }
+  if (!options.confirm) {
+    throw new Error(
+      "Removing the legacy DSH Maker MCP registration requires explicit confirmation."
+    );
+  }
+  const registration = registrations[0];
+  const previousContent = fs23.readFileSync(registration.configPath, "utf8");
+  const document = (0, import_yaml2.parseDocument)(previousContent, { prettyErrors: true });
+  if (document.errors.length > 0) {
+    throw new Error(`Invalid YAML in ${registration.configPath}: ${document.errors[0].message}`);
+  }
+  removeDshMakerRegistration(document, registration);
+  const nextContent = document.toString({ lineWidth: 0 });
+  const state = {
+    schema_version: 1,
+    client: "dsh",
+    config_path: registration.configPath,
+    removed_registration: registration.registration,
+    removed_registration_sha256: sha2562(JSON.stringify(registration.registration)),
+    migrated_at: (/* @__PURE__ */ new Date()).toISOString()
+  };
+  fs23.mkdirSync(path24.dirname(statePath), { recursive: true });
+  const write = writeConfigWithTapTapBackupIfChanged(registration.configPath, nextContent, () => {
+    const after = findDshMakerRegistrations(options.dshHome);
+    if (after.some((entry) => entry.configPath === registration.configPath)) {
+      throw new Error("DSH Maker MCP migration validation still found a registration.");
+    }
+    fs23.writeFileSync(statePath, `${JSON.stringify(state, null, 2)}
+`, "utf8");
+  });
+  return {
+    ...inspectDshLegacyMakerMcp(options),
+    action: "removed",
+    changed: write.changed,
+    ...write.backupPath ? { backup_path: write.backupPath } : {},
+    state_path: statePath
+  };
+}
+function restoreDshLegacyMakerMcp(options = {}) {
+  const makerHome = getMakerHome();
+  const statePath = getDshPluginMigrationStatePath(makerHome);
+  const inspection = inspectDshLegacyMakerMcp(options);
+  const state = readDshMigrationState(statePath);
+  if (!state) {
+    return { ...inspection, action: "not_owned", changed: false };
+  }
+  if (!options.confirm) {
+    throw new Error(
+      "Restoring the legacy DSH Maker MCP registration requires explicit confirmation."
+    );
+  }
+  if (inspection.status === "ambiguous") {
+    throw new Error(
+      `DSH Maker MCP restoration found ${inspection.registration_count} registrations; resolve the duplicates before restoring.`
+    );
+  }
+  if (inspection.status === "active") {
+    const current = findDshMakerRegistrations(options.dshHome)[0];
+    const currentSha = sha2562(JSON.stringify(current.registration));
+    if (currentSha === state.removed_registration_sha256) {
+      fs23.rmSync(statePath, { force: true });
+      return { ...inspection, action: "already_restored", changed: false, state_path: statePath };
+    }
+    return { ...inspection, action: "not_owned", changed: false };
+  }
+  const configPath = state.config_path;
+  const previousContent = fs23.readFileSync(configPath, "utf8");
+  const document = (0, import_yaml2.parseDocument)(previousContent, { prettyErrors: true });
+  if (document.errors.length > 0) {
+    throw new Error(`Invalid YAML in ${configPath}: ${document.errors[0].message}`);
+  }
+  reinsertDshMakerRegistration(document, state.removed_registration);
+  const nextContent = document.toString({ lineWidth: 0 });
+  const write = writeConfigWithTapTapBackupIfChanged(configPath, nextContent, () => {
+    const restored = findDshMakerRegistrations(options.dshHome);
+    const match = restored.find((entry) => entry.configPath === configPath);
+    if (!match || sha2562(JSON.stringify(match.registration)) !== state.removed_registration_sha256) {
+      throw new Error("DSH Maker MCP restoration changed the registration identity.");
+    }
+    fs23.rmSync(statePath, { force: true });
+  });
+  return {
+    ...inspectDshLegacyMakerMcp(options),
+    action: "restored",
+    changed: write.changed,
+    ...write.backupPath ? { backup_path: write.backupPath } : {},
+    state_path: statePath
+  };
+}
+function findDshMakerRegistrations(dshHome) {
+  const resolvedDshHome = dshHome || getDshHome();
+  const configPaths = listDshMcpConfigPaths({ homeDir: os7.homedir(), dshHome: resolvedDshHome });
+  const registrations = [];
+  for (const configPath of configPaths) {
+    if (!fs23.existsSync(configPath)) {
+      continue;
+    }
+    const content = fs23.readFileSync(configPath, "utf8");
+    const document = (0, import_yaml2.parseDocument)(content, { prettyErrors: true });
+    if (document.errors.length > 0) {
+      throw new Error(`Invalid YAML in ${configPath}: ${document.errors[0].message}`);
+    }
+    const candidates = findDshMakerCandidates(document);
+    for (const candidate of candidates) {
+      registrations.push({ configPath, ...candidate });
+    }
+  }
+  return registrations;
+}
+function findDshMakerCandidates(document) {
+  const candidates = [];
+  const top = document.contents;
+  if (!(0, import_yaml2.isSeq)(top)) {
+    return candidates;
+  }
+  top.items.forEach((rawPatch, patchIndex) => {
+    const patchNode = rawPatch;
+    const patch = patchNode.toJSON();
+    if (Array.isArray(patch == null ? void 0 : patch.insert)) {
+      const insertNode = (0, import_yaml2.isMap)(patchNode) ? patchNode.get("insert", true) : void 0;
+      if (!(0, import_yaml2.isSeq)(insertNode)) {
+        return;
+      }
+      insertNode.items.forEach((rawRow, insertIndex) => {
+        const rowNode = rawRow;
+        const row = rowNode.toJSON();
+        if (isDshMakerPluginCandidate(row)) {
+          candidates.push({
+            patchIndex,
+            insertIndex,
+            registration: row
+          });
+        }
+      });
+      return;
+    }
+    if (isDshMakerPluginCandidate(patch)) {
+      candidates.push({
+        patchIndex,
+        registration: patch
+      });
+    }
+  });
+  return candidates;
+}
+function removeDshMakerRegistration(document, registration) {
+  const top = document.contents;
+  if (!(0, import_yaml2.isSeq)(top)) {
+    throw new Error("DSH config top-level value must be a plugin array.");
+  }
+  if (registration.insertIndex !== void 0) {
+    const patchNode = top.items[registration.patchIndex];
+    const insertNode = (0, import_yaml2.isMap)(patchNode) ? patchNode.get("insert", true) : void 0;
+    if (!(0, import_yaml2.isSeq)(insertNode)) {
+      throw new Error("Invalid DSH insert patch.");
+    }
+    insertNode.items.splice(registration.insertIndex, 1);
+    if (insertNode.items.length === 0) {
+      top.items.splice(registration.patchIndex, 1);
+    }
+    return;
+  }
+  top.items.splice(registration.patchIndex, 1);
+}
+function reinsertDshMakerRegistration(document, registration) {
+  const top = document.contents;
+  if (!(0, import_yaml2.isSeq)(top)) {
+    throw new Error("DSH config top-level value must be a plugin array.");
+  }
+  top.items.push(document.createNode({ insert: [registration] }));
+}
+function isDshMakerPluginCandidate(value) {
+  if (!isRecord6(value)) {
+    return false;
+  }
+  if (value.id === DSH_MAKER_PLUGIN_ID) {
+    return true;
+  }
+  const config2 = isRecord6(value.config) ? value.config : void 0;
+  return value.name === DSH_MCP_PLUGIN_NAME && (config2 == null ? void 0 : config2.serverName) === DSH_MAKER_MCP_NAME;
+}
+function getDshPluginMigrationStatePath(makerHome) {
+  return path24.join(makerHome, "plugin-migrations", "dsh.json");
+}
+function readDshMigrationState(statePath) {
+  if (!fs23.existsSync(statePath)) {
+    return void 0;
+  }
+  try {
+    const state = JSON.parse(fs23.readFileSync(statePath, "utf8"));
+    return (state == null ? void 0 : state.schema_version) === 1 && state.client === "dsh" ? state : void 0;
+  } catch {
+    return void 0;
+  }
+}
+function createDshInspection(status, primaryPaths, allPaths) {
+  return {
+    client: "dsh",
+    status,
+    config_path: primaryPaths[0] ?? "",
+    config_paths: allPaths,
+    registration_count: primaryPaths.length
+  };
+}
+function sha2562(content) {
+  return crypto4.createHash("sha256").update(content).digest("hex");
+}
+function isRecord6(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+function unique(values) {
+  return [...new Set(values)];
+}
+
+// src/maker/cli/workBuddyProjectSkills.ts
+import fs24 from "node:fs";
+import path25 from "node:path";
 function syncWorkBuddyProjectSkills(targetDir, options = {}) {
   const platform = options.platform ?? process.platform;
-  const projectDir = path24.resolve(targetDir);
-  const sourceDir = path24.join(projectDir, ".installer", "skills");
-  const workBuddySkillsDir = path24.join(projectDir, ".workbuddy", "skills");
+  const projectDir = path25.resolve(targetDir);
+  const sourceDir = path25.join(projectDir, ".installer", "skills");
+  const workBuddySkillsDir = path25.join(projectDir, ".workbuddy", "skills");
   const result = {
     status: "skipped",
     sourceDir,
@@ -49575,18 +49835,18 @@ function syncWorkBuddyProjectSkills(targetDir, options = {}) {
     result.reason = "source_not_found";
     return result;
   }
-  const sourceSkills = fs23.readdirSync(sourceDir, { withFileTypes: true }).filter(
-    (entry) => entry.isDirectory() && fs23.existsSync(path24.join(sourceDir, entry.name, "SKILL.md"))
+  const sourceSkills = fs24.readdirSync(sourceDir, { withFileTypes: true }).filter(
+    (entry) => entry.isDirectory() && fs24.existsSync(path25.join(sourceDir, entry.name, "SKILL.md"))
   ).map((entry) => entry.name).sort();
   for (const sourceSkillName of sourceSkills) {
     const workBuddySkillName = `taptap-maker-${sourceSkillName}`;
-    const workBuddySkillDir = path24.join(workBuddySkillsDir, workBuddySkillName);
+    const workBuddySkillDir = path25.join(workBuddySkillsDir, workBuddySkillName);
     if (pathEntryExists(workBuddySkillDir)) {
       result.skippedSkills.push(workBuddySkillName);
       continue;
     }
-    fs23.mkdirSync(workBuddySkillsDir, { recursive: true });
-    installSkillContents(path24.join(sourceDir, sourceSkillName), workBuddySkillDir, platform);
+    fs24.mkdirSync(workBuddySkillsDir, { recursive: true });
+    installSkillContents(path25.join(sourceDir, sourceSkillName), workBuddySkillDir, platform);
     result.installedSkills.push(workBuddySkillName);
   }
   if (result.installedSkills.length > 0) {
@@ -49595,29 +49855,29 @@ function syncWorkBuddyProjectSkills(targetDir, options = {}) {
   return result;
 }
 function installSkillContents(sourceDir, targetDir, platform) {
-  fs23.mkdirSync(targetDir);
+  fs24.mkdirSync(targetDir);
   try {
-    for (const entry of fs23.readdirSync(sourceDir)) {
-      linkOrCopyEntry(path24.join(sourceDir, entry), path24.join(targetDir, entry), platform);
+    for (const entry of fs24.readdirSync(sourceDir)) {
+      linkOrCopyEntry(path25.join(sourceDir, entry), path25.join(targetDir, entry), platform);
     }
   } catch (error2) {
-    fs23.rmSync(targetDir, { recursive: true, force: true });
+    fs24.rmSync(targetDir, { recursive: true, force: true });
     throw error2;
   }
 }
 function linkOrCopyEntry(source, target, platform) {
-  const stat = fs23.statSync(source);
+  const stat = fs24.statSync(source);
   if (platform === "win32" && stat.isFile()) {
-    fs23.copyFileSync(source, target);
+    fs24.copyFileSync(source, target);
     return;
   }
   try {
-    const linkTarget = platform === "win32" ? source : path24.relative(path24.dirname(target), source);
+    const linkTarget = platform === "win32" ? source : path25.relative(path25.dirname(target), source);
     const linkType = stat.isDirectory() ? platform === "win32" ? "junction" : "dir" : "file";
-    fs23.symlinkSync(linkTarget, target, linkType);
+    fs24.symlinkSync(linkTarget, target, linkType);
   } catch (error2) {
     try {
-      fs23.cpSync(source, target, { recursive: stat.isDirectory() });
+      fs24.cpSync(source, target, { recursive: stat.isDirectory() });
     } catch (copyError) {
       throw new Error(
         `Failed to install WorkBuddy project skill entry ${source}: ${formatError3(error2)}; copy fallback: ${formatError3(copyError)}`
@@ -49627,14 +49887,14 @@ function linkOrCopyEntry(source, target, platform) {
 }
 function isDirectory(value) {
   try {
-    return fs23.statSync(value).isDirectory();
+    return fs24.statSync(value).isDirectory();
   } catch {
     return false;
   }
 }
 function pathEntryExists(value) {
   try {
-    fs23.lstatSync(value);
+    fs24.lstatSync(value);
     return true;
   } catch {
     return false;
@@ -49756,29 +50016,29 @@ async function runMakerCli(argv) {
 function runPluginLifecycle(parsed, ctx) {
   const subcommand = parsed.command[1];
   const client = stringOption(parsed, "client") || "codex";
-  if (client !== "codex" && client !== "workbuddy") {
+  if (client !== "codex" && client !== "workbuddy" && client !== "dsh") {
     throw new Error(
-      `Unsupported Maker plugin client: ${client}. Supported clients: codex, workbuddy.`
+      `Unsupported Maker plugin client: ${client}. Supported clients: codex, workbuddy, dsh.`
     );
   }
   if (subcommand === "inspect") {
     writePluginLifecycleResult(
       ctx,
-      client === "codex" ? inspectCodexLegacyMakerMcp() : inspectWorkBuddyLegacyMakerMcp()
+      client === "codex" ? inspectCodexLegacyMakerMcp() : client === "workbuddy" ? inspectWorkBuddyLegacyMakerMcp() : inspectDshLegacyMakerMcp()
     );
     return;
   }
   if (subcommand === "migrate") {
     writePluginLifecycleResult(
       ctx,
-      client === "codex" ? migrateCodexLegacyMakerMcp({ confirm: booleanOption(parsed, "confirm") }) : migrateWorkBuddyLegacyMakerMcp({ confirm: booleanOption(parsed, "confirm") })
+      client === "codex" ? migrateCodexLegacyMakerMcp({ confirm: booleanOption(parsed, "confirm") }) : client === "workbuddy" ? migrateWorkBuddyLegacyMakerMcp({ confirm: booleanOption(parsed, "confirm") }) : migrateDshLegacyMakerMcp({ confirm: booleanOption(parsed, "confirm") })
     );
     return;
   }
   if (subcommand === "restore") {
     writePluginLifecycleResult(
       ctx,
-      client === "codex" ? restoreCodexLegacyMakerMcp({ confirm: booleanOption(parsed, "confirm") }) : restoreWorkBuddyLegacyMakerMcp({ confirm: booleanOption(parsed, "confirm") })
+      client === "codex" ? restoreCodexLegacyMakerMcp({ confirm: booleanOption(parsed, "confirm") }) : client === "workbuddy" ? restoreWorkBuddyLegacyMakerMcp({ confirm: booleanOption(parsed, "confirm") }) : restoreDshLegacyMakerMcp({ confirm: booleanOption(parsed, "confirm") })
     );
     return;
   }
@@ -49851,7 +50111,7 @@ function toOptionKey(value) {
 }
 async function runInit(parsed, ctx) {
   rejectPackageOption(parsed);
-  const targetDir = path25.resolve(stringOption(parsed, "target_dir") || process.cwd());
+  const targetDir = path26.resolve(stringOption(parsed, "target_dir") || process.cwd());
   const env = makerEnvOption(parsed);
   const skipConfirm = booleanOption(parsed, "skip_confirm");
   const skipMcpInstall = booleanOption(parsed, "skip_mcp_install");
@@ -49966,7 +50226,7 @@ async function runInit(parsed, ctx) {
 }
 async function runDoctor(parsed, ctx) {
   var _a3, _b;
-  const targetDir = path25.resolve(stringOption(parsed, "target_dir") || process.cwd());
+  const targetDir = path26.resolve(stringOption(parsed, "target_dir") || process.cwd());
   const env = makerEnvOption(parsed);
   const git = checkGitEnvironment();
   const python = checkMakerPythonEnvironment();
@@ -50057,8 +50317,8 @@ async function runDoctor(parsed, ctx) {
   );
 }
 function inspectMakerDoctorExecutionContext(options) {
-  const doctorCwd = path25.resolve(process.cwd());
-  const makerProjectDir = options.makerProjectDir ? path25.resolve(options.makerProjectDir) : void 0;
+  const doctorCwd = path26.resolve(process.cwd());
+  const makerProjectDir = options.makerProjectDir ? path26.resolve(options.makerProjectDir) : void 0;
   if (!makerProjectDir) {
     return {
       active_client_session: "not_checked",
@@ -50093,9 +50353,9 @@ function samePath2(left, right) {
   return normalizePathForCompare3(left) === normalizePathForCompare3(right);
 }
 function normalizePathForCompare3(value) {
-  const resolved = path25.resolve(value);
+  const resolved = path26.resolve(value);
   try {
-    return fs24.realpathSync.native(resolved);
+    return fs25.realpathSync.native(resolved);
   } catch {
     return resolved;
   }
@@ -50413,7 +50673,7 @@ async function runPatSet(parsed, ctx) {
 }
 async function resolvePatSet(parsed, ctx) {
   if (booleanOption(parsed, "pat_stdin") || booleanOption(parsed, "pat_from_stdin")) {
-    const pat = fs24.readFileSync(0, "utf8").trim();
+    const pat = fs25.readFileSync(0, "utf8").trim();
     if (!pat) {
       throw new Error("No PAT found on stdin.");
     }
@@ -50468,17 +50728,17 @@ async function prepareMcpLauncher(options) {
     if (options.mode === "self") {
       launcher = materializeMakerSelfLauncher({
         version: VERSION2,
-        bundleUrl: typeof __MAKER_BUNDLE_URL__ !== "undefined" ? __MAKER_BUNDLE_URL__ : pathToFileURL(path25.resolve(process.cwd(), "dist", "maker.js")).href,
+        bundleUrl: typeof __MAKER_BUNDLE_URL__ !== "undefined" ? __MAKER_BUNDLE_URL__ : pathToFileURL(path26.resolve(process.cwd(), "dist", "maker.js")).href,
         makerHome: getMakerHome()
       });
     } else {
       const packageSpec = resolveMakerPackageSpec(MAKER_NPM_PACKAGE, VERSION2);
       launcher = resolveMakerMcpLauncher({ packageName: packageSpec });
       const configuredCache = process.env.npm_config_cache || process.env.NPM_CONFIG_CACHE;
-      const npmCacheDir = path25.resolve(
-        configuredCache || path25.join(getMakerHome(), "cache", "npm")
+      const npmCacheDir = path26.resolve(
+        configuredCache || path26.join(getMakerHome(), "cache", "npm")
       );
-      fs24.mkdirSync(npmCacheDir, { recursive: true });
+      fs25.mkdirSync(npmCacheDir, { recursive: true });
       launcherEnv = { npm_config_cache: npmCacheDir };
     }
   } catch (error2) {
@@ -50611,7 +50871,7 @@ ${indent3(payload.stderr)}` : "",
 }
 async function runMcpReport(parsed, ctx) {
   rejectPackageOption(parsed);
-  const targetDir = path25.resolve(stringOption(parsed, "target_dir") || process.cwd());
+  const targetDir = path26.resolve(stringOption(parsed, "target_dir") || process.cwd());
   const contextInput = booleanOption(parsed, "context_stdin") ? await readStdinText() : "";
   const context = parseMakerMcpReportContext(contextInput);
   const reportRuntime = resolveMakerMcpReportRuntime({
@@ -50664,7 +50924,7 @@ async function runMcpReport(parsed, ctx) {
   const issue3 = buildMakerMcpIssue({
     context,
     diagnostics,
-    homeDir: os7.homedir()
+    homeDir: os8.homedir()
   });
   const submission = booleanOption(parsed, "consent") ? submitMakerMcpIssue(issue3) : {
     status: "consent_required",
@@ -50691,7 +50951,7 @@ async function runMcpReport(parsed, ctx) {
   );
 }
 async function runAgentsUpdate(parsed, ctx) {
-  const targetDir = path25.resolve(stringOption(parsed, "target_dir") || process.cwd());
+  const targetDir = path26.resolve(stringOption(parsed, "target_dir") || process.cwd());
   const result = updateMakerAgentsPolicy(targetDir);
   if (ctx.json) {
     writeJson(result);
@@ -50710,21 +50970,25 @@ async function runAgentsUpdate(parsed, ctx) {
 async function runUpgrade(parsed, ctx) {
   rejectPackageOption(parsed);
   const explicitTargetDir = stringOption(parsed, "target_dir");
-  const targetDir = path25.resolve(explicitTargetDir || process.cwd());
+  const targetDir = path26.resolve(explicitTargetDir || process.cwd());
   const env = makerEnvOption(parsed);
   const ides = parseIdeList(stringOption(parsed, "ide") || stringOption(parsed, "ides") || "");
-  const prepared = await prepareMcpLauncher({ env, mode: mcpLauncherOption(parsed) });
-  if (!prepared.ok) {
-    writeMcpLauncherFailure(ctx, prepared);
-    return;
+  const pluginDistribution = resolveMakerPluginDistribution();
+  let installResults = [];
+  if (!pluginDistribution) {
+    const prepared = await prepareMcpLauncher({ env, mode: mcpLauncherOption(parsed) });
+    if (!prepared.ok) {
+      writeMcpLauncherFailure(ctx, prepared);
+      return;
+    }
+    installResults = installMcpConfigs({
+      ides: ides.length > 0 ? ides : getDefaultMcpInstallIdes(),
+      env: makerMcpConfigEnvOption(parsed),
+      mcpName: stringOption(parsed, "name") || DEFAULT_MCP_NAME,
+      launcher: prepared.launcher,
+      launcherEnv: prepared.launcherEnv
+    });
   }
-  const installResults = installMcpConfigs({
-    ides: ides.length > 0 ? ides : getDefaultMcpInstallIdes(),
-    env: makerMcpConfigEnvOption(parsed),
-    mcpName: stringOption(parsed, "name") || DEFAULT_MCP_NAME,
-    launcher: prepared.launcher,
-    launcherEnv: prepared.launcherEnv
-  });
   const identify = identifyMakerProject({ cwd: targetDir });
   const agentsResult = identify.projectRoot ? updateMakerAgentsPolicy(identify.projectRoot) : void 0;
   const payload = {
@@ -50735,7 +50999,8 @@ async function runUpgrade(parsed, ctx) {
     agents_policy: agentsResult,
     restart_required: false,
     apply_mode: "next_mcp_start",
-    current_session: "preserved"
+    current_session: "preserved",
+    plugin_distribution: pluginDistribution == null ? void 0 : pluginDistribution.id
   };
   if (!payload.ok) {
     process.exitCode = 1;
@@ -50746,9 +51011,9 @@ async function runUpgrade(parsed, ctx) {
   }
   process.stdout.write(
     [
-      payload.ok ? "TapTap Maker upgrade completed" : "TapTap Maker upgrade completed with errors",
+      pluginDistribution ? "TapTap Maker project policy update completed" : payload.ok ? "TapTap Maker upgrade completed" : "TapTap Maker upgrade completed with errors",
       "",
-      ...installResults.map((result) => result.message),
+      ...pluginDistribution ? [`✓ Standalone MCP registration unchanged (${pluginDistribution.displayName} plugin)`] : installResults.map((result) => result.message),
       "",
       agentsResult ? [
         agentsResult.changed ? "✓ AGENTS.md managed policy updated" : "✓ AGENTS.md managed policy current",
@@ -50756,8 +51021,8 @@ async function runUpgrade(parsed, ctx) {
         `- previous_status: ${agentsResult.previousStatus}`
       ].join("\n") : "AGENTS.md managed policy skipped: current directory is not bound to a Maker project.",
       "",
-      "Current MCP session remains unchanged and continues using the existing version.",
-      "The updated package and AGENTS.md will take effect on the next MCP start or user-requested reconnect.",
+      pluginDistribution ? formatMakerPluginUpdateAction(pluginDistribution) : "Current MCP session remains unchanged and continues using the existing version.",
+      pluginDistribution ? "The updated AGENTS.md policy is available to the current project." : "The updated package and AGENTS.md will take effect on the next MCP start or user-requested reconnect.",
       ""
     ].join("\n")
   );
@@ -50794,7 +51059,7 @@ function getMcpVerifyNextSteps(mode, commandText) {
   ];
 }
 async function runDevKitUpdate(parsed, ctx) {
-  const targetDir = path25.resolve(stringOption(parsed, "target_dir") || process.cwd());
+  const targetDir = path26.resolve(stringOption(parsed, "target_dir") || process.cwd());
   const result = await installAiDevKit({
     targetDir,
     preserveExisting: false,
@@ -50807,7 +51072,7 @@ async function runDevKitUpdate(parsed, ctx) {
   emitDevKitSkillInstallerFailure(ctx, result.skillInstaller, "AI skills install failed");
 }
 async function runLogsWatch(parsed, ctx) {
-  const targetDir = path25.resolve(stringOption(parsed, "target_dir") || process.cwd());
+  const targetDir = path26.resolve(stringOption(parsed, "target_dir") || process.cwd());
   const intervalMs = parseDurationMs(stringOption(parsed, "interval") || "5s");
   const timeoutMs = numberOption(parsed, "timeout_ms") ?? DEFAULT_TOOL_CALL_TIMEOUT_MS;
   const maxPolls = numberOption(parsed, "max_polls");
@@ -50817,9 +51082,9 @@ async function runLogsWatch(parsed, ctx) {
     serverUrl: stringOption(parsed, "server_url"),
     env: makerEnvOption(parsed)
   });
-  const runtimeDir = path25.join(proxy.projectRoot, ".maker", "logs", "runtime");
-  const runtimeLog = path25.join(runtimeDir, "runtime.log");
-  const pidFile = path25.join(runtimeDir, "watcher.pid");
+  const runtimeDir = path26.join(proxy.projectRoot, ".maker", "logs", "runtime");
+  const runtimeLog = path26.join(runtimeDir, "runtime.log");
+  const pidFile = path26.join(runtimeDir, "watcher.pid");
   const replacedWatcher = registerRuntimeLogWatcherProcess(pidFile);
   const runtimeLogClient = createRemoteRuntimeLogClient(proxy, timeoutMs);
   emit(ctx, "logs_watch_start", "Maker runtime log watcher started", {
@@ -50864,10 +51129,10 @@ async function runLogsWatch(parsed, ctx) {
   }
 }
 function registerRuntimeLogWatcherProcess(pidFile) {
-  fs24.mkdirSync(path25.dirname(pidFile), { recursive: true });
+  fs25.mkdirSync(path26.dirname(pidFile), { recursive: true });
   const existingPid = readPidFile(pidFile);
   const previous = existingPid && existingPid !== process.pid ? stopExistingRuntimeLogWatcher(pidFile) : {};
-  fs24.writeFileSync(
+  fs25.writeFileSync(
     pidFile,
     `${JSON.stringify(
       {
@@ -50885,10 +51150,10 @@ function registerRuntimeLogWatcherProcess(pidFile) {
   return previous;
 }
 function readPidFile(pidFile) {
-  if (!fs24.existsSync(pidFile)) {
+  if (!fs25.existsSync(pidFile)) {
     return void 0;
   }
-  const raw = fs24.readFileSync(pidFile, "utf8").trim();
+  const raw = fs25.readFileSync(pidFile, "utf8").trim();
   let pid = Number(raw);
   if (!Number.isInteger(pid) || pid <= 0) {
     try {
@@ -50908,7 +51173,7 @@ function installRuntimeLogWatcherPidCleanup(pidFile) {
     }
     cleaned = true;
     if (readPidFile(pidFile) === process.pid) {
-      fs24.rmSync(pidFile, { force: true });
+      fs25.rmSync(pidFile, { force: true });
     }
   };
   process.once("exit", cleanup);
@@ -51059,7 +51324,7 @@ async function prepareDevKit(targetDir, ctx, options = {}) {
         onStart: (event) => emitSkillInstallerStart(ctx, event)
       });
       writeDevKitStagedGitignore(
-        path25.join(targetDir, DEV_KIT_GITIGNORE_STAGING_FILE),
+        path26.join(targetDir, DEV_KIT_GITIGNORE_STAGING_FILE),
         listPresentDevKitManagedEntries(targetDir)
       );
       syncWorkBuddyDevKitSkills(targetDir, ctx);
@@ -51077,7 +51342,7 @@ async function prepareDevKit(targetDir, ctx, options = {}) {
       );
     } catch (error2) {
       writeDevKitStagedGitignore(
-        path25.join(targetDir, DEV_KIT_GITIGNORE_STAGING_FILE),
+        path26.join(targetDir, DEV_KIT_GITIGNORE_STAGING_FILE),
         listPresentDevKitManagedEntries(targetDir)
       );
       if (options.finalizeGitignore) {
@@ -51124,10 +51389,10 @@ function syncWorkBuddyDevKitSkills(targetDir, ctx) {
   try {
     const result = syncWorkBuddyProjectSkills(targetDir);
     const managedSkillPaths = [...result.installedSkills, ...result.skippedSkills].map(
-      (skillName) => path25.join(".workbuddy", "skills", skillName)
+      (skillName) => path26.join(".workbuddy", "skills", skillName)
     );
     if (managedSkillPaths.length > 0) {
-      writeDevKitStagedGitignore(path25.join(targetDir, DEV_KIT_GITIGNORE_STAGING_FILE), [
+      writeDevKitStagedGitignore(path26.join(targetDir, DEV_KIT_GITIGNORE_STAGING_FILE), [
         ...listPresentDevKitManagedEntries(targetDir),
         ...managedSkillPaths
       ]);
@@ -51204,12 +51469,12 @@ function installMcpConfig(ide, options) {
 }
 function installMcpConfigUnsafe(ide, options) {
   if (ide === "codex") {
-    const configPath = path25.join(os7.homedir(), ".codex", "config.toml");
+    const configPath = path26.join(os8.homedir(), ".codex", "config.toml");
     const write = mergeCodexMcpConfig(configPath, withClientIde(options, "codex"));
     return [createMcpInstallResult(ide, "Codex", configPath, write)];
   }
   if (ide === "cursor") {
-    const configPath = path25.join(os7.homedir(), ".cursor", "mcp.json");
+    const configPath = path26.join(os8.homedir(), ".cursor", "mcp.json");
     const write = mergeJsonMcpConfig(configPath, withClientIde(options, "cursor"));
     return [createMcpInstallResult(ide, "Cursor", configPath, write)];
   }
@@ -51226,7 +51491,7 @@ function installMcpConfigUnsafe(ide, options) {
         }
       ];
     }
-    const configPath = path25.join(os7.homedir(), ".claude.json");
+    const configPath = path26.join(os8.homedir(), ".claude.json");
     const write = mergeJsonMcpConfig(configPath, claudeOptions);
     return [createMcpInstallResult(ide, "Claude fallback", configPath, write)];
   }
@@ -51240,7 +51505,7 @@ function installMcpConfigUnsafe(ide, options) {
   }
   if (ide === "opencode") {
     const configPath = getOpenCodeMcpConfigPath();
-    if (!fs24.existsSync(configPath)) {
+    if (!fs25.existsSync(configPath)) {
       return [{ ide, ok: false, message: "Skipped OpenCode: no supported config file found" }];
     }
     const write = mergeOpenCodeMcpConfig(configPath, withClientIde(options, "opencode"));
@@ -51323,13 +51588,13 @@ function getDefaultMcpInstallIdes() {
   if (getTraeMcpInstallPaths().length > 0) {
     ides.push("trae");
   }
-  if (fs24.existsSync(getOpenCodeMcpConfigPath())) {
+  if (fs25.existsSync(getOpenCodeMcpConfigPath())) {
     ides.push("opencode");
   }
   if (getWorkBuddyMcpInstallPaths().length > 0) {
     ides.push("workbuddy");
   }
-  if (fs24.existsSync(getDshHome())) {
+  if (fs25.existsSync(getDshHome())) {
     ides.push("dsh");
   }
   return ides;
@@ -51343,7 +51608,7 @@ function getExistingTraeUserConfigPaths(paths) {
   const seen = /* @__PURE__ */ new Set();
   return paths.filter((configPath) => {
     const key = normalizeConfigPathKey(configPath);
-    if (seen.has(key) || !fs24.existsSync(path25.dirname(configPath))) {
+    if (seen.has(key) || !fs25.existsSync(path26.dirname(configPath))) {
       return false;
     }
     seen.add(key);
@@ -51354,7 +51619,7 @@ function getExistingConfigPaths(paths) {
   const seen = /* @__PURE__ */ new Set();
   return paths.filter((configPath) => {
     const key = normalizeConfigPathKey(configPath);
-    if (seen.has(key) || !fs24.existsSync(configPath)) {
+    if (seen.has(key) || !fs25.existsSync(configPath)) {
       return false;
     }
     seen.add(key);
@@ -51362,62 +51627,62 @@ function getExistingConfigPaths(paths) {
   });
 }
 function normalizeConfigPathKey(configPath) {
-  const resolved = path25.resolve(configPath);
+  const resolved = path26.resolve(configPath);
   return process.platform === "win32" || process.platform === "darwin" ? resolved.toLowerCase() : resolved;
 }
 function getTraeSoloMcpConfigPaths() {
   if (process.platform === "win32") {
-    const roaming = process.env.APPDATA || path25.join(os7.homedir(), "AppData", "Roaming");
+    const roaming = process.env.APPDATA || path26.join(os8.homedir(), "AppData", "Roaming");
     return [
-      path25.join(roaming, "TRAE SOLO", "User", "mcp.json"),
-      path25.join(roaming, "TRAE SOLO CN", "User", "mcp.json")
+      path26.join(roaming, "TRAE SOLO", "User", "mcp.json"),
+      path26.join(roaming, "TRAE SOLO CN", "User", "mcp.json")
     ];
   }
-  const appSupport = path25.join(os7.homedir(), "Library", "Application Support");
+  const appSupport = path26.join(os8.homedir(), "Library", "Application Support");
   return [
-    path25.join(appSupport, "TRAE SOLO CN", "User", "mcp.json"),
-    path25.join(appSupport, "TRAE SOLO", "User", "mcp.json")
+    path26.join(appSupport, "TRAE SOLO CN", "User", "mcp.json"),
+    path26.join(appSupport, "TRAE SOLO", "User", "mcp.json")
   ];
 }
 function getTraeUnverifiedMcpConfigPaths() {
   if (process.platform === "win32") {
-    const roaming = process.env.APPDATA || path25.join(os7.homedir(), "AppData", "Roaming");
+    const roaming = process.env.APPDATA || path26.join(os8.homedir(), "AppData", "Roaming");
     return [
-      path25.join(roaming, "Trae", "User", "mcp.json"),
-      path25.join(roaming, "TRAE", "User", "mcp.json"),
-      path25.join(roaming, "Trae CN", "User", "mcp.json")
+      path26.join(roaming, "Trae", "User", "mcp.json"),
+      path26.join(roaming, "TRAE", "User", "mcp.json"),
+      path26.join(roaming, "Trae CN", "User", "mcp.json")
     ];
   }
-  const appSupport = path25.join(os7.homedir(), "Library", "Application Support");
+  const appSupport = path26.join(os8.homedir(), "Library", "Application Support");
   return [
-    path25.join(appSupport, "Trae", "User", "mcp.json"),
-    path25.join(appSupport, "TRAE", "User", "mcp.json"),
-    path25.join(appSupport, "Trae CN", "User", "mcp.json")
+    path26.join(appSupport, "Trae", "User", "mcp.json"),
+    path26.join(appSupport, "TRAE", "User", "mcp.json"),
+    path26.join(appSupport, "Trae CN", "User", "mcp.json")
   ];
 }
 function getOpenCodeMcpConfigPath() {
-  return path25.join(os7.homedir(), ".config", "opencode", "opencode.jsonc");
+  return path26.join(os8.homedir(), ".config", "opencode", "opencode.jsonc");
 }
 function getWorkBuddyHome() {
-  return path25.join(os7.homedir(), ".workbuddy");
+  return path26.join(os8.homedir(), ".workbuddy");
 }
 function getWorkBuddyMcpInstallPaths(options = {}) {
-  const primary = path25.join(getWorkBuddyHome(), "mcp.json");
-  if (fs24.existsSync(primary) || options.createPrimary) {
+  const primary = path26.join(getWorkBuddyHome(), "mcp.json");
+  if (fs25.existsSync(primary) || options.createPrimary) {
     return [primary];
   }
-  const legacy = path25.join(getWorkBuddyHome(), ".mcp.json");
-  if (fs24.existsSync(legacy)) {
+  const legacy = path26.join(getWorkBuddyHome(), ".mcp.json");
+  if (fs25.existsSync(legacy)) {
     return [legacy];
   }
   return [];
 }
 function inspectWorkBuddyTrustState(mcpName) {
   const workbuddyHome = getWorkBuddyHome();
-  const connectorsDir = path25.join(workbuddyHome, "connectors");
+  const connectorsDir = path26.join(workbuddyHome, "connectors");
   const accounts = [];
   const stateFiles = [];
-  if (!fs24.existsSync(connectorsDir)) {
+  if (!fs25.existsSync(connectorsDir)) {
     return {
       status: "not_found",
       mcp_name: mcpName,
@@ -51427,12 +51692,12 @@ function inspectWorkBuddyTrustState(mcpName) {
       accounts
     };
   }
-  for (const entry of fs24.readdirSync(connectorsDir, { withFileTypes: true })) {
+  for (const entry of fs25.readdirSync(connectorsDir, { withFileTypes: true })) {
     if (!entry.isDirectory()) {
       continue;
     }
-    const statePath = path25.join(connectorsDir, entry.name, "connector-states.json");
-    if (!fs24.existsSync(statePath)) {
+    const statePath = path26.join(connectorsDir, entry.name, "connector-states.json");
+    if (!fs25.existsSync(statePath)) {
       continue;
     }
     stateFiles.push(statePath);
@@ -51511,7 +51776,7 @@ function mergeJsonMcpConfig(configPath, options) {
   );
 }
 function mergeOpenCodeMcpConfig(configPath, options) {
-  const rawContent = fs24.readFileSync(configPath, "utf8");
+  const rawContent = fs25.readFileSync(configPath, "utf8");
   const rewroteJsonc = normalizeJsonConfigContent(rawContent, { jsonc: true }) !== rawContent;
   const existing = readJsonObject(configPath, { jsonc: true });
   const mcp = asObject(existing.mcp);
@@ -51543,7 +51808,7 @@ function mergeOpenCodeMcpConfig(configPath, options) {
   return { ...write, rewroteJsonc: write.changed && rewroteJsonc };
 }
 function mergeCodexMcpConfig(configPath, options) {
-  const existing = fs24.existsSync(configPath) ? fs24.readFileSync(configPath, "utf8") : "";
+  const existing = fs25.existsSync(configPath) ? fs25.readFileSync(configPath, "utf8") : "";
   const withoutOld = removeCodexMcpTables(existing, options.mcpName).trimEnd();
   const launch = options.launcher;
   const envValues = createMcpEnvironmentValues(options.env, options.clientIde, options.launcherEnv);
@@ -51577,7 +51842,7 @@ function mergeCodexMcpConfig(configPath, options) {
   );
 }
 function tryClaudeMcpAdd(options) {
-  const configPath = path25.join(os7.homedir(), ".claude.json");
+  const configPath = path26.join(os8.homedir(), ".claude.json");
   try {
     const existing = readJsonObject(configPath);
     const server = asObject(asObject(existing.mcpServers)[options.mcpName]);
@@ -51670,10 +51935,10 @@ function rejectPackageOption(parsed) {
   }
 }
 function readJsonObject(filePath, options = {}) {
-  if (!fs24.existsSync(filePath)) {
+  if (!fs25.existsSync(filePath)) {
     return {};
   }
-  const raw = fs24.readFileSync(filePath, "utf8");
+  const raw = fs25.readFileSync(filePath, "utf8");
   try {
     const normalized = normalizeJsonConfigContent(raw, options);
     const parsed = JSON.parse(normalized);
@@ -51845,10 +52110,10 @@ function formatMcpInstallMessage(label, configPath, write) {
   ].filter(Boolean).join("\n");
 }
 function saveInitState(targetDir, state) {
-  fs24.mkdirSync(getMakerHome(), { recursive: true });
-  const key = crypto4.createHash("sha256").update(path25.resolve(targetDir)).digest("hex").slice(0, 16);
-  fs24.writeFileSync(
-    path25.join(getMakerHome(), `init-state-${key}.json`),
+  fs25.mkdirSync(getMakerHome(), { recursive: true });
+  const key = crypto5.createHash("sha256").update(path26.resolve(targetDir)).digest("hex").slice(0, 16);
+  fs25.writeFileSync(
+    path26.join(getMakerHome(), `init-state-${key}.json`),
     `${JSON.stringify({ ...state, updated_at: (/* @__PURE__ */ new Date()).toISOString() }, null, 2)}
 `,
     "utf8"
@@ -51996,7 +52261,7 @@ function makerEnvOption(parsed) {
     return env;
   }
   const targetDir = stringOption(parsed, "target_dir");
-  return getMakerEnvironment(void 0, targetDir ? path25.resolve(targetDir) : process.cwd());
+  return getMakerEnvironment(void 0, targetDir ? path26.resolve(targetDir) : process.cwd());
 }
 function makerMcpConfigEnvOption(parsed) {
   return stringOption(parsed, "env") === "rnd" ? "rnd" : "production";
@@ -52068,9 +52333,9 @@ function printHelp() {
       "                            [--context-stdin] [--consent] [--json]",
       "                            # Run only after the user agrees to submit",
       "  taptap-maker agents update [--target-dir DIR] [--json]",
-      "  taptap-maker plugin inspect --client codex|workbuddy [--json]",
-      "  taptap-maker plugin migrate --client codex|workbuddy --confirm [--json]",
-      "  taptap-maker plugin restore --client codex|workbuddy --confirm [--json]",
+      "  taptap-maker plugin inspect --client codex|workbuddy|dsh [--json]",
+      "  taptap-maker plugin migrate --client codex|workbuddy|dsh --confirm [--json]",
+      "  taptap-maker plugin restore --client codex|workbuddy|dsh --confirm [--json]",
       "  taptap-maker upgrade [--launcher self|npx] [--target-dir DIR] [--json]",
       "  taptap-maker dev-kit update [--target-dir DIR] [--json]",
       "  taptap-maker logs watch [--target-dir DIR] [--interval 5s] [--reset] [--json]",
@@ -52112,7 +52377,7 @@ function formatCliError(error2) {
   return error2 instanceof Error ? error2.message : String(error2);
 }
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/transport.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/transport.js
 function normalizeHeaders(headers) {
   if (!headers)
     return {};
@@ -52139,14 +52404,14 @@ function createFetchWithInit(baseFetch = fetch, baseInit) {
   };
 }
 
-// node_modules/pkce-challenge/dist/index.node.js
-var crypto5;
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/pkce-challenge/dist/index.node.js
+var crypto6;
 var _a2;
-crypto5 = ((_a2 = globalThis.crypto) == null ? void 0 : _a2.webcrypto) ?? // Node.js [18-16] REPL
+crypto6 = ((_a2 = globalThis.crypto) == null ? void 0 : _a2.webcrypto) ?? // Node.js [18-16] REPL
 globalThis.crypto ?? // Node.js >18
 import("node:crypto").then((m) => m.webcrypto);
 async function getRandomValues(size) {
-  return (await crypto5).getRandomValues(new Uint8Array(size));
+  return (await crypto6).getRandomValues(new Uint8Array(size));
 }
 async function random(size) {
   const mask2 = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~";
@@ -52162,7 +52427,7 @@ async function generateVerifier(length) {
   return await random(length);
 }
 async function generateChallenge(code_verifier) {
-  const buffer = await (await crypto5).subtle.digest("SHA-256", new TextEncoder().encode(code_verifier));
+  const buffer = await (await crypto6).subtle.digest("SHA-256", new TextEncoder().encode(code_verifier));
   return btoa(String.fromCharCode(...new Uint8Array(buffer))).replace(/\//g, "_").replace(/\+/g, "-").replace(/=/g, "");
 }
 async function pkceChallenge(length) {
@@ -52179,7 +52444,7 @@ async function pkceChallenge(length) {
   };
 }
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/auth.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/auth.js
 var SafeUrlSchema = url().superRefine((val, ctx) => {
   if (!URL.canParse(val)) {
     ctx.addIssue({
@@ -52323,7 +52588,7 @@ var OAuthTokenRevocationRequestSchema = object2({
   token_type_hint: string2().optional()
 }).strip();
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/auth-utils.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/auth-utils.js
 function resourceUrlFromServerUrl(url2) {
   const resourceURL = typeof url2 === "string" ? new URL(url2) : new URL(url2.href);
   resourceURL.hash = "";
@@ -52343,7 +52608,7 @@ function checkResourceAllowed({ requestedResource, configuredResource }) {
   return requestedPath.startsWith(configuredPath);
 }
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/server/auth/errors.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/auth/errors.js
 var OAuthError = class extends Error {
   constructor(message, errorUri) {
     super(message);
@@ -52438,7 +52703,7 @@ var OAUTH_ERRORS = {
   [InvalidTargetError.errorCode]: InvalidTargetError
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/client/auth.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/client/auth.js
 var UnauthorizedError = class extends Error {
   constructor(message) {
     super(message ?? "Unauthorized");
@@ -52978,7 +53243,7 @@ async function registerClient(authorizationServerUrl, { metadata, clientMetadata
   return OAuthClientInformationFullSchema.parse(await response.json());
 }
 
-// node_modules/eventsource-parser/dist/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/eventsource-parser/dist/index.js
 var ParseError = class extends Error {
   constructor(message, options) {
     super(message), this.name = "ParseError", this.type = options.type, this.field = options.field, this.value = options.value, this.line = options.line;
@@ -53081,7 +53346,7 @@ function splitLines(chunk) {
   return [lines, incompleteLine];
 }
 
-// node_modules/eventsource-parser/dist/stream.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/eventsource-parser/dist/stream.js
 var EventSourceParserStream = class extends TransformStream {
   constructor({ onError, onRetry, onComment } = {}) {
     let parser;
@@ -53105,7 +53370,7 @@ var EventSourceParserStream = class extends TransformStream {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/client/streamableHttp.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/client/streamableHttp.js
 var DEFAULT_STREAMABLE_HTTP_RECONNECTION_OPTIONS = {
   initialReconnectionDelay: 1e3,
   maxReconnectionDelay: 3e4,
@@ -53517,8 +53782,8 @@ var StreamableHTTPClientTransport = class {
 };
 
 // src/mcp-proxy/proxy.ts
-import * as path27 from "node:path";
-import * as crypto7 from "node:crypto";
+import * as path28 from "node:path";
+import * as crypto8 from "node:crypto";
 
 // src/mcp-proxy/cookieJar.ts
 var CookieJar = class {
@@ -53699,9 +53964,9 @@ function createCookieFetch(cookieJar) {
 }
 
 // src/core/utils/logWriter.ts
-import * as fs25 from "node:fs";
-import * as path26 from "node:path";
-import * as crypto6 from "node:crypto";
+import * as fs26 from "node:fs";
+import * as path27 from "node:path";
+import * as crypto7 from "node:crypto";
 
 // src/core/types/log.ts
 var LOG_LEVEL_PRIORITY = {
@@ -53741,7 +54006,7 @@ var LogWriter = class {
       return;
     }
     try {
-      await fs25.promises.mkdir(this.config.logDir, { recursive: true });
+      await fs26.promises.mkdir(this.config.logDir, { recursive: true });
       await this.cleanupOldLogs();
       this.initialized = true;
     } catch (error2) {
@@ -53764,7 +54029,7 @@ var LogWriter = class {
    */
   getLogFilePath(date5) {
     const d = date5 || this.getCurrentDate();
-    return path26.join(this.config.logDir, `${this.config.prefix}-${d}.log`);
+    return path27.join(this.config.logDir, `${this.config.prefix}-${d}.log`);
   }
   /**
    * 获取或创建写入流
@@ -53779,7 +54044,7 @@ var LogWriter = class {
       }
       this.currentDate = date5;
       try {
-        this.writeStream = fs25.createWriteStream(this.getLogFilePath(date5), {
+        this.writeStream = fs26.createWriteStream(this.getLogFilePath(date5), {
           flags: "a",
           encoding: "utf8"
         });
@@ -53831,11 +54096,11 @@ var LogWriter = class {
     if (this.shouldWriteToFile(level) && this.initialized && this.config.enabled) {
       try {
         const filePath = this.getLogFilePath();
-        const dir = path26.dirname(filePath);
-        if (!fs25.existsSync(dir)) {
-          fs25.mkdirSync(dir, { recursive: true });
+        const dir = path27.dirname(filePath);
+        if (!fs26.existsSync(dir)) {
+          fs26.mkdirSync(dir, { recursive: true });
         }
-        fs25.appendFileSync(filePath, message, "utf8");
+        fs26.appendFileSync(filePath, message, "utf8");
       } catch {
       }
     }
@@ -53846,7 +54111,7 @@ var LogWriter = class {
   async cleanupOldLogs() {
     if (this.config.maxDays <= 0) return;
     try {
-      const files = await fs25.promises.readdir(this.config.logDir);
+      const files = await fs26.promises.readdir(this.config.logDir);
       const cutoffDate = /* @__PURE__ */ new Date();
       cutoffDate.setDate(cutoffDate.getDate() - this.config.maxDays);
       const prefix = this.config.prefix;
@@ -53861,7 +54126,7 @@ var LogWriter = class {
           if (!Number.isNaN(year) && !Number.isNaN(month) && !Number.isNaN(day)) {
             const fileDate = new Date(year, month - 1, day);
             if (fileDate < cutoffDate) {
-              await fs25.promises.unlink(path26.join(this.config.logDir, file2));
+              await fs26.promises.unlink(path27.join(this.config.logDir, file2));
               process.stderr.write(`[LogWriter] Deleted old log: ${file2}
 `);
             }
@@ -53905,7 +54170,7 @@ function convertMcpApplicationErrorToToolResult(error2) {
     return void 0;
   }
   const data = error2.data;
-  if (!isRecord6(data) || !("remote_result" in data) || data.remote_result === void 0) {
+  if (!isRecord7(data) || !("remote_result" in data) || data.remote_result === void 0) {
     return void 0;
   }
   return {
@@ -53922,7 +54187,7 @@ function convertMcpApplicationErrorToToolResult(error2) {
     ]
   };
 }
-function isRecord6(value) {
+function isRecord7(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 function formatProxyDiagnosticValue(value) {
@@ -53982,10 +54247,10 @@ var TapTapMCPProxy = class {
     const { user_id, project_id } = this.config.tenant;
     let logDir;
     if (user_id && project_id) {
-      logDir = path27.join(logRoot, "proxy", user_id, project_id);
+      logDir = path28.join(logRoot, "proxy", user_id, project_id);
     } else {
-      const kidHash = crypto7.createHash("sha256").update(this.config.auth.kid).digest("hex").substring(0, 8);
-      logDir = path27.join(logRoot, "proxy", kidHash);
+      const kidHash = crypto8.createHash("sha256").update(this.config.auth.kid).digest("hex").substring(0, 8);
+      logDir = path28.join(logRoot, "proxy", kidHash);
     }
     return new LogWriter({
       logDir,

--- a/plugins/workbuddy/taptap-maker/dist/maker.js
+++ b/plugins/workbuddy/taptap-maker/dist/maker.js
@@ -41,9 +41,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/code.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/code.js
 var require_code = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/code.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/code.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.regexpCode = exports.getEsmExportName = exports.getProperty = exports.safeStringify = exports.stringify = exports.strConcat = exports.addCodeArg = exports.str = exports._ = exports.nil = exports._Code = exports.Name = exports.IDENTIFIER = exports._CodeOrName = void 0;
@@ -195,9 +195,9 @@ var require_code = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/scope.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/scope.js
 var require_scope = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/scope.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/scope.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.ValueScope = exports.ValueScopeName = exports.Scope = exports.varKinds = exports.UsedValueState = void 0;
@@ -340,9 +340,9 @@ var require_scope = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/index.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/index.js
 var require_codegen = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/index.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.or = exports.and = exports.not = exports.CodeGen = exports.operators = exports.varKinds = exports.ValueScopeName = exports.ValueScope = exports.Scope = exports.Name = exports.regexpCode = exports.stringify = exports.getProperty = exports.nil = exports.strConcat = exports.str = exports._ = void 0;
@@ -1060,9 +1060,9 @@ var require_codegen = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/util.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/util.js
 var require_util = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/util.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/util.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.checkStrictMode = exports.getErrorPath = exports.Type = exports.useFunc = exports.setEvaluated = exports.evaluatedPropsToName = exports.mergeEvaluated = exports.eachItem = exports.unescapeJsonPointer = exports.escapeJsonPointer = exports.escapeFragment = exports.unescapeFragment = exports.schemaRefOrVal = exports.schemaHasRulesButRef = exports.schemaHasRules = exports.checkUnknownRules = exports.alwaysValidSchema = exports.toHash = void 0;
@@ -1227,9 +1227,9 @@ var require_util = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/names.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/names.js
 var require_names = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/names.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/names.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -1266,9 +1266,9 @@ var require_names = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/errors.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/errors.js
 var require_errors = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/errors.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/errors.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.extendErrors = exports.resetErrorsCount = exports.reportExtraError = exports.reportError = exports.keyword$DataError = exports.keywordError = void 0;
@@ -1388,9 +1388,9 @@ var require_errors = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/boolSchema.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/boolSchema.js
 var require_boolSchema = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/boolSchema.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/boolSchema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.boolOrEmptySchema = exports.topBoolOrEmptySchema = void 0;
@@ -1439,9 +1439,9 @@ var require_boolSchema = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/rules.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/rules.js
 var require_rules = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/rules.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/rules.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getRules = exports.isJSONType = void 0;
@@ -1470,9 +1470,9 @@ var require_rules = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/applicability.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/applicability.js
 var require_applicability = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/applicability.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/applicability.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.shouldUseRule = exports.shouldUseGroup = exports.schemaHasRulesForType = void 0;
@@ -1493,9 +1493,9 @@ var require_applicability = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/dataType.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/dataType.js
 var require_dataType = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/dataType.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/dataType.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.reportTypeError = exports.checkDataTypes = exports.checkDataType = exports.coerceAndCheckDataType = exports.getJSONTypes = exports.getSchemaTypes = exports.DataType = void 0;
@@ -1677,9 +1677,9 @@ var require_dataType = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/defaults.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/defaults.js
 var require_defaults = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/defaults.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/defaults.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.assignDefaults = void 0;
@@ -1714,9 +1714,9 @@ var require_defaults = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/code.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/code.js
 var require_code2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/code.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/code.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateUnion = exports.validateArray = exports.usePattern = exports.callValidateCode = exports.schemaProperties = exports.allSchemaProperties = exports.noPropertyInData = exports.propertyInData = exports.isOwnProperty = exports.hasPropFunc = exports.reportMissingProp = exports.checkMissingProp = exports.checkReportMissingProp = void 0;
@@ -1847,9 +1847,9 @@ var require_code2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/keyword.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/keyword.js
 var require_keyword = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/keyword.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/keyword.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateKeywordUsage = exports.validSchemaType = exports.funcKeywordCode = exports.macroKeywordCode = void 0;
@@ -1965,9 +1965,9 @@ var require_keyword = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/subschema.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/subschema.js
 var require_subschema = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/subschema.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/subschema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.extendSubschemaMode = exports.extendSubschemaData = exports.getSubschema = void 0;
@@ -2048,9 +2048,9 @@ var require_subschema = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-deep-equal/index.js
+// node_modules/fast-deep-equal/index.js
 var require_fast_deep_equal = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-deep-equal/index.js"(exports, module) {
+  "node_modules/fast-deep-equal/index.js"(exports, module) {
     "use strict";
     module.exports = function equal(a, b) {
       if (a === b) return true;
@@ -2083,9 +2083,9 @@ var require_fast_deep_equal = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse/index.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse/index.js
 var require_json_schema_traverse = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse/index.js"(exports, module) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse/index.js"(exports, module) {
     "use strict";
     var traverse = module.exports = function(schema, opts, cb) {
       if (typeof opts == "function") {
@@ -2171,9 +2171,9 @@ var require_json_schema_traverse = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/resolve.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/resolve.js
 var require_resolve = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/resolve.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/resolve.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getSchemaRefs = exports.resolveUrl = exports.normalizeId = exports._getFullPath = exports.getFullPath = exports.inlineRef = void 0;
@@ -2327,9 +2327,9 @@ var require_resolve = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/index.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/index.js
 var require_validate = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/index.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getData = exports.KeywordCxt = exports.validateFunctionCode = void 0;
@@ -2835,9 +2835,9 @@ var require_validate = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/validation_error.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/validation_error.js
 var require_validation_error = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/validation_error.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/validation_error.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var ValidationError = class extends Error {
@@ -2851,9 +2851,9 @@ var require_validation_error = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/ref_error.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/ref_error.js
 var require_ref_error = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/ref_error.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/ref_error.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var resolve_1 = require_resolve();
@@ -2868,9 +2868,9 @@ var require_ref_error = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/index.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/index.js
 var require_compile = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/index.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.resolveSchema = exports.getCompilingSchema = exports.resolveRef = exports.compileSchema = exports.SchemaEnv = void 0;
@@ -3092,9 +3092,9 @@ var require_compile = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/data.json
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/data.json
 var require_data = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/data.json"(exports, module) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/data.json"(exports, module) {
     module.exports = {
       $id: "https://raw.githubusercontent.com/ajv-validator/ajv/master/lib/refs/data.json#",
       description: "Meta-schema for $data reference (JSON AnySchema extension proposal)",
@@ -3111,9 +3111,9 @@ var require_data = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-uri/lib/utils.js
+// node_modules/fast-uri/lib/utils.js
 var require_utils = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-uri/lib/utils.js"(exports, module) {
+  "node_modules/fast-uri/lib/utils.js"(exports, module) {
     "use strict";
     var isUUID = RegExp.prototype.test.bind(/^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/iu);
     var isIPv4 = RegExp.prototype.test.bind(/^(?:(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)$/u);
@@ -3368,9 +3368,9 @@ var require_utils = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-uri/lib/schemes.js
+// node_modules/fast-uri/lib/schemes.js
 var require_schemes = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-uri/lib/schemes.js"(exports, module) {
+  "node_modules/fast-uri/lib/schemes.js"(exports, module) {
     "use strict";
     var { isUUID } = require_utils();
     var URN_REG = /([\da-z][\d\-a-z]{0,31}):((?:[\w!$'()*+,\-.:;=@]|%[\da-f]{2})+)/iu;
@@ -3578,9 +3578,9 @@ var require_schemes = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-uri/index.js
+// node_modules/fast-uri/index.js
 var require_fast_uri = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-uri/index.js"(exports, module) {
+  "node_modules/fast-uri/index.js"(exports, module) {
     "use strict";
     var { normalizeIPv6, removeDotSegments, recomposeAuthority, normalizeComponentEncoding, isIPv4, nonSimpleDomain } = require_utils();
     var { SCHEMES, getSchemeHandler } = require_schemes();
@@ -3833,9 +3833,9 @@ var require_fast_uri = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/uri.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/uri.js
 var require_uri = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/uri.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/uri.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var uri = require_fast_uri();
@@ -3844,9 +3844,9 @@ var require_uri = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/core.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/core.js
 var require_core = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/core.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/core.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = void 0;
@@ -4455,9 +4455,9 @@ var require_core = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/id.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/id.js
 var require_id = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/id.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/id.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var def = {
@@ -4470,9 +4470,9 @@ var require_id = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/ref.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/ref.js
 var require_ref = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/ref.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/ref.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.callRef = exports.getValidate = void 0;
@@ -4592,9 +4592,9 @@ var require_ref = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/index.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/index.js
 var require_core2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/index.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var id_1 = require_id();
@@ -4613,9 +4613,9 @@ var require_core2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitNumber.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitNumber.js
 var require_limitNumber = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitNumber.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitNumber.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4645,9 +4645,9 @@ var require_limitNumber = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/multipleOf.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/multipleOf.js
 var require_multipleOf = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/multipleOf.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/multipleOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4673,9 +4673,9 @@ var require_multipleOf = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/ucs2length.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/ucs2length.js
 var require_ucs2length = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/ucs2length.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/ucs2length.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     function ucs2length(str) {
@@ -4699,9 +4699,9 @@ var require_ucs2length = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitLength.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitLength.js
 var require_limitLength = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitLength.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitLength.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4731,9 +4731,9 @@ var require_limitLength = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/pattern.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/pattern.js
 var require_pattern = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/pattern.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/pattern.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -4768,9 +4768,9 @@ var require_pattern = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitProperties.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitProperties.js
 var require_limitProperties = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitProperties.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4797,9 +4797,9 @@ var require_limitProperties = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/required.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/required.js
 var require_required = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/required.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/required.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -4879,9 +4879,9 @@ var require_required = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitItems.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitItems.js
 var require_limitItems = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitItems.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4908,9 +4908,9 @@ var require_limitItems = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/equal.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/equal.js
 var require_equal = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/equal.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/equal.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var equal = require_fast_deep_equal();
@@ -4919,9 +4919,9 @@ var require_equal = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js
 var require_uniqueItems = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var dataType_1 = require_dataType();
@@ -4986,9 +4986,9 @@ var require_uniqueItems = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/const.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/const.js
 var require_const = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/const.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/const.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5015,9 +5015,9 @@ var require_const = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/enum.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/enum.js
 var require_enum = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/enum.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/enum.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5064,9 +5064,9 @@ var require_enum = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/index.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/index.js
 var require_validation = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/index.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var limitNumber_1 = require_limitNumber();
@@ -5102,9 +5102,9 @@ var require_validation = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js
 var require_additionalItems = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateAdditionalItems = void 0;
@@ -5155,9 +5155,9 @@ var require_additionalItems = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items.js
 var require_items = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateTuple = void 0;
@@ -5212,9 +5212,9 @@ var require_items = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js
 var require_prefixItems = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var items_1 = require_items();
@@ -5229,9 +5229,9 @@ var require_prefixItems = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items2020.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items2020.js
 var require_items2020 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items2020.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items2020.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5264,9 +5264,9 @@ var require_items2020 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/contains.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/contains.js
 var require_contains = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/contains.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/contains.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5358,9 +5358,9 @@ var require_contains = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/dependencies.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/dependencies.js
 var require_dependencies = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/dependencies.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/dependencies.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateSchemaDeps = exports.validatePropertyDeps = exports.error = void 0;
@@ -5452,9 +5452,9 @@ var require_dependencies = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js
 var require_propertyNames = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5495,9 +5495,9 @@ var require_propertyNames = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js
 var require_additionalProperties = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -5601,9 +5601,9 @@ var require_additionalProperties = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/properties.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/properties.js
 var require_properties = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/properties.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/properties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var validate_1 = require_validate();
@@ -5659,9 +5659,9 @@ var require_properties = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js
 var require_patternProperties = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -5733,9 +5733,9 @@ var require_patternProperties = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/not.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/not.js
 var require_not = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/not.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/not.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util();
@@ -5764,9 +5764,9 @@ var require_not = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/anyOf.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/anyOf.js
 var require_anyOf = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/anyOf.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/anyOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -5781,9 +5781,9 @@ var require_anyOf = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/oneOf.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/oneOf.js
 var require_oneOf = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/oneOf.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/oneOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5839,9 +5839,9 @@ var require_oneOf = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/allOf.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/allOf.js
 var require_allOf = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/allOf.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/allOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util();
@@ -5866,9 +5866,9 @@ var require_allOf = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/if.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/if.js
 var require_if = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/if.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/if.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5935,9 +5935,9 @@ var require_if = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/thenElse.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/thenElse.js
 var require_thenElse = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/thenElse.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/thenElse.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util();
@@ -5953,9 +5953,9 @@ var require_thenElse = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/index.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/index.js
 var require_applicator = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/index.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var additionalItems_1 = require_additionalItems();
@@ -6001,9 +6001,9 @@ var require_applicator = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/format.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/format.js
 var require_format = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/format.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/format.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -6091,9 +6091,9 @@ var require_format = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/index.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/index.js
 var require_format2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/index.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var format_1 = require_format();
@@ -6102,9 +6102,9 @@ var require_format2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/metadata.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/metadata.js
 var require_metadata = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/metadata.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/metadata.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.contentVocabulary = exports.metadataVocabulary = void 0;
@@ -6125,9 +6125,9 @@ var require_metadata = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/draft7.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/draft7.js
 var require_draft7 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/draft7.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/draft7.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var core_1 = require_core2();
@@ -6147,9 +6147,9 @@ var require_draft7 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/types.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/types.js
 var require_types = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/types.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/types.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.DiscrError = void 0;
@@ -6161,9 +6161,9 @@ var require_types = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/index.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/index.js
 var require_discriminator = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/index.js"(exports) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -6266,9 +6266,9 @@ var require_discriminator = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/json-schema-draft-07.json
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/json-schema-draft-07.json
 var require_json_schema_draft_07 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/json-schema-draft-07.json"(exports, module) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/json-schema-draft-07.json"(exports, module) {
     module.exports = {
       $schema: "http://json-schema.org/draft-07/schema#",
       $id: "http://json-schema.org/draft-07/schema#",
@@ -6423,9 +6423,9 @@ var require_json_schema_draft_07 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/ajv.js
+// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/ajv.js
 var require_ajv = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/ajv.js"(exports, module) {
+  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/ajv.js"(exports, module) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.MissingRefError = exports.ValidationError = exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = exports.Ajv = void 0;
@@ -6493,9 +6493,9 @@ var require_ajv = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/dist/formats.js
+// node_modules/ajv-formats/dist/formats.js
 var require_formats = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/dist/formats.js"(exports) {
+  "node_modules/ajv-formats/dist/formats.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.formatNames = exports.fastFormats = exports.fullFormats = void 0;
@@ -6696,9 +6696,9 @@ var require_formats = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/code.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/code.js
 var require_code3 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/code.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/code.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.regexpCode = exports.getEsmExportName = exports.getProperty = exports.safeStringify = exports.stringify = exports.strConcat = exports.addCodeArg = exports.str = exports._ = exports.nil = exports._Code = exports.Name = exports.IDENTIFIER = exports._CodeOrName = void 0;
@@ -6850,9 +6850,9 @@ var require_code3 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/scope.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/scope.js
 var require_scope2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/scope.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/scope.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.ValueScope = exports.ValueScopeName = exports.Scope = exports.varKinds = exports.UsedValueState = void 0;
@@ -6995,9 +6995,9 @@ var require_scope2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/index.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/index.js
 var require_codegen2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/index.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.or = exports.and = exports.not = exports.CodeGen = exports.operators = exports.varKinds = exports.ValueScopeName = exports.ValueScope = exports.Scope = exports.Name = exports.regexpCode = exports.stringify = exports.getProperty = exports.nil = exports.strConcat = exports.str = exports._ = void 0;
@@ -7715,9 +7715,9 @@ var require_codegen2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/util.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/util.js
 var require_util2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/util.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/util.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.checkStrictMode = exports.getErrorPath = exports.Type = exports.useFunc = exports.setEvaluated = exports.evaluatedPropsToName = exports.mergeEvaluated = exports.eachItem = exports.unescapeJsonPointer = exports.escapeJsonPointer = exports.escapeFragment = exports.unescapeFragment = exports.schemaRefOrVal = exports.schemaHasRulesButRef = exports.schemaHasRules = exports.checkUnknownRules = exports.alwaysValidSchema = exports.toHash = void 0;
@@ -7882,9 +7882,9 @@ var require_util2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/names.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/names.js
 var require_names2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/names.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/names.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -7921,9 +7921,9 @@ var require_names2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/errors.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/errors.js
 var require_errors2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/errors.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/errors.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.extendErrors = exports.resetErrorsCount = exports.reportExtraError = exports.reportError = exports.keyword$DataError = exports.keywordError = void 0;
@@ -8043,9 +8043,9 @@ var require_errors2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/boolSchema.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/boolSchema.js
 var require_boolSchema2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/boolSchema.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/boolSchema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.boolOrEmptySchema = exports.topBoolOrEmptySchema = void 0;
@@ -8094,9 +8094,9 @@ var require_boolSchema2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/rules.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/rules.js
 var require_rules2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/rules.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/rules.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getRules = exports.isJSONType = void 0;
@@ -8125,9 +8125,9 @@ var require_rules2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/applicability.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/applicability.js
 var require_applicability2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/applicability.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/applicability.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.shouldUseRule = exports.shouldUseGroup = exports.schemaHasRulesForType = void 0;
@@ -8148,9 +8148,9 @@ var require_applicability2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/dataType.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/dataType.js
 var require_dataType2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/dataType.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/dataType.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.reportTypeError = exports.checkDataTypes = exports.checkDataType = exports.coerceAndCheckDataType = exports.getJSONTypes = exports.getSchemaTypes = exports.DataType = void 0;
@@ -8332,9 +8332,9 @@ var require_dataType2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/defaults.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/defaults.js
 var require_defaults2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/defaults.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/defaults.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.assignDefaults = void 0;
@@ -8369,9 +8369,9 @@ var require_defaults2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/code.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/code.js
 var require_code4 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/code.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/code.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateUnion = exports.validateArray = exports.usePattern = exports.callValidateCode = exports.schemaProperties = exports.allSchemaProperties = exports.noPropertyInData = exports.propertyInData = exports.isOwnProperty = exports.hasPropFunc = exports.reportMissingProp = exports.checkMissingProp = exports.checkReportMissingProp = void 0;
@@ -8502,9 +8502,9 @@ var require_code4 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/keyword.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/keyword.js
 var require_keyword2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/keyword.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/keyword.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateKeywordUsage = exports.validSchemaType = exports.funcKeywordCode = exports.macroKeywordCode = void 0;
@@ -8620,9 +8620,9 @@ var require_keyword2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/subschema.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/subschema.js
 var require_subschema2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/subschema.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/subschema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.extendSubschemaMode = exports.extendSubschemaData = exports.getSubschema = void 0;
@@ -8703,9 +8703,9 @@ var require_subschema2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/json-schema-traverse/index.js
+// node_modules/ajv-formats/node_modules/json-schema-traverse/index.js
 var require_json_schema_traverse2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/json-schema-traverse/index.js"(exports, module) {
+  "node_modules/ajv-formats/node_modules/json-schema-traverse/index.js"(exports, module) {
     "use strict";
     var traverse = module.exports = function(schema, opts, cb) {
       if (typeof opts == "function") {
@@ -8791,9 +8791,9 @@ var require_json_schema_traverse2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/resolve.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/resolve.js
 var require_resolve2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/resolve.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/resolve.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getSchemaRefs = exports.resolveUrl = exports.normalizeId = exports._getFullPath = exports.getFullPath = exports.inlineRef = void 0;
@@ -8947,9 +8947,9 @@ var require_resolve2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/index.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/index.js
 var require_validate2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/index.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getData = exports.KeywordCxt = exports.validateFunctionCode = void 0;
@@ -9455,9 +9455,9 @@ var require_validate2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/validation_error.js
+// node_modules/ajv-formats/node_modules/ajv/dist/runtime/validation_error.js
 var require_validation_error2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/validation_error.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/runtime/validation_error.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var ValidationError = class extends Error {
@@ -9471,9 +9471,9 @@ var require_validation_error2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/ref_error.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/ref_error.js
 var require_ref_error2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/ref_error.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/ref_error.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var resolve_1 = require_resolve2();
@@ -9488,9 +9488,9 @@ var require_ref_error2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/index.js
+// node_modules/ajv-formats/node_modules/ajv/dist/compile/index.js
 var require_compile2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/index.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/compile/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.resolveSchema = exports.getCompilingSchema = exports.resolveRef = exports.compileSchema = exports.SchemaEnv = void 0;
@@ -9712,9 +9712,9 @@ var require_compile2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/refs/data.json
+// node_modules/ajv-formats/node_modules/ajv/dist/refs/data.json
 var require_data2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/refs/data.json"(exports, module) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/refs/data.json"(exports, module) {
     module.exports = {
       $id: "https://raw.githubusercontent.com/ajv-validator/ajv/master/lib/refs/data.json#",
       description: "Meta-schema for $data reference (JSON AnySchema extension proposal)",
@@ -9731,9 +9731,9 @@ var require_data2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/uri.js
+// node_modules/ajv-formats/node_modules/ajv/dist/runtime/uri.js
 var require_uri2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/uri.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/runtime/uri.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var uri = require_fast_uri();
@@ -9742,9 +9742,9 @@ var require_uri2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/core.js
+// node_modules/ajv-formats/node_modules/ajv/dist/core.js
 var require_core3 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/core.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/core.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = void 0;
@@ -10353,9 +10353,9 @@ var require_core3 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/id.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/id.js
 var require_id2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/id.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/id.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var def = {
@@ -10368,9 +10368,9 @@ var require_id2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/ref.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/ref.js
 var require_ref2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/ref.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/ref.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.callRef = exports.getValidate = void 0;
@@ -10490,9 +10490,9 @@ var require_ref2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/index.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/index.js
 var require_core4 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/index.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var id_1 = require_id2();
@@ -10511,9 +10511,9 @@ var require_core4 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitNumber.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitNumber.js
 var require_limitNumber2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitNumber.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitNumber.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -10543,9 +10543,9 @@ var require_limitNumber2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/multipleOf.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/multipleOf.js
 var require_multipleOf2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/multipleOf.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/multipleOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -10571,9 +10571,9 @@ var require_multipleOf2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/ucs2length.js
+// node_modules/ajv-formats/node_modules/ajv/dist/runtime/ucs2length.js
 var require_ucs2length2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/ucs2length.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/runtime/ucs2length.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     function ucs2length(str) {
@@ -10597,9 +10597,9 @@ var require_ucs2length2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitLength.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitLength.js
 var require_limitLength2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitLength.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitLength.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -10629,9 +10629,9 @@ var require_limitLength2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/pattern.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/pattern.js
 var require_pattern2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/pattern.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/pattern.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code4();
@@ -10666,9 +10666,9 @@ var require_pattern2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitProperties.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitProperties.js
 var require_limitProperties2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitProperties.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -10695,9 +10695,9 @@ var require_limitProperties2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/required.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/required.js
 var require_required2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/required.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/required.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code4();
@@ -10777,9 +10777,9 @@ var require_required2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitItems.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitItems.js
 var require_limitItems2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitItems.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -10806,9 +10806,9 @@ var require_limitItems2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/equal.js
+// node_modules/ajv-formats/node_modules/ajv/dist/runtime/equal.js
 var require_equal2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/equal.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/runtime/equal.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var equal = require_fast_deep_equal();
@@ -10817,9 +10817,9 @@ var require_equal2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js
 var require_uniqueItems2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var dataType_1 = require_dataType2();
@@ -10884,9 +10884,9 @@ var require_uniqueItems2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/const.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/const.js
 var require_const2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/const.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/const.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -10913,9 +10913,9 @@ var require_const2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/enum.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/enum.js
 var require_enum2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/enum.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/enum.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -10962,9 +10962,9 @@ var require_enum2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/index.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/index.js
 var require_validation2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/index.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var limitNumber_1 = require_limitNumber2();
@@ -11000,9 +11000,9 @@ var require_validation2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js
 var require_additionalItems2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateAdditionalItems = void 0;
@@ -11053,9 +11053,9 @@ var require_additionalItems2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items.js
 var require_items2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateTuple = void 0;
@@ -11110,9 +11110,9 @@ var require_items2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js
 var require_prefixItems2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var items_1 = require_items2();
@@ -11127,9 +11127,9 @@ var require_prefixItems2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items2020.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items2020.js
 var require_items20202 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items2020.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items2020.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -11162,9 +11162,9 @@ var require_items20202 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/contains.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/contains.js
 var require_contains2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/contains.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/contains.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -11256,9 +11256,9 @@ var require_contains2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/dependencies.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/dependencies.js
 var require_dependencies2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/dependencies.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/dependencies.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateSchemaDeps = exports.validatePropertyDeps = exports.error = void 0;
@@ -11350,9 +11350,9 @@ var require_dependencies2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js
 var require_propertyNames2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -11393,9 +11393,9 @@ var require_propertyNames2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js
 var require_additionalProperties2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code4();
@@ -11499,9 +11499,9 @@ var require_additionalProperties2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/properties.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/properties.js
 var require_properties2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/properties.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/properties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var validate_1 = require_validate2();
@@ -11557,9 +11557,9 @@ var require_properties2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js
 var require_patternProperties2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code4();
@@ -11631,9 +11631,9 @@ var require_patternProperties2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/not.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/not.js
 var require_not2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/not.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/not.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util2();
@@ -11662,9 +11662,9 @@ var require_not2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/anyOf.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/anyOf.js
 var require_anyOf2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/anyOf.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/anyOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code4();
@@ -11679,9 +11679,9 @@ var require_anyOf2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/oneOf.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/oneOf.js
 var require_oneOf2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/oneOf.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/oneOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -11737,9 +11737,9 @@ var require_oneOf2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/allOf.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/allOf.js
 var require_allOf2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/allOf.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/allOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util2();
@@ -11764,9 +11764,9 @@ var require_allOf2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/if.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/if.js
 var require_if2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/if.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/if.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -11833,9 +11833,9 @@ var require_if2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/thenElse.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/thenElse.js
 var require_thenElse2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/thenElse.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/thenElse.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util2();
@@ -11851,9 +11851,9 @@ var require_thenElse2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/index.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/index.js
 var require_applicator2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/index.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var additionalItems_1 = require_additionalItems2();
@@ -11899,9 +11899,9 @@ var require_applicator2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/format.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/format.js
 var require_format3 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/format.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/format.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -11989,9 +11989,9 @@ var require_format3 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/index.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/index.js
 var require_format4 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/index.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var format_1 = require_format3();
@@ -12000,9 +12000,9 @@ var require_format4 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/metadata.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/metadata.js
 var require_metadata2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/metadata.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/metadata.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.contentVocabulary = exports.metadataVocabulary = void 0;
@@ -12023,9 +12023,9 @@ var require_metadata2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/draft7.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/draft7.js
 var require_draft72 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/draft7.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/draft7.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var core_1 = require_core4();
@@ -12045,9 +12045,9 @@ var require_draft72 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/types.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/types.js
 var require_types2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/types.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/types.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.DiscrError = void 0;
@@ -12059,9 +12059,9 @@ var require_types2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/index.js
+// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/index.js
 var require_discriminator2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/index.js"(exports) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -12164,9 +12164,9 @@ var require_discriminator2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/refs/json-schema-draft-07.json
+// node_modules/ajv-formats/node_modules/ajv/dist/refs/json-schema-draft-07.json
 var require_json_schema_draft_072 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/refs/json-schema-draft-07.json"(exports, module) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/refs/json-schema-draft-07.json"(exports, module) {
     module.exports = {
       $schema: "http://json-schema.org/draft-07/schema#",
       $id: "http://json-schema.org/draft-07/schema#",
@@ -12321,9 +12321,9 @@ var require_json_schema_draft_072 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/ajv.js
+// node_modules/ajv-formats/node_modules/ajv/dist/ajv.js
 var require_ajv2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/ajv.js"(exports, module) {
+  "node_modules/ajv-formats/node_modules/ajv/dist/ajv.js"(exports, module) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.MissingRefError = exports.ValidationError = exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = exports.Ajv = void 0;
@@ -12391,9 +12391,9 @@ var require_ajv2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/dist/limit.js
+// node_modules/ajv-formats/dist/limit.js
 var require_limit = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/dist/limit.js"(exports) {
+  "node_modules/ajv-formats/dist/limit.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.formatLimitDefinition = void 0;
@@ -12463,9 +12463,9 @@ var require_limit = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/dist/index.js
+// node_modules/ajv-formats/dist/index.js
 var require_dist = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/dist/index.js"(exports, module) {
+  "node_modules/ajv-formats/dist/index.js"(exports, module) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var formats_1 = require_formats();
@@ -12505,9 +12505,9 @@ var require_dist = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/isexe/windows.js
+// node_modules/isexe/windows.js
 var require_windows = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/isexe/windows.js"(exports, module) {
+  "node_modules/isexe/windows.js"(exports, module) {
     module.exports = isexe;
     isexe.sync = sync;
     var fs27 = __require("fs");
@@ -12545,9 +12545,9 @@ var require_windows = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/isexe/mode.js
+// node_modules/isexe/mode.js
 var require_mode = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/isexe/mode.js"(exports, module) {
+  "node_modules/isexe/mode.js"(exports, module) {
     module.exports = isexe;
     isexe.sync = sync;
     var fs27 = __require("fs");
@@ -12578,9 +12578,9 @@ var require_mode = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/isexe/index.js
+// node_modules/isexe/index.js
 var require_isexe = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/isexe/index.js"(exports, module) {
+  "node_modules/isexe/index.js"(exports, module) {
     var fs27 = __require("fs");
     var core;
     if (process.platform === "win32" || global.TESTING_WINDOWS) {
@@ -12633,9 +12633,9 @@ var require_isexe = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/which/which.js
+// node_modules/which/which.js
 var require_which = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/which/which.js"(exports, module) {
+  "node_modules/which/which.js"(exports, module) {
     var isWindows = process.platform === "win32" || process.env.OSTYPE === "cygwin" || process.env.OSTYPE === "msys";
     var path29 = __require("path");
     var COLON = isWindows ? ";" : ":";
@@ -12729,9 +12729,9 @@ var require_which = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/path-key/index.js
+// node_modules/path-key/index.js
 var require_path_key = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/path-key/index.js"(exports, module) {
+  "node_modules/path-key/index.js"(exports, module) {
     "use strict";
     var pathKey = (options = {}) => {
       const environment = options.env || process.env;
@@ -12746,9 +12746,9 @@ var require_path_key = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/util/resolveCommand.js
+// node_modules/cross-spawn/lib/util/resolveCommand.js
 var require_resolveCommand = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/util/resolveCommand.js"(exports, module) {
+  "node_modules/cross-spawn/lib/util/resolveCommand.js"(exports, module) {
     "use strict";
     var path29 = __require("path");
     var which = require_which();
@@ -12788,9 +12788,9 @@ var require_resolveCommand = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/util/escape.js
+// node_modules/cross-spawn/lib/util/escape.js
 var require_escape = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/util/escape.js"(exports, module) {
+  "node_modules/cross-spawn/lib/util/escape.js"(exports, module) {
     "use strict";
     var metaCharsRegExp = /([()\][%!^"`<>&|;, *?])/g;
     function escapeCommand(arg) {
@@ -12813,17 +12813,17 @@ var require_escape = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/shebang-regex/index.js
+// node_modules/shebang-regex/index.js
 var require_shebang_regex = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/shebang-regex/index.js"(exports, module) {
+  "node_modules/shebang-regex/index.js"(exports, module) {
     "use strict";
     module.exports = /^#!(.*)/;
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/shebang-command/index.js
+// node_modules/shebang-command/index.js
 var require_shebang_command = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/shebang-command/index.js"(exports, module) {
+  "node_modules/shebang-command/index.js"(exports, module) {
     "use strict";
     var shebangRegex = require_shebang_regex();
     module.exports = (string4 = "") => {
@@ -12841,9 +12841,9 @@ var require_shebang_command = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/util/readShebang.js
+// node_modules/cross-spawn/lib/util/readShebang.js
 var require_readShebang = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/util/readShebang.js"(exports, module) {
+  "node_modules/cross-spawn/lib/util/readShebang.js"(exports, module) {
     "use strict";
     var fs27 = __require("fs");
     var shebangCommand = require_shebang_command();
@@ -12863,9 +12863,9 @@ var require_readShebang = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/parse.js
+// node_modules/cross-spawn/lib/parse.js
 var require_parse = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/parse.js"(exports, module) {
+  "node_modules/cross-spawn/lib/parse.js"(exports, module) {
     "use strict";
     var path29 = __require("path");
     var resolveCommand = require_resolveCommand();
@@ -12925,9 +12925,9 @@ var require_parse = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/enoent.js
+// node_modules/cross-spawn/lib/enoent.js
 var require_enoent = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/enoent.js"(exports, module) {
+  "node_modules/cross-spawn/lib/enoent.js"(exports, module) {
     "use strict";
     var isWin = process.platform === "win32";
     function notFoundError(original, syscall) {
@@ -12975,9 +12975,9 @@ var require_enoent = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/index.js
+// node_modules/cross-spawn/index.js
 var require_cross_spawn = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/index.js"(exports, module) {
+  "node_modules/cross-spawn/index.js"(exports, module) {
     "use strict";
     var cp = __require("child_process");
     var parse3 = require_parse();
@@ -13002,9 +13002,9 @@ var require_cross_spawn = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/identity.js
+// node_modules/yaml/dist/nodes/identity.js
 var require_identity = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/identity.js"(exports) {
+  "node_modules/yaml/dist/nodes/identity.js"(exports) {
     "use strict";
     var ALIAS = Symbol.for("yaml.alias");
     var DOC = Symbol.for("yaml.document");
@@ -13059,9 +13059,9 @@ var require_identity = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/visit.js
+// node_modules/yaml/dist/visit.js
 var require_visit = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/visit.js"(exports) {
+  "node_modules/yaml/dist/visit.js"(exports) {
     "use strict";
     var identity = require_identity();
     var BREAK = Symbol("break visit");
@@ -13218,9 +13218,9 @@ var require_visit = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/directives.js
+// node_modules/yaml/dist/doc/directives.js
 var require_directives = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/directives.js"(exports) {
+  "node_modules/yaml/dist/doc/directives.js"(exports) {
     "use strict";
     var identity = require_identity();
     var visit = require_visit();
@@ -13389,9 +13389,9 @@ var require_directives = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/anchors.js
+// node_modules/yaml/dist/doc/anchors.js
 var require_anchors = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/anchors.js"(exports) {
+  "node_modules/yaml/dist/doc/anchors.js"(exports) {
     "use strict";
     var identity = require_identity();
     var visit = require_visit();
@@ -13459,9 +13459,9 @@ var require_anchors = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/applyReviver.js
+// node_modules/yaml/dist/doc/applyReviver.js
 var require_applyReviver = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/applyReviver.js"(exports) {
+  "node_modules/yaml/dist/doc/applyReviver.js"(exports) {
     "use strict";
     function applyReviver(reviver, obj, key, val) {
       if (val && typeof val === "object") {
@@ -13509,9 +13509,9 @@ var require_applyReviver = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/toJS.js
+// node_modules/yaml/dist/nodes/toJS.js
 var require_toJS = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/toJS.js"(exports) {
+  "node_modules/yaml/dist/nodes/toJS.js"(exports) {
     "use strict";
     var identity = require_identity();
     function toJS(value, arg, ctx) {
@@ -13539,9 +13539,9 @@ var require_toJS = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Node.js
+// node_modules/yaml/dist/nodes/Node.js
 var require_Node = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Node.js"(exports) {
+  "node_modules/yaml/dist/nodes/Node.js"(exports) {
     "use strict";
     var applyReviver = require_applyReviver();
     var identity = require_identity();
@@ -13580,9 +13580,9 @@ var require_Node = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Alias.js
+// node_modules/yaml/dist/nodes/Alias.js
 var require_Alias = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Alias.js"(exports) {
+  "node_modules/yaml/dist/nodes/Alias.js"(exports) {
     "use strict";
     var anchors = require_anchors();
     var visit = require_visit();
@@ -13694,9 +13694,9 @@ var require_Alias = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Scalar.js
+// node_modules/yaml/dist/nodes/Scalar.js
 var require_Scalar = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Scalar.js"(exports) {
+  "node_modules/yaml/dist/nodes/Scalar.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Node = require_Node();
@@ -13724,9 +13724,9 @@ var require_Scalar = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/createNode.js
+// node_modules/yaml/dist/doc/createNode.js
 var require_createNode = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/createNode.js"(exports) {
+  "node_modules/yaml/dist/doc/createNode.js"(exports) {
     "use strict";
     var Alias = require_Alias();
     var identity = require_identity();
@@ -13803,9 +13803,9 @@ var require_createNode = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Collection.js
+// node_modules/yaml/dist/nodes/Collection.js
 var require_Collection = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Collection.js"(exports) {
+  "node_modules/yaml/dist/nodes/Collection.js"(exports) {
     "use strict";
     var createNode = require_createNode();
     var identity = require_identity();
@@ -13946,9 +13946,9 @@ var require_Collection = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyComment.js
+// node_modules/yaml/dist/stringify/stringifyComment.js
 var require_stringifyComment = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyComment.js"(exports) {
+  "node_modules/yaml/dist/stringify/stringifyComment.js"(exports) {
     "use strict";
     var stringifyComment = (str) => str.replace(/^(?!$)(?: $)?/gm, "#");
     function indentComment(comment, indent4) {
@@ -13963,9 +13963,9 @@ var require_stringifyComment = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/foldFlowLines.js
+// node_modules/yaml/dist/stringify/foldFlowLines.js
 var require_foldFlowLines = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/foldFlowLines.js"(exports) {
+  "node_modules/yaml/dist/stringify/foldFlowLines.js"(exports) {
     "use strict";
     var FOLD_FLOW = "flow";
     var FOLD_BLOCK = "block";
@@ -14099,9 +14099,9 @@ ${indent4}${text.slice(fold + 1, end2)}`;
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyString.js
+// node_modules/yaml/dist/stringify/stringifyString.js
 var require_stringifyString = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyString.js"(exports) {
+  "node_modules/yaml/dist/stringify/stringifyString.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var foldFlowLines = require_foldFlowLines();
@@ -14385,9 +14385,9 @@ ${indent4}`);
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringify.js
+// node_modules/yaml/dist/stringify/stringify.js
 var require_stringify = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringify.js"(exports) {
+  "node_modules/yaml/dist/stringify/stringify.js"(exports) {
     "use strict";
     var anchors = require_anchors();
     var identity = require_identity();
@@ -14513,9 +14513,9 @@ ${ctx.indent}${str}`;
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyPair.js
+// node_modules/yaml/dist/stringify/stringifyPair.js
 var require_stringifyPair = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyPair.js"(exports) {
+  "node_modules/yaml/dist/stringify/stringifyPair.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -14646,9 +14646,9 @@ ${ctx.indent}`;
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/log.js
+// node_modules/yaml/dist/log.js
 var require_log = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/log.js"(exports) {
+  "node_modules/yaml/dist/log.js"(exports) {
     "use strict";
     var node_process = __require("process");
     function debug(logLevel, ...messages) {
@@ -14668,9 +14668,9 @@ var require_log = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/merge.js
+// node_modules/yaml/dist/schema/yaml-1.1/merge.js
 var require_merge = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/merge.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/merge.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -14725,9 +14725,9 @@ var require_merge = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/addPairToJSMap.js
+// node_modules/yaml/dist/nodes/addPairToJSMap.js
 var require_addPairToJSMap = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/addPairToJSMap.js"(exports) {
+  "node_modules/yaml/dist/nodes/addPairToJSMap.js"(exports) {
     "use strict";
     var log = require_log();
     var merge2 = require_merge();
@@ -14789,9 +14789,9 @@ var require_addPairToJSMap = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Pair.js
+// node_modules/yaml/dist/nodes/Pair.js
 var require_Pair = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Pair.js"(exports) {
+  "node_modules/yaml/dist/nodes/Pair.js"(exports) {
     "use strict";
     var createNode = require_createNode();
     var stringifyPair = require_stringifyPair();
@@ -14829,9 +14829,9 @@ var require_Pair = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyCollection.js
+// node_modules/yaml/dist/stringify/stringifyCollection.js
 var require_stringifyCollection = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyCollection.js"(exports) {
+  "node_modules/yaml/dist/stringify/stringifyCollection.js"(exports) {
     "use strict";
     var identity = require_identity();
     var stringify = require_stringify();
@@ -14973,9 +14973,9 @@ ${indent4}${end}`;
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/YAMLMap.js
+// node_modules/yaml/dist/nodes/YAMLMap.js
 var require_YAMLMap = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/YAMLMap.js"(exports) {
+  "node_modules/yaml/dist/nodes/YAMLMap.js"(exports) {
     "use strict";
     var stringifyCollection = require_stringifyCollection();
     var addPairToJSMap = require_addPairToJSMap();
@@ -15118,9 +15118,9 @@ var require_YAMLMap = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/map.js
+// node_modules/yaml/dist/schema/common/map.js
 var require_map = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/map.js"(exports) {
+  "node_modules/yaml/dist/schema/common/map.js"(exports) {
     "use strict";
     var identity = require_identity();
     var YAMLMap = require_YAMLMap();
@@ -15140,9 +15140,9 @@ var require_map = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/YAMLSeq.js
+// node_modules/yaml/dist/nodes/YAMLSeq.js
 var require_YAMLSeq = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/YAMLSeq.js"(exports) {
+  "node_modules/yaml/dist/nodes/YAMLSeq.js"(exports) {
     "use strict";
     var createNode = require_createNode();
     var stringifyCollection = require_stringifyCollection();
@@ -15256,9 +15256,9 @@ var require_YAMLSeq = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/seq.js
+// node_modules/yaml/dist/schema/common/seq.js
 var require_seq = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/seq.js"(exports) {
+  "node_modules/yaml/dist/schema/common/seq.js"(exports) {
     "use strict";
     var identity = require_identity();
     var YAMLSeq = require_YAMLSeq();
@@ -15278,9 +15278,9 @@ var require_seq = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/string.js
+// node_modules/yaml/dist/schema/common/string.js
 var require_string = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/string.js"(exports) {
+  "node_modules/yaml/dist/schema/common/string.js"(exports) {
     "use strict";
     var stringifyString = require_stringifyString();
     var string4 = {
@@ -15297,9 +15297,9 @@ var require_string = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/null.js
+// node_modules/yaml/dist/schema/common/null.js
 var require_null = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/null.js"(exports) {
+  "node_modules/yaml/dist/schema/common/null.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var nullTag = {
@@ -15315,9 +15315,9 @@ var require_null = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/bool.js
+// node_modules/yaml/dist/schema/core/bool.js
 var require_bool = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/bool.js"(exports) {
+  "node_modules/yaml/dist/schema/core/bool.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var boolTag = {
@@ -15339,9 +15339,9 @@ var require_bool = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyNumber.js
+// node_modules/yaml/dist/stringify/stringifyNumber.js
 var require_stringifyNumber = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyNumber.js"(exports) {
+  "node_modules/yaml/dist/stringify/stringifyNumber.js"(exports) {
     "use strict";
     function stringifyNumber({ format, minFractionDigits, tag, value }) {
       if (typeof value === "bigint")
@@ -15366,9 +15366,9 @@ var require_stringifyNumber = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/float.js
+// node_modules/yaml/dist/schema/core/float.js
 var require_float = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/float.js"(exports) {
+  "node_modules/yaml/dist/schema/core/float.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var stringifyNumber = require_stringifyNumber();
@@ -15412,9 +15412,9 @@ var require_float = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/int.js
+// node_modules/yaml/dist/schema/core/int.js
 var require_int = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/int.js"(exports) {
+  "node_modules/yaml/dist/schema/core/int.js"(exports) {
     "use strict";
     var stringifyNumber = require_stringifyNumber();
     var intIdentify = (value) => typeof value === "bigint" || Number.isInteger(value);
@@ -15457,9 +15457,9 @@ var require_int = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/schema.js
+// node_modules/yaml/dist/schema/core/schema.js
 var require_schema = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/schema.js"(exports) {
+  "node_modules/yaml/dist/schema/core/schema.js"(exports) {
     "use strict";
     var map2 = require_map();
     var _null4 = require_null();
@@ -15485,9 +15485,9 @@ var require_schema = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/json/schema.js
+// node_modules/yaml/dist/schema/json/schema.js
 var require_schema2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/json/schema.js"(exports) {
+  "node_modules/yaml/dist/schema/json/schema.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var map2 = require_map();
@@ -15552,9 +15552,9 @@ var require_schema2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/binary.js
+// node_modules/yaml/dist/schema/yaml-1.1/binary.js
 var require_binary = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/binary.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/binary.js"(exports) {
     "use strict";
     var node_buffer = __require("buffer");
     var Scalar = require_Scalar();
@@ -15618,9 +15618,9 @@ var require_binary = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/pairs.js
+// node_modules/yaml/dist/schema/yaml-1.1/pairs.js
 var require_pairs = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/pairs.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/pairs.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Pair = require_Pair();
@@ -15696,9 +15696,9 @@ ${cn.comment}` : item.comment;
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/omap.js
+// node_modules/yaml/dist/schema/yaml-1.1/omap.js
 var require_omap = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/omap.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/omap.js"(exports) {
     "use strict";
     var identity = require_identity();
     var toJS = require_toJS();
@@ -15774,9 +15774,9 @@ var require_omap = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/bool.js
+// node_modules/yaml/dist/schema/yaml-1.1/bool.js
 var require_bool2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/bool.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/bool.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     function boolStringify({ value, source }, ctx) {
@@ -15806,9 +15806,9 @@ var require_bool2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/float.js
+// node_modules/yaml/dist/schema/yaml-1.1/float.js
 var require_float2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/float.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/float.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var stringifyNumber = require_stringifyNumber();
@@ -15855,9 +15855,9 @@ var require_float2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/int.js
+// node_modules/yaml/dist/schema/yaml-1.1/int.js
 var require_int2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/int.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/int.js"(exports) {
     "use strict";
     var stringifyNumber = require_stringifyNumber();
     var intIdentify = (value) => typeof value === "bigint" || Number.isInteger(value);
@@ -15934,9 +15934,9 @@ var require_int2 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/set.js
+// node_modules/yaml/dist/schema/yaml-1.1/set.js
 var require_set = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/set.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/set.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Pair = require_Pair();
@@ -16023,9 +16023,9 @@ var require_set = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/timestamp.js
+// node_modules/yaml/dist/schema/yaml-1.1/timestamp.js
 var require_timestamp = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/timestamp.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/timestamp.js"(exports) {
     "use strict";
     var stringifyNumber = require_stringifyNumber();
     function parseSexagesimal(str, asBigInt) {
@@ -16111,9 +16111,9 @@ var require_timestamp = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/schema.js
+// node_modules/yaml/dist/schema/yaml-1.1/schema.js
 var require_schema3 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/schema.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/schema.js"(exports) {
     "use strict";
     var map2 = require_map();
     var _null4 = require_null();
@@ -16155,9 +16155,9 @@ var require_schema3 = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/tags.js
+// node_modules/yaml/dist/schema/tags.js
 var require_tags = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/tags.js"(exports) {
+  "node_modules/yaml/dist/schema/tags.js"(exports) {
     "use strict";
     var map2 = require_map();
     var _null4 = require_null();
@@ -16249,9 +16249,9 @@ var require_tags = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/Schema.js
+// node_modules/yaml/dist/schema/Schema.js
 var require_Schema = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/Schema.js"(exports) {
+  "node_modules/yaml/dist/schema/Schema.js"(exports) {
     "use strict";
     var identity = require_identity();
     var map2 = require_map();
@@ -16281,9 +16281,9 @@ var require_Schema = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyDocument.js
+// node_modules/yaml/dist/stringify/stringifyDocument.js
 var require_stringifyDocument = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyDocument.js"(exports) {
+  "node_modules/yaml/dist/stringify/stringifyDocument.js"(exports) {
     "use strict";
     var identity = require_identity();
     var stringify = require_stringify();
@@ -16362,9 +16362,9 @@ var require_stringifyDocument = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/Document.js
+// node_modules/yaml/dist/doc/Document.js
 var require_Document = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/Document.js"(exports) {
+  "node_modules/yaml/dist/doc/Document.js"(exports) {
     "use strict";
     var Alias = require_Alias();
     var Collection = require_Collection();
@@ -16671,9 +16671,9 @@ var require_Document = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/errors.js
+// node_modules/yaml/dist/errors.js
 var require_errors3 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/errors.js"(exports) {
+  "node_modules/yaml/dist/errors.js"(exports) {
     "use strict";
     var YAMLError = class extends Error {
       constructor(name, pos, code, message) {
@@ -16736,9 +16736,9 @@ ${pointer}
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-props.js
+// node_modules/yaml/dist/compose/resolve-props.js
 var require_resolve_props = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-props.js"(exports) {
+  "node_modules/yaml/dist/compose/resolve-props.js"(exports) {
     "use strict";
     function resolveProps(tokens, { flow, indicator, next, offset, onError, parentIndent, startOnNewline }) {
       let spaceBefore = false;
@@ -16870,9 +16870,9 @@ var require_resolve_props = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-contains-newline.js
+// node_modules/yaml/dist/compose/util-contains-newline.js
 var require_util_contains_newline = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-contains-newline.js"(exports) {
+  "node_modules/yaml/dist/compose/util-contains-newline.js"(exports) {
     "use strict";
     function containsNewline(key) {
       if (!key)
@@ -16912,9 +16912,9 @@ var require_util_contains_newline = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-flow-indent-check.js
+// node_modules/yaml/dist/compose/util-flow-indent-check.js
 var require_util_flow_indent_check = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-flow-indent-check.js"(exports) {
+  "node_modules/yaml/dist/compose/util-flow-indent-check.js"(exports) {
     "use strict";
     var utilContainsNewline = require_util_contains_newline();
     function flowIndentCheck(indent4, fc, onError) {
@@ -16930,9 +16930,9 @@ var require_util_flow_indent_check = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-map-includes.js
+// node_modules/yaml/dist/compose/util-map-includes.js
 var require_util_map_includes = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-map-includes.js"(exports) {
+  "node_modules/yaml/dist/compose/util-map-includes.js"(exports) {
     "use strict";
     var identity = require_identity();
     function mapIncludes(ctx, items, search) {
@@ -16946,9 +16946,9 @@ var require_util_map_includes = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-block-map.js
+// node_modules/yaml/dist/compose/resolve-block-map.js
 var require_resolve_block_map = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-block-map.js"(exports) {
+  "node_modules/yaml/dist/compose/resolve-block-map.js"(exports) {
     "use strict";
     var Pair = require_Pair();
     var YAMLMap = require_YAMLMap();
@@ -17055,9 +17055,9 @@ var require_resolve_block_map = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-block-seq.js
+// node_modules/yaml/dist/compose/resolve-block-seq.js
 var require_resolve_block_seq = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-block-seq.js"(exports) {
+  "node_modules/yaml/dist/compose/resolve-block-seq.js"(exports) {
     "use strict";
     var YAMLSeq = require_YAMLSeq();
     var resolveProps = require_resolve_props();
@@ -17106,9 +17106,9 @@ var require_resolve_block_seq = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-end.js
+// node_modules/yaml/dist/compose/resolve-end.js
 var require_resolve_end = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-end.js"(exports) {
+  "node_modules/yaml/dist/compose/resolve-end.js"(exports) {
     "use strict";
     function resolveEnd(end, offset, reqSpace, onError) {
       let comment = "";
@@ -17149,9 +17149,9 @@ var require_resolve_end = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-flow-collection.js
+// node_modules/yaml/dist/compose/resolve-flow-collection.js
 var require_resolve_flow_collection = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-flow-collection.js"(exports) {
+  "node_modules/yaml/dist/compose/resolve-flow-collection.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Pair = require_Pair();
@@ -17344,9 +17344,9 @@ var require_resolve_flow_collection = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-collection.js
+// node_modules/yaml/dist/compose/compose-collection.js
 var require_compose_collection = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-collection.js"(exports) {
+  "node_modules/yaml/dist/compose/compose-collection.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -17410,9 +17410,9 @@ var require_compose_collection = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-block-scalar.js
+// node_modules/yaml/dist/compose/resolve-block-scalar.js
 var require_resolve_block_scalar = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-block-scalar.js"(exports) {
+  "node_modules/yaml/dist/compose/resolve-block-scalar.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     function resolveBlockScalar(ctx, scalar, onError) {
@@ -17593,9 +17593,9 @@ var require_resolve_block_scalar = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-flow-scalar.js
+// node_modules/yaml/dist/compose/resolve-flow-scalar.js
 var require_resolve_flow_scalar = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-flow-scalar.js"(exports) {
+  "node_modules/yaml/dist/compose/resolve-flow-scalar.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var resolveEnd = require_resolve_end();
@@ -17812,9 +17812,9 @@ var require_resolve_flow_scalar = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-scalar.js
+// node_modules/yaml/dist/compose/compose-scalar.js
 var require_compose_scalar = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-scalar.js"(exports) {
+  "node_modules/yaml/dist/compose/compose-scalar.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -17900,9 +17900,9 @@ var require_compose_scalar = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-empty-scalar-position.js
+// node_modules/yaml/dist/compose/util-empty-scalar-position.js
 var require_util_empty_scalar_position = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-empty-scalar-position.js"(exports) {
+  "node_modules/yaml/dist/compose/util-empty-scalar-position.js"(exports) {
     "use strict";
     function emptyScalarPosition(offset, before, pos) {
       if (before) {
@@ -17930,9 +17930,9 @@ var require_util_empty_scalar_position = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-node.js
+// node_modules/yaml/dist/compose/compose-node.js
 var require_compose_node = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-node.js"(exports) {
+  "node_modules/yaml/dist/compose/compose-node.js"(exports) {
     "use strict";
     var Alias = require_Alias();
     var identity = require_identity();
@@ -18031,9 +18031,9 @@ var require_compose_node = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-doc.js
+// node_modules/yaml/dist/compose/compose-doc.js
 var require_compose_doc = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-doc.js"(exports) {
+  "node_modules/yaml/dist/compose/compose-doc.js"(exports) {
     "use strict";
     var Document = require_Document();
     var composeNode = require_compose_node();
@@ -18074,9 +18074,9 @@ var require_compose_doc = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/composer.js
+// node_modules/yaml/dist/compose/composer.js
 var require_composer = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/composer.js"(exports) {
+  "node_modules/yaml/dist/compose/composer.js"(exports) {
     "use strict";
     var node_process = __require("process");
     var directives = require_directives();
@@ -18281,9 +18281,9 @@ ${end.comment}` : end.comment;
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst-scalar.js
+// node_modules/yaml/dist/parse/cst-scalar.js
 var require_cst_scalar = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst-scalar.js"(exports) {
+  "node_modules/yaml/dist/parse/cst-scalar.js"(exports) {
     "use strict";
     var resolveBlockScalar = require_resolve_block_scalar();
     var resolveFlowScalar = require_resolve_flow_scalar();
@@ -18466,9 +18466,9 @@ var require_cst_scalar = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst-stringify.js
+// node_modules/yaml/dist/parse/cst-stringify.js
 var require_cst_stringify = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst-stringify.js"(exports) {
+  "node_modules/yaml/dist/parse/cst-stringify.js"(exports) {
     "use strict";
     var stringify = (cst) => "type" in cst ? stringifyToken(cst) : stringifyItem(cst);
     function stringifyToken(token) {
@@ -18527,9 +18527,9 @@ var require_cst_stringify = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst-visit.js
+// node_modules/yaml/dist/parse/cst-visit.js
 var require_cst_visit = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst-visit.js"(exports) {
+  "node_modules/yaml/dist/parse/cst-visit.js"(exports) {
     "use strict";
     var BREAK = Symbol("break visit");
     var SKIP = Symbol("skip children");
@@ -18589,9 +18589,9 @@ var require_cst_visit = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst.js
+// node_modules/yaml/dist/parse/cst.js
 var require_cst = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst.js"(exports) {
+  "node_modules/yaml/dist/parse/cst.js"(exports) {
     "use strict";
     var cstScalar = require_cst_scalar();
     var cstStringify = require_cst_stringify();
@@ -18691,9 +18691,9 @@ var require_cst = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/lexer.js
+// node_modules/yaml/dist/parse/lexer.js
 var require_lexer = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/lexer.js"(exports) {
+  "node_modules/yaml/dist/parse/lexer.js"(exports) {
     "use strict";
     var cst = require_cst();
     function isEmpty(ch) {
@@ -19270,9 +19270,9 @@ var require_lexer = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/line-counter.js
+// node_modules/yaml/dist/parse/line-counter.js
 var require_line_counter = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/line-counter.js"(exports) {
+  "node_modules/yaml/dist/parse/line-counter.js"(exports) {
     "use strict";
     var LineCounter = class {
       constructor() {
@@ -19301,9 +19301,9 @@ var require_line_counter = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/parser.js
+// node_modules/yaml/dist/parse/parser.js
 var require_parser = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/parser.js"(exports) {
+  "node_modules/yaml/dist/parse/parser.js"(exports) {
     "use strict";
     var node_process = __require("process");
     var cst = require_cst();
@@ -20171,9 +20171,9 @@ var require_parser = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/public-api.js
+// node_modules/yaml/dist/public-api.js
 var require_public_api = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/public-api.js"(exports) {
+  "node_modules/yaml/dist/public-api.js"(exports) {
     "use strict";
     var composer = require_composer();
     var Document = require_Document();
@@ -20268,9 +20268,9 @@ var require_public_api = __commonJS({
   }
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/index.js
+// node_modules/yaml/dist/index.js
 var require_dist2 = __commonJS({
-  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/index.js"(exports) {
+  "node_modules/yaml/dist/index.js"(exports) {
     "use strict";
     var composer = require_composer();
     var Document = require_Document();
@@ -20326,7 +20326,7 @@ import fs17 from "node:fs";
 import path18 from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v3/helpers/util.js
+// node_modules/zod/v3/helpers/util.js
 var util;
 (function(util2) {
   util2.assertEqual = (_) => {
@@ -20460,7 +20460,7 @@ var getParsedType = (data) => {
   }
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v3/ZodError.js
+// node_modules/zod/v3/ZodError.js
 var ZodIssueCode = util.arrayToEnum([
   "invalid_type",
   "invalid_literal",
@@ -20574,7 +20574,7 @@ ZodError.create = (issues) => {
   return error2;
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v3/locales/en.js
+// node_modules/zod/v3/locales/en.js
 var errorMap = (issue3, _ctx) => {
   let message;
   switch (issue3.code) {
@@ -20677,13 +20677,13 @@ var errorMap = (issue3, _ctx) => {
 };
 var en_default = errorMap;
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v3/errors.js
+// node_modules/zod/v3/errors.js
 var overrideErrorMap = en_default;
 function getErrorMap() {
   return overrideErrorMap;
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v3/helpers/parseUtil.js
+// node_modules/zod/v3/helpers/parseUtil.js
 var makeIssue = (params) => {
   const { data, path: path29, errorMaps, issueData } = params;
   const fullPath = [...path29, ...issueData.path || []];
@@ -20792,14 +20792,14 @@ var isDirty = (x) => x.status === "dirty";
 var isValid = (x) => x.status === "valid";
 var isAsync = (x) => typeof Promise !== "undefined" && x instanceof Promise;
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v3/helpers/errorUtil.js
+// node_modules/zod/v3/helpers/errorUtil.js
 var errorUtil;
 (function(errorUtil2) {
   errorUtil2.errToObj = (message) => typeof message === "string" ? { message } : message || {};
   errorUtil2.toString = (message) => typeof message === "string" ? message : message == null ? void 0 : message.message;
 })(errorUtil || (errorUtil = {}));
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v3/types.js
+// node_modules/zod/v3/types.js
 var ParseInputLazyPath = class {
   constructor(parent, value, path29, key) {
     this._cachedPath = [];
@@ -24205,7 +24205,7 @@ var nullableType = ZodNullable.create;
 var preprocessType = ZodEffects.createWithPreprocess;
 var pipelineType = ZodPipeline.create;
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/core.js
+// node_modules/zod/v4/core/core.js
 var NEVER = Object.freeze({
   status: "aborted"
 });
@@ -24281,7 +24281,7 @@ function config(newConfig) {
   return globalConfig;
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/util.js
+// node_modules/zod/v4/core/util.js
 var util_exports = {};
 __export(util_exports, {
   BIGINT_FORMAT_RANGES: () => BIGINT_FORMAT_RANGES,
@@ -24963,7 +24963,7 @@ var Class = class {
   }
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/errors.js
+// node_modules/zod/v4/core/errors.js
 var initializer = (inst, def) => {
   inst.name = "$ZodError";
   Object.defineProperty(inst, "_zod", {
@@ -25029,7 +25029,7 @@ function formatError(error2, mapper = (issue3) => issue3.message) {
   return fieldErrors;
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/parse.js
+// node_modules/zod/v4/core/parse.js
 var _parse = (_Err) => (schema, value, _ctx, _params) => {
   const ctx = _ctx ? Object.assign(_ctx, { async: false }) : { async: false };
   const result = schema._zod.run({ value, issues: [] }, ctx);
@@ -25109,7 +25109,7 @@ var _safeDecodeAsync = (_Err) => async (schema, value, _ctx) => {
   return _safeParseAsync(_Err)(schema, value, _ctx);
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/regexes.js
+// node_modules/zod/v4/core/regexes.js
 var regexes_exports = {};
 __export(regexes_exports, {
   base64: () => base64,
@@ -25266,7 +25266,7 @@ var sha512_hex = /^[0-9a-fA-F]{128}$/;
 var sha512_base64 = /* @__PURE__ */ fixedBase64(86, "==");
 var sha512_base64url = /* @__PURE__ */ fixedBase64url(86);
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/checks.js
+// node_modules/zod/v4/core/checks.js
 var $ZodCheck = /* @__PURE__ */ $constructor("$ZodCheck", (inst, def) => {
   var _a3;
   inst._zod ?? (inst._zod = {});
@@ -25815,7 +25815,7 @@ var $ZodCheckOverwrite = /* @__PURE__ */ $constructor("$ZodCheckOverwrite", (ins
   };
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/doc.js
+// node_modules/zod/v4/core/doc.js
 var Doc = class {
   constructor(args = []) {
     this.content = [];
@@ -25851,14 +25851,14 @@ var Doc = class {
   }
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/versions.js
+// node_modules/zod/v4/core/versions.js
 var version = {
   major: 4,
   minor: 3,
   patch: 6
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/schemas.js
+// node_modules/zod/v4/core/schemas.js
 var $ZodType = /* @__PURE__ */ $constructor("$ZodType", (inst, def) => {
   var _a4;
   var _a3;
@@ -27856,7 +27856,7 @@ function handleRefineResult(result, payload, input2, inst) {
   }
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/locales/en.js
+// node_modules/zod/v4/locales/en.js
 var error = () => {
   const Sizable = {
     string: { unit: "characters", verb: "to have" },
@@ -27965,7 +27965,7 @@ function en_default2() {
   };
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/registries.js
+// node_modules/zod/v4/core/registries.js
 var _a;
 var $output = Symbol("ZodOutput");
 var $input = Symbol("ZodInput");
@@ -28015,7 +28015,7 @@ function registry() {
 (_a = globalThis).__zod_globalRegistry ?? (_a.__zod_globalRegistry = registry());
 var globalRegistry = globalThis.__zod_globalRegistry;
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/api.js
+// node_modules/zod/v4/core/api.js
 // @__NO_SIDE_EFFECTS__
 function _string(Class2, params) {
   return new Class2({
@@ -28860,7 +28860,7 @@ function _stringFormat(Class2, format, fnOrRegex, _params = {}) {
   return inst;
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/to-json-schema.js
+// node_modules/zod/v4/core/to-json-schema.js
 function initializeContext(params) {
   let target = (params == null ? void 0 : params.target) ?? "draft-2020-12";
   if (target === "draft-4")
@@ -29216,7 +29216,7 @@ var createStandardJSONSchemaMethod = (schema, io, processors = {}) => (params) =
   return finalize(ctx, schema);
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/json-schema-processors.js
+// node_modules/zod/v4/core/json-schema-processors.js
 var formatMap = {
   guid: "uuid",
   url: "uri",
@@ -29693,7 +29693,7 @@ var lazyProcessor = (schema, ctx, _json, params) => {
   seen.ref = innerType;
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-compat.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-compat.js
 function isZ4Schema(s) {
   const schema = s;
   return !!schema._zod;
@@ -29758,7 +29758,7 @@ function getLiteralValue(schema) {
   return void 0;
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/schemas.js
+// node_modules/zod/v4/classic/schemas.js
 var schemas_exports3 = {};
 __export(schemas_exports3, {
   ZodAny: () => ZodAny2,
@@ -29927,7 +29927,7 @@ __export(schemas_exports3, {
   xor: () => xor
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/checks.js
+// node_modules/zod/v4/classic/checks.js
 var checks_exports2 = {};
 __export(checks_exports2, {
   endsWith: () => _endsWith,
@@ -29961,7 +29961,7 @@ __export(checks_exports2, {
   uppercase: () => _uppercase
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/iso.js
+// node_modules/zod/v4/classic/iso.js
 var iso_exports2 = {};
 __export(iso_exports2, {
   ZodISODate: () => ZodISODate,
@@ -30002,7 +30002,7 @@ function duration2(params) {
   return _isoDuration(ZodISODuration, params);
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/errors.js
+// node_modules/zod/v4/classic/errors.js
 var initializer2 = (inst, issues) => {
   $ZodError.init(inst, issues);
   inst.name = "ZodError";
@@ -30042,7 +30042,7 @@ var ZodRealError = $constructor("ZodError", initializer2, {
   Parent: Error
 });
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/parse.js
+// node_modules/zod/v4/classic/parse.js
 var parse2 = /* @__PURE__ */ _parse(ZodRealError);
 var parseAsync2 = /* @__PURE__ */ _parseAsync(ZodRealError);
 var safeParse3 = /* @__PURE__ */ _safeParse(ZodRealError);
@@ -30056,7 +30056,7 @@ var safeDecode2 = /* @__PURE__ */ _safeDecode(ZodRealError);
 var safeEncodeAsync2 = /* @__PURE__ */ _safeEncodeAsync(ZodRealError);
 var safeDecodeAsync2 = /* @__PURE__ */ _safeDecodeAsync(ZodRealError);
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/schemas.js
+// node_modules/zod/v4/classic/schemas.js
 var ZodType2 = /* @__PURE__ */ $constructor("ZodType", (inst, def) => {
   $ZodType.init(inst, def);
   Object.assign(inst["~standard"], {
@@ -31136,7 +31136,7 @@ function preprocess(fn, schema) {
   return pipe(transform(fn), schema);
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/compat.js
+// node_modules/zod/v4/classic/compat.js
 var ZodIssueCode2 = {
   invalid_type: "invalid_type",
   too_big: "too_big",
@@ -31154,14 +31154,14 @@ var ZodFirstPartyTypeKind2;
 /* @__PURE__ */ (function(ZodFirstPartyTypeKind3) {
 })(ZodFirstPartyTypeKind2 || (ZodFirstPartyTypeKind2 = {}));
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/from-json-schema.js
+// node_modules/zod/v4/classic/from-json-schema.js
 var z = {
   ...schemas_exports3,
   ...checks_exports2,
   iso: iso_exports2
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/coerce.js
+// node_modules/zod/v4/classic/coerce.js
 var coerce_exports2 = {};
 __export(coerce_exports2, {
   bigint: () => bigint3,
@@ -31186,10 +31186,10 @@ function date4(params) {
   return _coercedDate(ZodDate2, params);
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/external.js
+// node_modules/zod/v4/classic/external.js
 config(en_default2());
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/types.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/types.js
 var LATEST_PROTOCOL_VERSION = "2025-11-25";
 var SUPPORTED_PROTOCOL_VERSIONS = [LATEST_PROTOCOL_VERSION, "2025-06-18", "2025-03-26", "2024-11-05", "2024-10-07"];
 var RELATED_TASK_META_KEY = "io.modelcontextprotocol/related-task";
@@ -32697,18 +32697,18 @@ var UrlElicitationRequiredError = class extends McpError {
   }
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/interfaces.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/interfaces.js
 function isTerminal(status) {
   return status === "completed" || status === "failed" || status === "cancelled";
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod-to-json-schema/dist/esm/Options.js
+// node_modules/zod-to-json-schema/dist/esm/Options.js
 var ignoreOverride = Symbol("Let zodToJsonSchema decide on which parser to use");
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod-to-json-schema/dist/esm/parsers/string.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/string.js
 var ALPHA_NUMERIC = new Set("ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvxyz0123456789");
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-json-schema-compat.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-json-schema-compat.js
 function getMethodLiteral(schema) {
   const shape = getObjectShape(schema);
   const methodSchema = shape == null ? void 0 : shape.method;
@@ -32729,7 +32729,7 @@ function parseWithCompat(schema, data) {
   return result.data;
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/protocol.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/protocol.js
 var DEFAULT_REQUEST_TIMEOUT_MSEC = 6e4;
 var Protocol = class {
   constructor(_options) {
@@ -33694,7 +33694,7 @@ function mergeCapabilities(base, additional) {
   return result;
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/validation/ajv-provider.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/validation/ajv-provider.js
 var import_ajv = __toESM(require_ajv(), 1);
 var import_ajv_formats = __toESM(require_dist(), 1);
 function createDefaultAjvInstance() {
@@ -33762,7 +33762,7 @@ var AjvJsonSchemaValidator = class {
   }
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/server.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/server.js
 var ExperimentalServerTasks = class {
   constructor(_server) {
     this._server = _server;
@@ -33977,7 +33977,7 @@ var ExperimentalServerTasks = class {
   }
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/helpers.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/helpers.js
 function assertToolsCallTaskCapability(requests, method, entityName) {
   var _a3;
   if (!requests) {
@@ -34014,7 +34014,7 @@ function assertClientRequestTaskCapability(requests, method, entityName) {
   }
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/index.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/index.js
 var Server = class extends Protocol {
   /**
    * Initializes this server with the given name and version information.
@@ -34406,10 +34406,10 @@ var Server = class extends Protocol {
   }
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js
 import process3 from "node:process";
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/stdio.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/stdio.js
 var ReadBuffer = class {
   append(chunk) {
     this._buffer = this._buffer ? Buffer.concat([this._buffer, chunk]) : chunk;
@@ -34437,7 +34437,7 @@ function serializeMessage(message) {
   return JSON.stringify(message) + "\n";
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js
 var StdioServerTransport = class {
   constructor(_stdin = process3.stdin, _stdout = process3.stdout) {
     this._stdin = _stdin;
@@ -34501,7 +34501,7 @@ var StdioServerTransport = class {
   }
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/client.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/client.js
 var ExperimentalClientTasks = class {
   constructor(_client) {
     this._client = _client;
@@ -34655,7 +34655,7 @@ var ExperimentalClientTasks = class {
   }
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/client/index.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/client/index.js
 function applyElicitationDefaults(schema, data) {
   if (!schema || data === null || typeof data !== "object")
     return;
@@ -35185,7 +35185,7 @@ var Client = class extends Protocol {
   }
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/client/stdio.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/client/stdio.js
 var import_cross_spawn = __toESM(require_cross_spawn(), 1);
 import process4 from "node:process";
 import { PassThrough } from "node:stream";
@@ -52377,7 +52377,7 @@ function formatCliError(error2) {
   return error2 instanceof Error ? error2.message : String(error2);
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/transport.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/transport.js
 function normalizeHeaders(headers) {
   if (!headers)
     return {};
@@ -52404,7 +52404,7 @@ function createFetchWithInit(baseFetch = fetch, baseInit) {
   };
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/pkce-challenge/dist/index.node.js
+// node_modules/pkce-challenge/dist/index.node.js
 var crypto6;
 var _a2;
 crypto6 = ((_a2 = globalThis.crypto) == null ? void 0 : _a2.webcrypto) ?? // Node.js [18-16] REPL
@@ -52444,7 +52444,7 @@ async function pkceChallenge(length) {
   };
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/auth.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/auth.js
 var SafeUrlSchema = url().superRefine((val, ctx) => {
   if (!URL.canParse(val)) {
     ctx.addIssue({
@@ -52588,7 +52588,7 @@ var OAuthTokenRevocationRequestSchema = object2({
   token_type_hint: string2().optional()
 }).strip();
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/auth-utils.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/auth-utils.js
 function resourceUrlFromServerUrl(url2) {
   const resourceURL = typeof url2 === "string" ? new URL(url2) : new URL(url2.href);
   resourceURL.hash = "";
@@ -52608,7 +52608,7 @@ function checkResourceAllowed({ requestedResource, configuredResource }) {
   return requestedPath.startsWith(configuredPath);
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/auth/errors.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/auth/errors.js
 var OAuthError = class extends Error {
   constructor(message, errorUri) {
     super(message);
@@ -52703,7 +52703,7 @@ var OAUTH_ERRORS = {
   [InvalidTargetError.errorCode]: InvalidTargetError
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/client/auth.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/client/auth.js
 var UnauthorizedError = class extends Error {
   constructor(message) {
     super(message ?? "Unauthorized");
@@ -53243,7 +53243,7 @@ async function registerClient(authorizationServerUrl, { metadata, clientMetadata
   return OAuthClientInformationFullSchema.parse(await response.json());
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/eventsource-parser/dist/index.js
+// node_modules/eventsource-parser/dist/index.js
 var ParseError = class extends Error {
   constructor(message, options) {
     super(message), this.name = "ParseError", this.type = options.type, this.field = options.field, this.value = options.value, this.line = options.line;
@@ -53346,7 +53346,7 @@ function splitLines(chunk) {
   return [lines, incompleteLine];
 }
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/eventsource-parser/dist/stream.js
+// node_modules/eventsource-parser/dist/stream.js
 var EventSourceParserStream = class extends TransformStream {
   constructor({ onError, onRetry, onComment } = {}) {
     let parser;
@@ -53370,7 +53370,7 @@ var EventSourceParserStream = class extends TransformStream {
   }
 };
 
-// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/client/streamableHttp.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/client/streamableHttp.js
 var DEFAULT_STREAMABLE_HTTP_RECONNECTION_OPTIONS = {
   initialReconnectionDelay: 1e3,
   maxReconnectionDelay: 3e4,

--- a/plugins/workbuddy/taptap-maker/dist/maker.js
+++ b/plugins/workbuddy/taptap-maker/dist/maker.js
@@ -41,9 +41,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/code.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/code.js
 var require_code = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/code.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/code.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.regexpCode = exports.getEsmExportName = exports.getProperty = exports.safeStringify = exports.stringify = exports.strConcat = exports.addCodeArg = exports.str = exports._ = exports.nil = exports._Code = exports.Name = exports.IDENTIFIER = exports._CodeOrName = void 0;
@@ -195,9 +195,9 @@ var require_code = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/scope.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/scope.js
 var require_scope = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/scope.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/scope.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.ValueScope = exports.ValueScopeName = exports.Scope = exports.varKinds = exports.UsedValueState = void 0;
@@ -340,9 +340,9 @@ var require_scope = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/index.js
 var require_codegen = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/codegen/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.or = exports.and = exports.not = exports.CodeGen = exports.operators = exports.varKinds = exports.ValueScopeName = exports.ValueScope = exports.Scope = exports.Name = exports.regexpCode = exports.stringify = exports.getProperty = exports.nil = exports.strConcat = exports.str = exports._ = void 0;
@@ -1060,9 +1060,9 @@ var require_codegen = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/util.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/util.js
 var require_util = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/util.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/util.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.checkStrictMode = exports.getErrorPath = exports.Type = exports.useFunc = exports.setEvaluated = exports.evaluatedPropsToName = exports.mergeEvaluated = exports.eachItem = exports.unescapeJsonPointer = exports.escapeJsonPointer = exports.escapeFragment = exports.unescapeFragment = exports.schemaRefOrVal = exports.schemaHasRulesButRef = exports.schemaHasRules = exports.checkUnknownRules = exports.alwaysValidSchema = exports.toHash = void 0;
@@ -1227,9 +1227,9 @@ var require_util = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/names.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/names.js
 var require_names = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/names.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/names.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -1266,9 +1266,9 @@ var require_names = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/errors.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/errors.js
 var require_errors = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/errors.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/errors.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.extendErrors = exports.resetErrorsCount = exports.reportExtraError = exports.reportError = exports.keyword$DataError = exports.keywordError = void 0;
@@ -1388,9 +1388,9 @@ var require_errors = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/boolSchema.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/boolSchema.js
 var require_boolSchema = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/boolSchema.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/boolSchema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.boolOrEmptySchema = exports.topBoolOrEmptySchema = void 0;
@@ -1439,9 +1439,9 @@ var require_boolSchema = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/rules.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/rules.js
 var require_rules = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/rules.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/rules.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getRules = exports.isJSONType = void 0;
@@ -1470,9 +1470,9 @@ var require_rules = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/applicability.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/applicability.js
 var require_applicability = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/applicability.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/applicability.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.shouldUseRule = exports.shouldUseGroup = exports.schemaHasRulesForType = void 0;
@@ -1493,9 +1493,9 @@ var require_applicability = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/dataType.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/dataType.js
 var require_dataType = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/dataType.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/dataType.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.reportTypeError = exports.checkDataTypes = exports.checkDataType = exports.coerceAndCheckDataType = exports.getJSONTypes = exports.getSchemaTypes = exports.DataType = void 0;
@@ -1677,9 +1677,9 @@ var require_dataType = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/defaults.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/defaults.js
 var require_defaults = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/defaults.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/defaults.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.assignDefaults = void 0;
@@ -1714,9 +1714,9 @@ var require_defaults = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/code.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/code.js
 var require_code2 = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/code.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/code.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateUnion = exports.validateArray = exports.usePattern = exports.callValidateCode = exports.schemaProperties = exports.allSchemaProperties = exports.noPropertyInData = exports.propertyInData = exports.isOwnProperty = exports.hasPropFunc = exports.reportMissingProp = exports.checkMissingProp = exports.checkReportMissingProp = void 0;
@@ -1847,9 +1847,9 @@ var require_code2 = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/keyword.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/keyword.js
 var require_keyword = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/keyword.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/keyword.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateKeywordUsage = exports.validSchemaType = exports.funcKeywordCode = exports.macroKeywordCode = void 0;
@@ -1965,9 +1965,9 @@ var require_keyword = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/subschema.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/subschema.js
 var require_subschema = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/subschema.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/subschema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.extendSubschemaMode = exports.extendSubschemaData = exports.getSubschema = void 0;
@@ -2048,9 +2048,9 @@ var require_subschema = __commonJS({
   }
 });
 
-// node_modules/fast-deep-equal/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-deep-equal/index.js
 var require_fast_deep_equal = __commonJS({
-  "node_modules/fast-deep-equal/index.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-deep-equal/index.js"(exports, module) {
     "use strict";
     module.exports = function equal(a, b) {
       if (a === b) return true;
@@ -2083,9 +2083,9 @@ var require_fast_deep_equal = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse/index.js
 var require_json_schema_traverse = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse/index.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse/index.js"(exports, module) {
     "use strict";
     var traverse = module.exports = function(schema, opts, cb) {
       if (typeof opts == "function") {
@@ -2171,9 +2171,9 @@ var require_json_schema_traverse = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/resolve.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/resolve.js
 var require_resolve = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/resolve.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/resolve.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getSchemaRefs = exports.resolveUrl = exports.normalizeId = exports._getFullPath = exports.getFullPath = exports.inlineRef = void 0;
@@ -2327,9 +2327,9 @@ var require_resolve = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/index.js
 var require_validate = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/validate/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getData = exports.KeywordCxt = exports.validateFunctionCode = void 0;
@@ -2835,9 +2835,9 @@ var require_validate = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/validation_error.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/validation_error.js
 var require_validation_error = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/validation_error.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/validation_error.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var ValidationError = class extends Error {
@@ -2851,9 +2851,9 @@ var require_validation_error = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/ref_error.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/ref_error.js
 var require_ref_error = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/ref_error.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/ref_error.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var resolve_1 = require_resolve();
@@ -2868,9 +2868,9 @@ var require_ref_error = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/index.js
 var require_compile = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/compile/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.resolveSchema = exports.getCompilingSchema = exports.resolveRef = exports.compileSchema = exports.SchemaEnv = void 0;
@@ -3092,9 +3092,9 @@ var require_compile = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/data.json
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/data.json
 var require_data = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/data.json"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/data.json"(exports, module) {
     module.exports = {
       $id: "https://raw.githubusercontent.com/ajv-validator/ajv/master/lib/refs/data.json#",
       description: "Meta-schema for $data reference (JSON AnySchema extension proposal)",
@@ -3111,9 +3111,9 @@ var require_data = __commonJS({
   }
 });
 
-// node_modules/fast-uri/lib/utils.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-uri/lib/utils.js
 var require_utils = __commonJS({
-  "node_modules/fast-uri/lib/utils.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-uri/lib/utils.js"(exports, module) {
     "use strict";
     var isUUID = RegExp.prototype.test.bind(/^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/iu);
     var isIPv4 = RegExp.prototype.test.bind(/^(?:(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)$/u);
@@ -3234,8 +3234,8 @@ var require_utils = __commonJS({
       }
       return ind;
     }
-    function removeDotSegments(path28) {
-      let input2 = path28;
+    function removeDotSegments(path29) {
+      let input2 = path29;
       const output2 = [];
       let nextSlash = -1;
       let len = 0;
@@ -3368,9 +3368,9 @@ var require_utils = __commonJS({
   }
 });
 
-// node_modules/fast-uri/lib/schemes.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-uri/lib/schemes.js
 var require_schemes = __commonJS({
-  "node_modules/fast-uri/lib/schemes.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-uri/lib/schemes.js"(exports, module) {
     "use strict";
     var { isUUID } = require_utils();
     var URN_REG = /([\da-z][\d\-a-z]{0,31}):((?:[\w!$'()*+,\-.:;=@]|%[\da-f]{2})+)/iu;
@@ -3434,8 +3434,8 @@ var require_schemes = __commonJS({
         wsComponent.secure = void 0;
       }
       if (wsComponent.resourceName) {
-        const [path28, query] = wsComponent.resourceName.split("?");
-        wsComponent.path = path28 && path28 !== "/" ? path28 : void 0;
+        const [path29, query] = wsComponent.resourceName.split("?");
+        wsComponent.path = path29 && path29 !== "/" ? path29 : void 0;
         wsComponent.query = query;
         wsComponent.resourceName = void 0;
       }
@@ -3578,9 +3578,9 @@ var require_schemes = __commonJS({
   }
 });
 
-// node_modules/fast-uri/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-uri/index.js
 var require_fast_uri = __commonJS({
-  "node_modules/fast-uri/index.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/fast-uri/index.js"(exports, module) {
     "use strict";
     var { normalizeIPv6, removeDotSegments, recomposeAuthority, normalizeComponentEncoding, isIPv4, nonSimpleDomain } = require_utils();
     var { SCHEMES, getSchemeHandler } = require_schemes();
@@ -3833,9 +3833,9 @@ var require_fast_uri = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/uri.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/uri.js
 var require_uri = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/uri.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/uri.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var uri = require_fast_uri();
@@ -3844,9 +3844,9 @@ var require_uri = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/core.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/core.js
 var require_core = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/core.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/core.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = void 0;
@@ -4455,9 +4455,9 @@ var require_core = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/id.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/id.js
 var require_id = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/id.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/id.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var def = {
@@ -4470,9 +4470,9 @@ var require_id = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/ref.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/ref.js
 var require_ref = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/ref.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/ref.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.callRef = exports.getValidate = void 0;
@@ -4592,9 +4592,9 @@ var require_ref = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/index.js
 var require_core2 = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/core/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var id_1 = require_id();
@@ -4613,9 +4613,9 @@ var require_core2 = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitNumber.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitNumber.js
 var require_limitNumber = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitNumber.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitNumber.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4645,9 +4645,9 @@ var require_limitNumber = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/multipleOf.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/multipleOf.js
 var require_multipleOf = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/multipleOf.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/multipleOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4673,9 +4673,9 @@ var require_multipleOf = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/ucs2length.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/ucs2length.js
 var require_ucs2length = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/ucs2length.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/ucs2length.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     function ucs2length(str) {
@@ -4699,9 +4699,9 @@ var require_ucs2length = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitLength.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitLength.js
 var require_limitLength = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitLength.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitLength.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4731,9 +4731,9 @@ var require_limitLength = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/pattern.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/pattern.js
 var require_pattern = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/pattern.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/pattern.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -4768,9 +4768,9 @@ var require_pattern = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitProperties.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitProperties.js
 var require_limitProperties = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitProperties.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4797,9 +4797,9 @@ var require_limitProperties = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/required.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/required.js
 var require_required = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/required.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/required.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -4879,9 +4879,9 @@ var require_required = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitItems.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitItems.js
 var require_limitItems = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitItems.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/limitItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4908,9 +4908,9 @@ var require_limitItems = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/equal.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/equal.js
 var require_equal = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/equal.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/runtime/equal.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var equal = require_fast_deep_equal();
@@ -4919,9 +4919,9 @@ var require_equal = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js
 var require_uniqueItems = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var dataType_1 = require_dataType();
@@ -4986,9 +4986,9 @@ var require_uniqueItems = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/const.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/const.js
 var require_const = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/const.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/const.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5015,9 +5015,9 @@ var require_const = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/enum.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/enum.js
 var require_enum = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/enum.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/enum.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5064,9 +5064,9 @@ var require_enum = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/index.js
 var require_validation = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/validation/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var limitNumber_1 = require_limitNumber();
@@ -5102,9 +5102,9 @@ var require_validation = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js
 var require_additionalItems = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateAdditionalItems = void 0;
@@ -5155,9 +5155,9 @@ var require_additionalItems = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items.js
 var require_items = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateTuple = void 0;
@@ -5212,9 +5212,9 @@ var require_items = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js
 var require_prefixItems = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var items_1 = require_items();
@@ -5229,9 +5229,9 @@ var require_prefixItems = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items2020.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items2020.js
 var require_items2020 = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items2020.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/items2020.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5264,9 +5264,9 @@ var require_items2020 = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/contains.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/contains.js
 var require_contains = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/contains.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/contains.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5358,9 +5358,9 @@ var require_contains = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/dependencies.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/dependencies.js
 var require_dependencies = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/dependencies.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/dependencies.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateSchemaDeps = exports.validatePropertyDeps = exports.error = void 0;
@@ -5452,9 +5452,9 @@ var require_dependencies = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js
 var require_propertyNames = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5495,9 +5495,9 @@ var require_propertyNames = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js
 var require_additionalProperties = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -5601,9 +5601,9 @@ var require_additionalProperties = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/properties.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/properties.js
 var require_properties = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/properties.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/properties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var validate_1 = require_validate();
@@ -5659,9 +5659,9 @@ var require_properties = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js
 var require_patternProperties = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -5733,9 +5733,9 @@ var require_patternProperties = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/not.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/not.js
 var require_not = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/not.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/not.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util();
@@ -5764,9 +5764,9 @@ var require_not = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/anyOf.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/anyOf.js
 var require_anyOf = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/anyOf.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/anyOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -5781,9 +5781,9 @@ var require_anyOf = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/oneOf.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/oneOf.js
 var require_oneOf = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/oneOf.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/oneOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5839,9 +5839,9 @@ var require_oneOf = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/allOf.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/allOf.js
 var require_allOf = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/allOf.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/allOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util();
@@ -5866,9 +5866,9 @@ var require_allOf = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/if.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/if.js
 var require_if = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/if.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/if.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5935,9 +5935,9 @@ var require_if = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/thenElse.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/thenElse.js
 var require_thenElse = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/thenElse.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/thenElse.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util();
@@ -5953,9 +5953,9 @@ var require_thenElse = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/index.js
 var require_applicator = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/applicator/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var additionalItems_1 = require_additionalItems();
@@ -6001,9 +6001,9 @@ var require_applicator = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/format.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/format.js
 var require_format = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/format.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/format.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -6091,9 +6091,9 @@ var require_format = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/index.js
 var require_format2 = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/format/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var format_1 = require_format();
@@ -6102,9 +6102,9 @@ var require_format2 = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/metadata.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/metadata.js
 var require_metadata = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/metadata.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/metadata.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.contentVocabulary = exports.metadataVocabulary = void 0;
@@ -6125,9 +6125,9 @@ var require_metadata = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/draft7.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/draft7.js
 var require_draft7 = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/draft7.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/draft7.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var core_1 = require_core2();
@@ -6147,9 +6147,9 @@ var require_draft7 = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/types.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/types.js
 var require_types = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/types.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/types.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.DiscrError = void 0;
@@ -6161,9 +6161,9 @@ var require_types = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/index.js
 var require_discriminator = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/vocabularies/discriminator/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -6266,9 +6266,9 @@ var require_discriminator = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/json-schema-draft-07.json
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/json-schema-draft-07.json
 var require_json_schema_draft_07 = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/json-schema-draft-07.json"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/refs/json-schema-draft-07.json"(exports, module) {
     module.exports = {
       $schema: "http://json-schema.org/draft-07/schema#",
       $id: "http://json-schema.org/draft-07/schema#",
@@ -6423,9 +6423,9 @@ var require_json_schema_draft_07 = __commonJS({
   }
 });
 
-// node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/ajv.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/ajv.js
 var require_ajv = __commonJS({
-  "node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/ajv.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/dist/ajv.js"(exports, module) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.MissingRefError = exports.ValidationError = exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = exports.Ajv = void 0;
@@ -6493,9 +6493,9 @@ var require_ajv = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/dist/formats.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/dist/formats.js
 var require_formats = __commonJS({
-  "node_modules/ajv-formats/dist/formats.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/dist/formats.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.formatNames = exports.fastFormats = exports.fullFormats = void 0;
@@ -6696,9 +6696,9 @@ var require_formats = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/code.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/code.js
 var require_code3 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/code.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/code.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.regexpCode = exports.getEsmExportName = exports.getProperty = exports.safeStringify = exports.stringify = exports.strConcat = exports.addCodeArg = exports.str = exports._ = exports.nil = exports._Code = exports.Name = exports.IDENTIFIER = exports._CodeOrName = void 0;
@@ -6850,9 +6850,9 @@ var require_code3 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/scope.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/scope.js
 var require_scope2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/scope.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/scope.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.ValueScope = exports.ValueScopeName = exports.Scope = exports.varKinds = exports.UsedValueState = void 0;
@@ -6995,9 +6995,9 @@ var require_scope2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/index.js
 var require_codegen2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/codegen/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.or = exports.and = exports.not = exports.CodeGen = exports.operators = exports.varKinds = exports.ValueScopeName = exports.ValueScope = exports.Scope = exports.Name = exports.regexpCode = exports.stringify = exports.getProperty = exports.nil = exports.strConcat = exports.str = exports._ = void 0;
@@ -7715,9 +7715,9 @@ var require_codegen2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/util.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/util.js
 var require_util2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/util.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/util.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.checkStrictMode = exports.getErrorPath = exports.Type = exports.useFunc = exports.setEvaluated = exports.evaluatedPropsToName = exports.mergeEvaluated = exports.eachItem = exports.unescapeJsonPointer = exports.escapeJsonPointer = exports.escapeFragment = exports.unescapeFragment = exports.schemaRefOrVal = exports.schemaHasRulesButRef = exports.schemaHasRules = exports.checkUnknownRules = exports.alwaysValidSchema = exports.toHash = void 0;
@@ -7882,9 +7882,9 @@ var require_util2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/names.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/names.js
 var require_names2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/names.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/names.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -7921,9 +7921,9 @@ var require_names2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/errors.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/errors.js
 var require_errors2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/errors.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/errors.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.extendErrors = exports.resetErrorsCount = exports.reportExtraError = exports.reportError = exports.keyword$DataError = exports.keywordError = void 0;
@@ -8043,9 +8043,9 @@ var require_errors2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/boolSchema.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/boolSchema.js
 var require_boolSchema2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/boolSchema.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/boolSchema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.boolOrEmptySchema = exports.topBoolOrEmptySchema = void 0;
@@ -8094,9 +8094,9 @@ var require_boolSchema2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/rules.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/rules.js
 var require_rules2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/rules.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/rules.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getRules = exports.isJSONType = void 0;
@@ -8125,9 +8125,9 @@ var require_rules2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/applicability.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/applicability.js
 var require_applicability2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/applicability.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/applicability.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.shouldUseRule = exports.shouldUseGroup = exports.schemaHasRulesForType = void 0;
@@ -8148,9 +8148,9 @@ var require_applicability2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/dataType.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/dataType.js
 var require_dataType2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/dataType.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/dataType.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.reportTypeError = exports.checkDataTypes = exports.checkDataType = exports.coerceAndCheckDataType = exports.getJSONTypes = exports.getSchemaTypes = exports.DataType = void 0;
@@ -8332,9 +8332,9 @@ var require_dataType2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/defaults.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/defaults.js
 var require_defaults2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/defaults.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/defaults.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.assignDefaults = void 0;
@@ -8369,9 +8369,9 @@ var require_defaults2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/code.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/code.js
 var require_code4 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/code.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/code.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateUnion = exports.validateArray = exports.usePattern = exports.callValidateCode = exports.schemaProperties = exports.allSchemaProperties = exports.noPropertyInData = exports.propertyInData = exports.isOwnProperty = exports.hasPropFunc = exports.reportMissingProp = exports.checkMissingProp = exports.checkReportMissingProp = void 0;
@@ -8502,9 +8502,9 @@ var require_code4 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/keyword.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/keyword.js
 var require_keyword2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/keyword.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/keyword.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateKeywordUsage = exports.validSchemaType = exports.funcKeywordCode = exports.macroKeywordCode = void 0;
@@ -8620,9 +8620,9 @@ var require_keyword2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/subschema.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/subschema.js
 var require_subschema2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/subschema.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/subschema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.extendSubschemaMode = exports.extendSubschemaData = exports.getSubschema = void 0;
@@ -8703,9 +8703,9 @@ var require_subschema2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/json-schema-traverse/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/json-schema-traverse/index.js
 var require_json_schema_traverse2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/json-schema-traverse/index.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/json-schema-traverse/index.js"(exports, module) {
     "use strict";
     var traverse = module.exports = function(schema, opts, cb) {
       if (typeof opts == "function") {
@@ -8791,9 +8791,9 @@ var require_json_schema_traverse2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/resolve.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/resolve.js
 var require_resolve2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/resolve.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/resolve.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getSchemaRefs = exports.resolveUrl = exports.normalizeId = exports._getFullPath = exports.getFullPath = exports.inlineRef = void 0;
@@ -8947,9 +8947,9 @@ var require_resolve2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/index.js
 var require_validate2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/validate/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getData = exports.KeywordCxt = exports.validateFunctionCode = void 0;
@@ -9455,9 +9455,9 @@ var require_validate2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/runtime/validation_error.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/validation_error.js
 var require_validation_error2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/runtime/validation_error.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/validation_error.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var ValidationError = class extends Error {
@@ -9471,9 +9471,9 @@ var require_validation_error2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/ref_error.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/ref_error.js
 var require_ref_error2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/ref_error.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/ref_error.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var resolve_1 = require_resolve2();
@@ -9488,9 +9488,9 @@ var require_ref_error2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/compile/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/index.js
 var require_compile2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/compile/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/compile/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.resolveSchema = exports.getCompilingSchema = exports.resolveRef = exports.compileSchema = exports.SchemaEnv = void 0;
@@ -9712,9 +9712,9 @@ var require_compile2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/refs/data.json
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/refs/data.json
 var require_data2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/refs/data.json"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/refs/data.json"(exports, module) {
     module.exports = {
       $id: "https://raw.githubusercontent.com/ajv-validator/ajv/master/lib/refs/data.json#",
       description: "Meta-schema for $data reference (JSON AnySchema extension proposal)",
@@ -9731,9 +9731,9 @@ var require_data2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/runtime/uri.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/uri.js
 var require_uri2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/runtime/uri.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/uri.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var uri = require_fast_uri();
@@ -9742,9 +9742,9 @@ var require_uri2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/core.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/core.js
 var require_core3 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/core.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/core.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = void 0;
@@ -10353,9 +10353,9 @@ var require_core3 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/id.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/id.js
 var require_id2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/id.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/id.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var def = {
@@ -10368,9 +10368,9 @@ var require_id2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/ref.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/ref.js
 var require_ref2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/ref.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/ref.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.callRef = exports.getValidate = void 0;
@@ -10490,9 +10490,9 @@ var require_ref2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/index.js
 var require_core4 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/core/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var id_1 = require_id2();
@@ -10511,9 +10511,9 @@ var require_core4 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitNumber.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitNumber.js
 var require_limitNumber2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitNumber.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitNumber.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -10543,9 +10543,9 @@ var require_limitNumber2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/multipleOf.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/multipleOf.js
 var require_multipleOf2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/multipleOf.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/multipleOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -10571,9 +10571,9 @@ var require_multipleOf2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/runtime/ucs2length.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/ucs2length.js
 var require_ucs2length2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/runtime/ucs2length.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/ucs2length.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     function ucs2length(str) {
@@ -10597,9 +10597,9 @@ var require_ucs2length2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitLength.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitLength.js
 var require_limitLength2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitLength.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitLength.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -10629,9 +10629,9 @@ var require_limitLength2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/pattern.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/pattern.js
 var require_pattern2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/pattern.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/pattern.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code4();
@@ -10666,9 +10666,9 @@ var require_pattern2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitProperties.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitProperties.js
 var require_limitProperties2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitProperties.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -10695,9 +10695,9 @@ var require_limitProperties2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/required.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/required.js
 var require_required2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/required.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/required.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code4();
@@ -10777,9 +10777,9 @@ var require_required2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitItems.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitItems.js
 var require_limitItems2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitItems.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/limitItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -10806,9 +10806,9 @@ var require_limitItems2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/runtime/equal.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/equal.js
 var require_equal2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/runtime/equal.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/runtime/equal.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var equal = require_fast_deep_equal();
@@ -10817,9 +10817,9 @@ var require_equal2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js
 var require_uniqueItems2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var dataType_1 = require_dataType2();
@@ -10884,9 +10884,9 @@ var require_uniqueItems2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/const.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/const.js
 var require_const2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/const.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/const.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -10913,9 +10913,9 @@ var require_const2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/enum.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/enum.js
 var require_enum2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/enum.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/enum.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -10962,9 +10962,9 @@ var require_enum2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/index.js
 var require_validation2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/validation/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var limitNumber_1 = require_limitNumber2();
@@ -11000,9 +11000,9 @@ var require_validation2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js
 var require_additionalItems2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateAdditionalItems = void 0;
@@ -11053,9 +11053,9 @@ var require_additionalItems2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items.js
 var require_items2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateTuple = void 0;
@@ -11110,9 +11110,9 @@ var require_items2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js
 var require_prefixItems2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var items_1 = require_items2();
@@ -11127,9 +11127,9 @@ var require_prefixItems2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items2020.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items2020.js
 var require_items20202 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items2020.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/items2020.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -11162,9 +11162,9 @@ var require_items20202 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/contains.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/contains.js
 var require_contains2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/contains.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/contains.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -11256,9 +11256,9 @@ var require_contains2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/dependencies.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/dependencies.js
 var require_dependencies2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/dependencies.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/dependencies.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateSchemaDeps = exports.validatePropertyDeps = exports.error = void 0;
@@ -11350,9 +11350,9 @@ var require_dependencies2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js
 var require_propertyNames2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -11393,9 +11393,9 @@ var require_propertyNames2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js
 var require_additionalProperties2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code4();
@@ -11499,9 +11499,9 @@ var require_additionalProperties2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/properties.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/properties.js
 var require_properties2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/properties.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/properties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var validate_1 = require_validate2();
@@ -11557,9 +11557,9 @@ var require_properties2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js
 var require_patternProperties2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code4();
@@ -11631,9 +11631,9 @@ var require_patternProperties2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/not.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/not.js
 var require_not2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/not.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/not.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util2();
@@ -11662,9 +11662,9 @@ var require_not2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/anyOf.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/anyOf.js
 var require_anyOf2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/anyOf.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/anyOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code4();
@@ -11679,9 +11679,9 @@ var require_anyOf2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/oneOf.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/oneOf.js
 var require_oneOf2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/oneOf.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/oneOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -11737,9 +11737,9 @@ var require_oneOf2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/allOf.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/allOf.js
 var require_allOf2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/allOf.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/allOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util2();
@@ -11764,9 +11764,9 @@ var require_allOf2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/if.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/if.js
 var require_if2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/if.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/if.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -11833,9 +11833,9 @@ var require_if2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/thenElse.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/thenElse.js
 var require_thenElse2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/thenElse.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/thenElse.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util2();
@@ -11851,9 +11851,9 @@ var require_thenElse2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/index.js
 var require_applicator2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/applicator/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var additionalItems_1 = require_additionalItems2();
@@ -11899,9 +11899,9 @@ var require_applicator2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/format.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/format.js
 var require_format3 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/format.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/format.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -11989,9 +11989,9 @@ var require_format3 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/index.js
 var require_format4 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/format/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var format_1 = require_format3();
@@ -12000,9 +12000,9 @@ var require_format4 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/metadata.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/metadata.js
 var require_metadata2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/metadata.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/metadata.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.contentVocabulary = exports.metadataVocabulary = void 0;
@@ -12023,9 +12023,9 @@ var require_metadata2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/draft7.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/draft7.js
 var require_draft72 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/draft7.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/draft7.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var core_1 = require_core4();
@@ -12045,9 +12045,9 @@ var require_draft72 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/types.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/types.js
 var require_types2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/types.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/types.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.DiscrError = void 0;
@@ -12059,9 +12059,9 @@ var require_types2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/index.js
 var require_discriminator2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/vocabularies/discriminator/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen2();
@@ -12164,9 +12164,9 @@ var require_discriminator2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/refs/json-schema-draft-07.json
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/refs/json-schema-draft-07.json
 var require_json_schema_draft_072 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/refs/json-schema-draft-07.json"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/refs/json-schema-draft-07.json"(exports, module) {
     module.exports = {
       $schema: "http://json-schema.org/draft-07/schema#",
       $id: "http://json-schema.org/draft-07/schema#",
@@ -12321,9 +12321,9 @@ var require_json_schema_draft_072 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/node_modules/ajv/dist/ajv.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/ajv.js
 var require_ajv2 = __commonJS({
-  "node_modules/ajv-formats/node_modules/ajv/dist/ajv.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/node_modules/ajv/dist/ajv.js"(exports, module) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.MissingRefError = exports.ValidationError = exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = exports.Ajv = void 0;
@@ -12391,9 +12391,9 @@ var require_ajv2 = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/dist/limit.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/dist/limit.js
 var require_limit = __commonJS({
-  "node_modules/ajv-formats/dist/limit.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/dist/limit.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.formatLimitDefinition = void 0;
@@ -12463,9 +12463,9 @@ var require_limit = __commonJS({
   }
 });
 
-// node_modules/ajv-formats/dist/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/dist/index.js
 var require_dist = __commonJS({
-  "node_modules/ajv-formats/dist/index.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/ajv-formats/dist/index.js"(exports, module) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var formats_1 = require_formats();
@@ -12492,12 +12492,12 @@ var require_dist = __commonJS({
         throw new Error(`Unknown format "${name}"`);
       return f;
     };
-    function addFormats(ajv, list, fs26, exportName) {
+    function addFormats(ajv, list, fs27, exportName) {
       var _a3;
       var _b;
       (_a3 = (_b = ajv.opts.code).formats) !== null && _a3 !== void 0 ? _a3 : _b.formats = (0, codegen_1._)`require("ajv-formats/dist/formats").${exportName}`;
       for (const f of list)
-        ajv.addFormat(f, fs26[f]);
+        ajv.addFormat(f, fs27[f]);
     }
     module.exports = exports = formatsPlugin;
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -12505,13 +12505,13 @@ var require_dist = __commonJS({
   }
 });
 
-// node_modules/isexe/windows.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/isexe/windows.js
 var require_windows = __commonJS({
-  "node_modules/isexe/windows.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/isexe/windows.js"(exports, module) {
     module.exports = isexe;
     isexe.sync = sync;
-    var fs26 = __require("fs");
-    function checkPathExt(path28, options) {
+    var fs27 = __require("fs");
+    function checkPathExt(path29, options) {
       var pathext = options.pathExt !== void 0 ? options.pathExt : process.env.PATHEXT;
       if (!pathext) {
         return true;
@@ -12522,42 +12522,42 @@ var require_windows = __commonJS({
       }
       for (var i = 0; i < pathext.length; i++) {
         var p = pathext[i].toLowerCase();
-        if (p && path28.substr(-p.length).toLowerCase() === p) {
+        if (p && path29.substr(-p.length).toLowerCase() === p) {
           return true;
         }
       }
       return false;
     }
-    function checkStat(stat, path28, options) {
+    function checkStat(stat, path29, options) {
       if (!stat.isSymbolicLink() && !stat.isFile()) {
         return false;
       }
-      return checkPathExt(path28, options);
+      return checkPathExt(path29, options);
     }
-    function isexe(path28, options, cb) {
-      fs26.stat(path28, function(er, stat) {
-        cb(er, er ? false : checkStat(stat, path28, options));
+    function isexe(path29, options, cb) {
+      fs27.stat(path29, function(er, stat) {
+        cb(er, er ? false : checkStat(stat, path29, options));
       });
     }
-    function sync(path28, options) {
-      return checkStat(fs26.statSync(path28), path28, options);
+    function sync(path29, options) {
+      return checkStat(fs27.statSync(path29), path29, options);
     }
   }
 });
 
-// node_modules/isexe/mode.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/isexe/mode.js
 var require_mode = __commonJS({
-  "node_modules/isexe/mode.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/isexe/mode.js"(exports, module) {
     module.exports = isexe;
     isexe.sync = sync;
-    var fs26 = __require("fs");
-    function isexe(path28, options, cb) {
-      fs26.stat(path28, function(er, stat) {
+    var fs27 = __require("fs");
+    function isexe(path29, options, cb) {
+      fs27.stat(path29, function(er, stat) {
         cb(er, er ? false : checkStat(stat, options));
       });
     }
-    function sync(path28, options) {
-      return checkStat(fs26.statSync(path28), options);
+    function sync(path29, options) {
+      return checkStat(fs27.statSync(path29), options);
     }
     function checkStat(stat, options) {
       return stat.isFile() && checkMode(stat, options);
@@ -12578,10 +12578,10 @@ var require_mode = __commonJS({
   }
 });
 
-// node_modules/isexe/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/isexe/index.js
 var require_isexe = __commonJS({
-  "node_modules/isexe/index.js"(exports, module) {
-    var fs26 = __require("fs");
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/isexe/index.js"(exports, module) {
+    var fs27 = __require("fs");
     var core;
     if (process.platform === "win32" || global.TESTING_WINDOWS) {
       core = require_windows();
@@ -12590,7 +12590,7 @@ var require_isexe = __commonJS({
     }
     module.exports = isexe;
     isexe.sync = sync;
-    function isexe(path28, options, cb) {
+    function isexe(path29, options, cb) {
       if (typeof options === "function") {
         cb = options;
         options = {};
@@ -12600,7 +12600,7 @@ var require_isexe = __commonJS({
           throw new TypeError("callback not provided");
         }
         return new Promise(function(resolve, reject) {
-          isexe(path28, options || {}, function(er, is) {
+          isexe(path29, options || {}, function(er, is) {
             if (er) {
               reject(er);
             } else {
@@ -12609,7 +12609,7 @@ var require_isexe = __commonJS({
           });
         });
       }
-      core(path28, options || {}, function(er, is) {
+      core(path29, options || {}, function(er, is) {
         if (er) {
           if (er.code === "EACCES" || options && options.ignoreErrors) {
             er = null;
@@ -12619,9 +12619,9 @@ var require_isexe = __commonJS({
         cb(er, is);
       });
     }
-    function sync(path28, options) {
+    function sync(path29, options) {
       try {
-        return core.sync(path28, options || {});
+        return core.sync(path29, options || {});
       } catch (er) {
         if (options && options.ignoreErrors || er.code === "EACCES") {
           return false;
@@ -12633,11 +12633,11 @@ var require_isexe = __commonJS({
   }
 });
 
-// node_modules/which/which.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/which/which.js
 var require_which = __commonJS({
-  "node_modules/which/which.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/which/which.js"(exports, module) {
     var isWindows = process.platform === "win32" || process.env.OSTYPE === "cygwin" || process.env.OSTYPE === "msys";
-    var path28 = __require("path");
+    var path29 = __require("path");
     var COLON = isWindows ? ";" : ":";
     var isexe = require_isexe();
     var getNotFoundError = (cmd) => Object.assign(new Error(`not found: ${cmd}`), { code: "ENOENT" });
@@ -12675,7 +12675,7 @@ var require_which = __commonJS({
           return opt.all && found.length ? resolve(found) : reject(getNotFoundError(cmd));
         const ppRaw = pathEnv[i];
         const pathPart = /^".*"$/.test(ppRaw) ? ppRaw.slice(1, -1) : ppRaw;
-        const pCmd = path28.join(pathPart, cmd);
+        const pCmd = path29.join(pathPart, cmd);
         const p = !pathPart && /^\.[\\\/]/.test(cmd) ? cmd.slice(0, 2) + pCmd : pCmd;
         resolve(subStep(p, i, 0));
       });
@@ -12702,7 +12702,7 @@ var require_which = __commonJS({
       for (let i = 0; i < pathEnv.length; i++) {
         const ppRaw = pathEnv[i];
         const pathPart = /^".*"$/.test(ppRaw) ? ppRaw.slice(1, -1) : ppRaw;
-        const pCmd = path28.join(pathPart, cmd);
+        const pCmd = path29.join(pathPart, cmd);
         const p = !pathPart && /^\.[\\\/]/.test(cmd) ? cmd.slice(0, 2) + pCmd : pCmd;
         for (let j = 0; j < pathExt.length; j++) {
           const cur = p + pathExt[j];
@@ -12729,9 +12729,9 @@ var require_which = __commonJS({
   }
 });
 
-// node_modules/path-key/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/path-key/index.js
 var require_path_key = __commonJS({
-  "node_modules/path-key/index.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/path-key/index.js"(exports, module) {
     "use strict";
     var pathKey = (options = {}) => {
       const environment = options.env || process.env;
@@ -12746,11 +12746,11 @@ var require_path_key = __commonJS({
   }
 });
 
-// node_modules/cross-spawn/lib/util/resolveCommand.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/util/resolveCommand.js
 var require_resolveCommand = __commonJS({
-  "node_modules/cross-spawn/lib/util/resolveCommand.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/util/resolveCommand.js"(exports, module) {
     "use strict";
-    var path28 = __require("path");
+    var path29 = __require("path");
     var which = require_which();
     var getPathKey = require_path_key();
     function resolveCommandAttempt(parsed, withoutPathExt) {
@@ -12768,7 +12768,7 @@ var require_resolveCommand = __commonJS({
       try {
         resolved = which.sync(parsed.command, {
           path: env[getPathKey({ env })],
-          pathExt: withoutPathExt ? path28.delimiter : void 0
+          pathExt: withoutPathExt ? path29.delimiter : void 0
         });
       } catch (e) {
       } finally {
@@ -12777,7 +12777,7 @@ var require_resolveCommand = __commonJS({
         }
       }
       if (resolved) {
-        resolved = path28.resolve(hasCustomCwd ? parsed.options.cwd : "", resolved);
+        resolved = path29.resolve(hasCustomCwd ? parsed.options.cwd : "", resolved);
       }
       return resolved;
     }
@@ -12788,9 +12788,9 @@ var require_resolveCommand = __commonJS({
   }
 });
 
-// node_modules/cross-spawn/lib/util/escape.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/util/escape.js
 var require_escape = __commonJS({
-  "node_modules/cross-spawn/lib/util/escape.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/util/escape.js"(exports, module) {
     "use strict";
     var metaCharsRegExp = /([()\][%!^"`<>&|;, *?])/g;
     function escapeCommand(arg) {
@@ -12813,17 +12813,17 @@ var require_escape = __commonJS({
   }
 });
 
-// node_modules/shebang-regex/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/shebang-regex/index.js
 var require_shebang_regex = __commonJS({
-  "node_modules/shebang-regex/index.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/shebang-regex/index.js"(exports, module) {
     "use strict";
     module.exports = /^#!(.*)/;
   }
 });
 
-// node_modules/shebang-command/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/shebang-command/index.js
 var require_shebang_command = __commonJS({
-  "node_modules/shebang-command/index.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/shebang-command/index.js"(exports, module) {
     "use strict";
     var shebangRegex = require_shebang_regex();
     module.exports = (string4 = "") => {
@@ -12831,8 +12831,8 @@ var require_shebang_command = __commonJS({
       if (!match) {
         return null;
       }
-      const [path28, argument] = match[0].replace(/#! ?/, "").split(" ");
-      const binary = path28.split("/").pop();
+      const [path29, argument] = match[0].replace(/#! ?/, "").split(" ");
+      const binary = path29.split("/").pop();
       if (binary === "env") {
         return argument;
       }
@@ -12841,20 +12841,20 @@ var require_shebang_command = __commonJS({
   }
 });
 
-// node_modules/cross-spawn/lib/util/readShebang.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/util/readShebang.js
 var require_readShebang = __commonJS({
-  "node_modules/cross-spawn/lib/util/readShebang.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/util/readShebang.js"(exports, module) {
     "use strict";
-    var fs26 = __require("fs");
+    var fs27 = __require("fs");
     var shebangCommand = require_shebang_command();
     function readShebang(command) {
       const size = 150;
       const buffer = Buffer.alloc(size);
       let fd;
       try {
-        fd = fs26.openSync(command, "r");
-        fs26.readSync(fd, buffer, 0, size, 0);
-        fs26.closeSync(fd);
+        fd = fs27.openSync(command, "r");
+        fs27.readSync(fd, buffer, 0, size, 0);
+        fs27.closeSync(fd);
       } catch (e) {
       }
       return shebangCommand(buffer.toString());
@@ -12863,11 +12863,11 @@ var require_readShebang = __commonJS({
   }
 });
 
-// node_modules/cross-spawn/lib/parse.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/parse.js
 var require_parse = __commonJS({
-  "node_modules/cross-spawn/lib/parse.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/parse.js"(exports, module) {
     "use strict";
-    var path28 = __require("path");
+    var path29 = __require("path");
     var resolveCommand = require_resolveCommand();
     var escape2 = require_escape();
     var readShebang = require_readShebang();
@@ -12892,7 +12892,7 @@ var require_parse = __commonJS({
       const needsShell = !isExecutableRegExp.test(commandFile);
       if (parsed.options.forceShell || needsShell) {
         const needsDoubleEscapeMetaChars = isCmdShimRegExp.test(commandFile);
-        parsed.command = path28.normalize(parsed.command);
+        parsed.command = path29.normalize(parsed.command);
         parsed.command = escape2.command(parsed.command);
         parsed.args = parsed.args.map((arg) => escape2.argument(arg, needsDoubleEscapeMetaChars));
         const shellCommand = [parsed.command].concat(parsed.args).join(" ");
@@ -12925,9 +12925,9 @@ var require_parse = __commonJS({
   }
 });
 
-// node_modules/cross-spawn/lib/enoent.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/enoent.js
 var require_enoent = __commonJS({
-  "node_modules/cross-spawn/lib/enoent.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/lib/enoent.js"(exports, module) {
     "use strict";
     var isWin = process.platform === "win32";
     function notFoundError(original, syscall) {
@@ -12975,9 +12975,9 @@ var require_enoent = __commonJS({
   }
 });
 
-// node_modules/cross-spawn/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/index.js
 var require_cross_spawn = __commonJS({
-  "node_modules/cross-spawn/index.js"(exports, module) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/cross-spawn/index.js"(exports, module) {
     "use strict";
     var cp = __require("child_process");
     var parse3 = require_parse();
@@ -13002,9 +13002,9 @@ var require_cross_spawn = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/identity.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/identity.js
 var require_identity = __commonJS({
-  "node_modules/yaml/dist/nodes/identity.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/identity.js"(exports) {
     "use strict";
     var ALIAS = Symbol.for("yaml.alias");
     var DOC = Symbol.for("yaml.document");
@@ -13015,10 +13015,10 @@ var require_identity = __commonJS({
     var NODE_TYPE = Symbol.for("yaml.node.type");
     var isAlias = (node) => !!node && typeof node === "object" && node[NODE_TYPE] === ALIAS;
     var isDocument = (node) => !!node && typeof node === "object" && node[NODE_TYPE] === DOC;
-    var isMap2 = (node) => !!node && typeof node === "object" && node[NODE_TYPE] === MAP;
+    var isMap3 = (node) => !!node && typeof node === "object" && node[NODE_TYPE] === MAP;
     var isPair = (node) => !!node && typeof node === "object" && node[NODE_TYPE] === PAIR;
     var isScalar = (node) => !!node && typeof node === "object" && node[NODE_TYPE] === SCALAR;
-    var isSeq2 = (node) => !!node && typeof node === "object" && node[NODE_TYPE] === SEQ;
+    var isSeq3 = (node) => !!node && typeof node === "object" && node[NODE_TYPE] === SEQ;
     function isCollection(node) {
       if (node && typeof node === "object")
         switch (node[NODE_TYPE]) {
@@ -13051,17 +13051,17 @@ var require_identity = __commonJS({
     exports.isAlias = isAlias;
     exports.isCollection = isCollection;
     exports.isDocument = isDocument;
-    exports.isMap = isMap2;
+    exports.isMap = isMap3;
     exports.isNode = isNode;
     exports.isPair = isPair;
     exports.isScalar = isScalar;
-    exports.isSeq = isSeq2;
+    exports.isSeq = isSeq3;
   }
 });
 
-// node_modules/yaml/dist/visit.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/visit.js
 var require_visit = __commonJS({
-  "node_modules/yaml/dist/visit.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/visit.js"(exports) {
     "use strict";
     var identity = require_identity();
     var BREAK = Symbol("break visit");
@@ -13079,17 +13079,17 @@ var require_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    function visit_(key, node, visitor, path28) {
-      const ctrl = callVisitor(key, node, visitor, path28);
+    function visit_(key, node, visitor, path29) {
+      const ctrl = callVisitor(key, node, visitor, path29);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path28, ctrl);
-        return visit_(key, ctrl, visitor, path28);
+        replaceNode(key, path29, ctrl);
+        return visit_(key, ctrl, visitor, path29);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path28 = Object.freeze(path28.concat(node));
+          path29 = Object.freeze(path29.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = visit_(i, node.items[i], visitor, path28);
+            const ci = visit_(i, node.items[i], visitor, path29);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -13100,13 +13100,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path28 = Object.freeze(path28.concat(node));
-          const ck = visit_("key", node.key, visitor, path28);
+          path29 = Object.freeze(path29.concat(node));
+          const ck = visit_("key", node.key, visitor, path29);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = visit_("value", node.value, visitor, path28);
+          const cv = visit_("value", node.value, visitor, path29);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -13127,17 +13127,17 @@ var require_visit = __commonJS({
     visitAsync.BREAK = BREAK;
     visitAsync.SKIP = SKIP;
     visitAsync.REMOVE = REMOVE;
-    async function visitAsync_(key, node, visitor, path28) {
-      const ctrl = await callVisitor(key, node, visitor, path28);
+    async function visitAsync_(key, node, visitor, path29) {
+      const ctrl = await callVisitor(key, node, visitor, path29);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path28, ctrl);
-        return visitAsync_(key, ctrl, visitor, path28);
+        replaceNode(key, path29, ctrl);
+        return visitAsync_(key, ctrl, visitor, path29);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path28 = Object.freeze(path28.concat(node));
+          path29 = Object.freeze(path29.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = await visitAsync_(i, node.items[i], visitor, path28);
+            const ci = await visitAsync_(i, node.items[i], visitor, path29);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -13148,13 +13148,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path28 = Object.freeze(path28.concat(node));
-          const ck = await visitAsync_("key", node.key, visitor, path28);
+          path29 = Object.freeze(path29.concat(node));
+          const ck = await visitAsync_("key", node.key, visitor, path29);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = await visitAsync_("value", node.value, visitor, path28);
+          const cv = await visitAsync_("value", node.value, visitor, path29);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -13181,24 +13181,24 @@ var require_visit = __commonJS({
       }
       return visitor;
     }
-    function callVisitor(key, node, visitor, path28) {
+    function callVisitor(key, node, visitor, path29) {
       var _a3, _b, _c, _d, _e;
       if (typeof visitor === "function")
-        return visitor(key, node, path28);
+        return visitor(key, node, path29);
       if (identity.isMap(node))
-        return (_a3 = visitor.Map) == null ? void 0 : _a3.call(visitor, key, node, path28);
+        return (_a3 = visitor.Map) == null ? void 0 : _a3.call(visitor, key, node, path29);
       if (identity.isSeq(node))
-        return (_b = visitor.Seq) == null ? void 0 : _b.call(visitor, key, node, path28);
+        return (_b = visitor.Seq) == null ? void 0 : _b.call(visitor, key, node, path29);
       if (identity.isPair(node))
-        return (_c = visitor.Pair) == null ? void 0 : _c.call(visitor, key, node, path28);
+        return (_c = visitor.Pair) == null ? void 0 : _c.call(visitor, key, node, path29);
       if (identity.isScalar(node))
-        return (_d = visitor.Scalar) == null ? void 0 : _d.call(visitor, key, node, path28);
+        return (_d = visitor.Scalar) == null ? void 0 : _d.call(visitor, key, node, path29);
       if (identity.isAlias(node))
-        return (_e = visitor.Alias) == null ? void 0 : _e.call(visitor, key, node, path28);
+        return (_e = visitor.Alias) == null ? void 0 : _e.call(visitor, key, node, path29);
       return void 0;
     }
-    function replaceNode(key, path28, node) {
-      const parent = path28[path28.length - 1];
+    function replaceNode(key, path29, node) {
+      const parent = path29[path29.length - 1];
       if (identity.isCollection(parent)) {
         parent.items[key] = node;
       } else if (identity.isPair(parent)) {
@@ -13218,9 +13218,9 @@ var require_visit = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/directives.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/directives.js
 var require_directives = __commonJS({
-  "node_modules/yaml/dist/doc/directives.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/directives.js"(exports) {
     "use strict";
     var identity = require_identity();
     var visit = require_visit();
@@ -13389,9 +13389,9 @@ var require_directives = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/anchors.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/anchors.js
 var require_anchors = __commonJS({
-  "node_modules/yaml/dist/doc/anchors.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/anchors.js"(exports) {
     "use strict";
     var identity = require_identity();
     var visit = require_visit();
@@ -13459,9 +13459,9 @@ var require_anchors = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/applyReviver.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/applyReviver.js
 var require_applyReviver = __commonJS({
-  "node_modules/yaml/dist/doc/applyReviver.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/applyReviver.js"(exports) {
     "use strict";
     function applyReviver(reviver, obj, key, val) {
       if (val && typeof val === "object") {
@@ -13509,9 +13509,9 @@ var require_applyReviver = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/toJS.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/toJS.js
 var require_toJS = __commonJS({
-  "node_modules/yaml/dist/nodes/toJS.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/toJS.js"(exports) {
     "use strict";
     var identity = require_identity();
     function toJS(value, arg, ctx) {
@@ -13539,9 +13539,9 @@ var require_toJS = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Node.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Node.js
 var require_Node = __commonJS({
-  "node_modules/yaml/dist/nodes/Node.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Node.js"(exports) {
     "use strict";
     var applyReviver = require_applyReviver();
     var identity = require_identity();
@@ -13580,9 +13580,9 @@ var require_Node = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Alias.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Alias.js
 var require_Alias = __commonJS({
-  "node_modules/yaml/dist/nodes/Alias.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Alias.js"(exports) {
     "use strict";
     var anchors = require_anchors();
     var visit = require_visit();
@@ -13694,9 +13694,9 @@ var require_Alias = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Scalar.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Scalar.js
 var require_Scalar = __commonJS({
-  "node_modules/yaml/dist/nodes/Scalar.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Scalar.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Node = require_Node();
@@ -13724,9 +13724,9 @@ var require_Scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/createNode.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/createNode.js
 var require_createNode = __commonJS({
-  "node_modules/yaml/dist/doc/createNode.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/createNode.js"(exports) {
     "use strict";
     var Alias = require_Alias();
     var identity = require_identity();
@@ -13803,17 +13803,17 @@ var require_createNode = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Collection.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Collection.js
 var require_Collection = __commonJS({
-  "node_modules/yaml/dist/nodes/Collection.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Collection.js"(exports) {
     "use strict";
     var createNode = require_createNode();
     var identity = require_identity();
     var Node = require_Node();
-    function collectionFromPath(schema, path28, value) {
+    function collectionFromPath(schema, path29, value) {
       let v = value;
-      for (let i = path28.length - 1; i >= 0; --i) {
-        const k = path28[i];
+      for (let i = path29.length - 1; i >= 0; --i) {
+        const k = path29[i];
         if (typeof k === "number" && Number.isInteger(k) && k >= 0) {
           const a = [];
           a[k] = v;
@@ -13832,7 +13832,7 @@ var require_Collection = __commonJS({
         sourceObjects: /* @__PURE__ */ new Map()
       });
     }
-    var isEmptyPath = (path28) => path28 == null || typeof path28 === "object" && !!path28[Symbol.iterator]().next().done;
+    var isEmptyPath = (path29) => path29 == null || typeof path29 === "object" && !!path29[Symbol.iterator]().next().done;
     var Collection = class extends Node.NodeBase {
       constructor(type, schema) {
         super(type);
@@ -13862,11 +13862,11 @@ var require_Collection = __commonJS({
        * be a Pair instance or a `{ key, value }` object, which may not have a key
        * that already exists in the map.
        */
-      addIn(path28, value) {
-        if (isEmptyPath(path28))
+      addIn(path29, value) {
+        if (isEmptyPath(path29))
           this.add(value);
         else {
-          const [key, ...rest] = path28;
+          const [key, ...rest] = path29;
           const node = this.get(key, true);
           if (identity.isCollection(node))
             node.addIn(rest, value);
@@ -13880,8 +13880,8 @@ var require_Collection = __commonJS({
        * Removes a value from the collection.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path28) {
-        const [key, ...rest] = path28;
+      deleteIn(path29) {
+        const [key, ...rest] = path29;
         if (rest.length === 0)
           return this.delete(key);
         const node = this.get(key, true);
@@ -13895,8 +13895,8 @@ var require_Collection = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path28, keepScalar) {
-        const [key, ...rest] = path28;
+      getIn(path29, keepScalar) {
+        const [key, ...rest] = path29;
         const node = this.get(key, true);
         if (rest.length === 0)
           return !keepScalar && identity.isScalar(node) ? node.value : node;
@@ -13914,8 +13914,8 @@ var require_Collection = __commonJS({
       /**
        * Checks if the collection includes a value with the key `key`.
        */
-      hasIn(path28) {
-        const [key, ...rest] = path28;
+      hasIn(path29) {
+        const [key, ...rest] = path29;
         if (rest.length === 0)
           return this.has(key);
         const node = this.get(key, true);
@@ -13925,8 +13925,8 @@ var require_Collection = __commonJS({
        * Sets a value in this collection. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path28, value) {
-        const [key, ...rest] = path28;
+      setIn(path29, value) {
+        const [key, ...rest] = path29;
         if (rest.length === 0) {
           this.set(key, value);
         } else {
@@ -13946,9 +13946,9 @@ var require_Collection = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyComment.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyComment.js
 var require_stringifyComment = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyComment.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyComment.js"(exports) {
     "use strict";
     var stringifyComment = (str) => str.replace(/^(?!$)(?: $)?/gm, "#");
     function indentComment(comment, indent4) {
@@ -13963,9 +13963,9 @@ var require_stringifyComment = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/foldFlowLines.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/foldFlowLines.js
 var require_foldFlowLines = __commonJS({
-  "node_modules/yaml/dist/stringify/foldFlowLines.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/foldFlowLines.js"(exports) {
     "use strict";
     var FOLD_FLOW = "flow";
     var FOLD_BLOCK = "block";
@@ -14099,9 +14099,9 @@ ${indent4}${text.slice(fold + 1, end2)}`;
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyString.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyString.js
 var require_stringifyString = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyString.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyString.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var foldFlowLines = require_foldFlowLines();
@@ -14385,9 +14385,9 @@ ${indent4}`);
   }
 });
 
-// node_modules/yaml/dist/stringify/stringify.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringify.js
 var require_stringify = __commonJS({
-  "node_modules/yaml/dist/stringify/stringify.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringify.js"(exports) {
     "use strict";
     var anchors = require_anchors();
     var identity = require_identity();
@@ -14513,9 +14513,9 @@ ${ctx.indent}${str}`;
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyPair.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyPair.js
 var require_stringifyPair = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyPair.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyPair.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -14646,9 +14646,9 @@ ${ctx.indent}`;
   }
 });
 
-// node_modules/yaml/dist/log.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/log.js
 var require_log = __commonJS({
-  "node_modules/yaml/dist/log.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/log.js"(exports) {
     "use strict";
     var node_process = __require("process");
     function debug(logLevel, ...messages) {
@@ -14668,9 +14668,9 @@ var require_log = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/merge.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/merge.js
 var require_merge = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/merge.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/merge.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -14725,9 +14725,9 @@ var require_merge = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/addPairToJSMap.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/addPairToJSMap.js
 var require_addPairToJSMap = __commonJS({
-  "node_modules/yaml/dist/nodes/addPairToJSMap.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/addPairToJSMap.js"(exports) {
     "use strict";
     var log = require_log();
     var merge2 = require_merge();
@@ -14789,9 +14789,9 @@ var require_addPairToJSMap = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Pair.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Pair.js
 var require_Pair = __commonJS({
-  "node_modules/yaml/dist/nodes/Pair.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/Pair.js"(exports) {
     "use strict";
     var createNode = require_createNode();
     var stringifyPair = require_stringifyPair();
@@ -14829,9 +14829,9 @@ var require_Pair = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyCollection.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyCollection.js
 var require_stringifyCollection = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyCollection.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyCollection.js"(exports) {
     "use strict";
     var identity = require_identity();
     var stringify = require_stringify();
@@ -14973,9 +14973,9 @@ ${indent4}${end}`;
   }
 });
 
-// node_modules/yaml/dist/nodes/YAMLMap.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/YAMLMap.js
 var require_YAMLMap = __commonJS({
-  "node_modules/yaml/dist/nodes/YAMLMap.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/YAMLMap.js"(exports) {
     "use strict";
     var stringifyCollection = require_stringifyCollection();
     var addPairToJSMap = require_addPairToJSMap();
@@ -15118,9 +15118,9 @@ var require_YAMLMap = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/common/map.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/map.js
 var require_map = __commonJS({
-  "node_modules/yaml/dist/schema/common/map.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/map.js"(exports) {
     "use strict";
     var identity = require_identity();
     var YAMLMap = require_YAMLMap();
@@ -15140,9 +15140,9 @@ var require_map = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/YAMLSeq.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/YAMLSeq.js
 var require_YAMLSeq = __commonJS({
-  "node_modules/yaml/dist/nodes/YAMLSeq.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/nodes/YAMLSeq.js"(exports) {
     "use strict";
     var createNode = require_createNode();
     var stringifyCollection = require_stringifyCollection();
@@ -15256,9 +15256,9 @@ var require_YAMLSeq = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/common/seq.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/seq.js
 var require_seq = __commonJS({
-  "node_modules/yaml/dist/schema/common/seq.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/seq.js"(exports) {
     "use strict";
     var identity = require_identity();
     var YAMLSeq = require_YAMLSeq();
@@ -15278,9 +15278,9 @@ var require_seq = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/common/string.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/string.js
 var require_string = __commonJS({
-  "node_modules/yaml/dist/schema/common/string.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/string.js"(exports) {
     "use strict";
     var stringifyString = require_stringifyString();
     var string4 = {
@@ -15297,9 +15297,9 @@ var require_string = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/common/null.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/null.js
 var require_null = __commonJS({
-  "node_modules/yaml/dist/schema/common/null.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/common/null.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var nullTag = {
@@ -15315,9 +15315,9 @@ var require_null = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/core/bool.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/bool.js
 var require_bool = __commonJS({
-  "node_modules/yaml/dist/schema/core/bool.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/bool.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var boolTag = {
@@ -15339,9 +15339,9 @@ var require_bool = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyNumber.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyNumber.js
 var require_stringifyNumber = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyNumber.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyNumber.js"(exports) {
     "use strict";
     function stringifyNumber({ format, minFractionDigits, tag, value }) {
       if (typeof value === "bigint")
@@ -15366,9 +15366,9 @@ var require_stringifyNumber = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/core/float.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/float.js
 var require_float = __commonJS({
-  "node_modules/yaml/dist/schema/core/float.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/float.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var stringifyNumber = require_stringifyNumber();
@@ -15412,9 +15412,9 @@ var require_float = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/core/int.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/int.js
 var require_int = __commonJS({
-  "node_modules/yaml/dist/schema/core/int.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/int.js"(exports) {
     "use strict";
     var stringifyNumber = require_stringifyNumber();
     var intIdentify = (value) => typeof value === "bigint" || Number.isInteger(value);
@@ -15457,9 +15457,9 @@ var require_int = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/core/schema.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/schema.js
 var require_schema = __commonJS({
-  "node_modules/yaml/dist/schema/core/schema.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/core/schema.js"(exports) {
     "use strict";
     var map2 = require_map();
     var _null4 = require_null();
@@ -15485,9 +15485,9 @@ var require_schema = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/json/schema.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/json/schema.js
 var require_schema2 = __commonJS({
-  "node_modules/yaml/dist/schema/json/schema.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/json/schema.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var map2 = require_map();
@@ -15552,9 +15552,9 @@ var require_schema2 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/binary.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/binary.js
 var require_binary = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/binary.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/binary.js"(exports) {
     "use strict";
     var node_buffer = __require("buffer");
     var Scalar = require_Scalar();
@@ -15618,9 +15618,9 @@ var require_binary = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/pairs.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/pairs.js
 var require_pairs = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/pairs.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/pairs.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Pair = require_Pair();
@@ -15696,9 +15696,9 @@ ${cn.comment}` : item.comment;
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/omap.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/omap.js
 var require_omap = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/omap.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/omap.js"(exports) {
     "use strict";
     var identity = require_identity();
     var toJS = require_toJS();
@@ -15774,9 +15774,9 @@ var require_omap = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/bool.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/bool.js
 var require_bool2 = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/bool.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/bool.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     function boolStringify({ value, source }, ctx) {
@@ -15806,9 +15806,9 @@ var require_bool2 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/float.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/float.js
 var require_float2 = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/float.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/float.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var stringifyNumber = require_stringifyNumber();
@@ -15855,9 +15855,9 @@ var require_float2 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/int.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/int.js
 var require_int2 = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/int.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/int.js"(exports) {
     "use strict";
     var stringifyNumber = require_stringifyNumber();
     var intIdentify = (value) => typeof value === "bigint" || Number.isInteger(value);
@@ -15934,9 +15934,9 @@ var require_int2 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/set.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/set.js
 var require_set = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/set.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/set.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Pair = require_Pair();
@@ -16023,9 +16023,9 @@ var require_set = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/timestamp.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/timestamp.js
 var require_timestamp = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/timestamp.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/timestamp.js"(exports) {
     "use strict";
     var stringifyNumber = require_stringifyNumber();
     function parseSexagesimal(str, asBigInt) {
@@ -16111,9 +16111,9 @@ var require_timestamp = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/schema.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/schema.js
 var require_schema3 = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/schema.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/yaml-1.1/schema.js"(exports) {
     "use strict";
     var map2 = require_map();
     var _null4 = require_null();
@@ -16155,9 +16155,9 @@ var require_schema3 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/tags.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/tags.js
 var require_tags = __commonJS({
-  "node_modules/yaml/dist/schema/tags.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/tags.js"(exports) {
     "use strict";
     var map2 = require_map();
     var _null4 = require_null();
@@ -16249,9 +16249,9 @@ var require_tags = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/Schema.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/Schema.js
 var require_Schema = __commonJS({
-  "node_modules/yaml/dist/schema/Schema.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/schema/Schema.js"(exports) {
     "use strict";
     var identity = require_identity();
     var map2 = require_map();
@@ -16281,9 +16281,9 @@ var require_Schema = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyDocument.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyDocument.js
 var require_stringifyDocument = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyDocument.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/stringify/stringifyDocument.js"(exports) {
     "use strict";
     var identity = require_identity();
     var stringify = require_stringify();
@@ -16362,9 +16362,9 @@ var require_stringifyDocument = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/Document.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/Document.js
 var require_Document = __commonJS({
-  "node_modules/yaml/dist/doc/Document.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/doc/Document.js"(exports) {
     "use strict";
     var Alias = require_Alias();
     var Collection = require_Collection();
@@ -16440,9 +16440,9 @@ var require_Document = __commonJS({
           this.contents.add(value);
       }
       /** Adds a value to the document. */
-      addIn(path28, value) {
+      addIn(path29, value) {
         if (assertCollection(this.contents))
-          this.contents.addIn(path28, value);
+          this.contents.addIn(path29, value);
       }
       /**
        * Create a new `Alias` node, ensuring that the target `node` has the required anchor.
@@ -16517,14 +16517,14 @@ var require_Document = __commonJS({
        * Removes a value from the document.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path28) {
-        if (Collection.isEmptyPath(path28)) {
+      deleteIn(path29) {
+        if (Collection.isEmptyPath(path29)) {
           if (this.contents == null)
             return false;
           this.contents = null;
           return true;
         }
-        return assertCollection(this.contents) ? this.contents.deleteIn(path28) : false;
+        return assertCollection(this.contents) ? this.contents.deleteIn(path29) : false;
       }
       /**
        * Returns item at `key`, or `undefined` if not found. By default unwraps
@@ -16539,10 +16539,10 @@ var require_Document = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path28, keepScalar) {
-        if (Collection.isEmptyPath(path28))
+      getIn(path29, keepScalar) {
+        if (Collection.isEmptyPath(path29))
           return !keepScalar && identity.isScalar(this.contents) ? this.contents.value : this.contents;
-        return identity.isCollection(this.contents) ? this.contents.getIn(path28, keepScalar) : void 0;
+        return identity.isCollection(this.contents) ? this.contents.getIn(path29, keepScalar) : void 0;
       }
       /**
        * Checks if the document includes a value with the key `key`.
@@ -16553,10 +16553,10 @@ var require_Document = __commonJS({
       /**
        * Checks if the document includes a value at `path`.
        */
-      hasIn(path28) {
-        if (Collection.isEmptyPath(path28))
+      hasIn(path29) {
+        if (Collection.isEmptyPath(path29))
           return this.contents !== void 0;
-        return identity.isCollection(this.contents) ? this.contents.hasIn(path28) : false;
+        return identity.isCollection(this.contents) ? this.contents.hasIn(path29) : false;
       }
       /**
        * Sets a value in this document. For `!!set`, `value` needs to be a
@@ -16573,13 +16573,13 @@ var require_Document = __commonJS({
        * Sets a value in this document. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path28, value) {
-        if (Collection.isEmptyPath(path28)) {
+      setIn(path29, value) {
+        if (Collection.isEmptyPath(path29)) {
           this.contents = value;
         } else if (this.contents == null) {
-          this.contents = Collection.collectionFromPath(this.schema, Array.from(path28), value);
+          this.contents = Collection.collectionFromPath(this.schema, Array.from(path29), value);
         } else if (assertCollection(this.contents)) {
-          this.contents.setIn(path28, value);
+          this.contents.setIn(path29, value);
         }
       }
       /**
@@ -16671,9 +16671,9 @@ var require_Document = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/errors.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/errors.js
 var require_errors3 = __commonJS({
-  "node_modules/yaml/dist/errors.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/errors.js"(exports) {
     "use strict";
     var YAMLError = class extends Error {
       constructor(name, pos, code, message) {
@@ -16736,9 +16736,9 @@ ${pointer}
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-props.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-props.js
 var require_resolve_props = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-props.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-props.js"(exports) {
     "use strict";
     function resolveProps(tokens, { flow, indicator, next, offset, onError, parentIndent, startOnNewline }) {
       let spaceBefore = false;
@@ -16870,9 +16870,9 @@ var require_resolve_props = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/util-contains-newline.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-contains-newline.js
 var require_util_contains_newline = __commonJS({
-  "node_modules/yaml/dist/compose/util-contains-newline.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-contains-newline.js"(exports) {
     "use strict";
     function containsNewline(key) {
       if (!key)
@@ -16912,9 +16912,9 @@ var require_util_contains_newline = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/util-flow-indent-check.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-flow-indent-check.js
 var require_util_flow_indent_check = __commonJS({
-  "node_modules/yaml/dist/compose/util-flow-indent-check.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-flow-indent-check.js"(exports) {
     "use strict";
     var utilContainsNewline = require_util_contains_newline();
     function flowIndentCheck(indent4, fc, onError) {
@@ -16930,9 +16930,9 @@ var require_util_flow_indent_check = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/util-map-includes.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-map-includes.js
 var require_util_map_includes = __commonJS({
-  "node_modules/yaml/dist/compose/util-map-includes.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-map-includes.js"(exports) {
     "use strict";
     var identity = require_identity();
     function mapIncludes(ctx, items, search) {
@@ -16946,9 +16946,9 @@ var require_util_map_includes = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-block-map.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-block-map.js
 var require_resolve_block_map = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-block-map.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-block-map.js"(exports) {
     "use strict";
     var Pair = require_Pair();
     var YAMLMap = require_YAMLMap();
@@ -17055,9 +17055,9 @@ var require_resolve_block_map = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-block-seq.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-block-seq.js
 var require_resolve_block_seq = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-block-seq.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-block-seq.js"(exports) {
     "use strict";
     var YAMLSeq = require_YAMLSeq();
     var resolveProps = require_resolve_props();
@@ -17106,9 +17106,9 @@ var require_resolve_block_seq = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-end.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-end.js
 var require_resolve_end = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-end.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-end.js"(exports) {
     "use strict";
     function resolveEnd(end, offset, reqSpace, onError) {
       let comment = "";
@@ -17149,9 +17149,9 @@ var require_resolve_end = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-flow-collection.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-flow-collection.js
 var require_resolve_flow_collection = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-flow-collection.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-flow-collection.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Pair = require_Pair();
@@ -17165,9 +17165,9 @@ var require_resolve_flow_collection = __commonJS({
     var isBlock = (token) => token && (token.type === "block-map" || token.type === "block-seq");
     function resolveFlowCollection({ composeNode, composeEmptyNode }, ctx, fc, onError, tag) {
       var _a3;
-      const isMap2 = fc.start.source === "{";
-      const fcName = isMap2 ? "flow map" : "flow sequence";
-      const NodeClass = (tag == null ? void 0 : tag.nodeClass) ?? (isMap2 ? YAMLMap.YAMLMap : YAMLSeq.YAMLSeq);
+      const isMap3 = fc.start.source === "{";
+      const fcName = isMap3 ? "flow map" : "flow sequence";
+      const NodeClass = (tag == null ? void 0 : tag.nodeClass) ?? (isMap3 ? YAMLMap.YAMLMap : YAMLSeq.YAMLSeq);
       const coll = new NodeClass(ctx.schema);
       coll.flow = true;
       const atRoot = ctx.atRoot;
@@ -17203,7 +17203,7 @@ var require_resolve_flow_collection = __commonJS({
             offset = props.end;
             continue;
           }
-          if (!isMap2 && ctx.options.strict && utilContainsNewline.containsNewline(key))
+          if (!isMap3 && ctx.options.strict && utilContainsNewline.containsNewline(key))
             onError(
               key,
               // checked by containsNewline()
@@ -17243,7 +17243,7 @@ var require_resolve_flow_collection = __commonJS({
             }
           }
         }
-        if (!isMap2 && !sep && !props.found) {
+        if (!isMap3 && !sep && !props.found) {
           const valueNode = value ? composeNode(ctx, value, props, onError) : composeEmptyNode(ctx, props.end, sep, null, props, onError);
           coll.items.push(valueNode);
           offset = valueNode.range[2];
@@ -17266,7 +17266,7 @@ var require_resolve_flow_collection = __commonJS({
             startOnNewline: false
           });
           if (valueProps.found) {
-            if (!isMap2 && !props.found && ctx.options.strict) {
+            if (!isMap3 && !props.found && ctx.options.strict) {
               if (sep)
                 for (const st of sep) {
                   if (st === valueProps.found)
@@ -17298,7 +17298,7 @@ var require_resolve_flow_collection = __commonJS({
           const pair = new Pair.Pair(keyNode, valueNode);
           if (ctx.options.keepSourceTokens)
             pair.srcToken = collItem;
-          if (isMap2) {
+          if (isMap3) {
             const map2 = coll;
             if (utilMapIncludes.mapIncludes(ctx, map2.items, keyNode))
               onError(keyStart, "DUPLICATE_KEY", "Map keys must be unique");
@@ -17314,7 +17314,7 @@ var require_resolve_flow_collection = __commonJS({
           offset = valueNode ? valueNode.range[2] : valueProps.end;
         }
       }
-      const expectedEnd = isMap2 ? "}" : "]";
+      const expectedEnd = isMap3 ? "}" : "]";
       const [ce, ...ee] = fc.end;
       let cePos = offset;
       if ((ce == null ? void 0 : ce.source) === expectedEnd)
@@ -17344,9 +17344,9 @@ var require_resolve_flow_collection = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/compose-collection.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-collection.js
 var require_compose_collection = __commonJS({
-  "node_modules/yaml/dist/compose/compose-collection.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-collection.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -17410,9 +17410,9 @@ var require_compose_collection = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-block-scalar.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-block-scalar.js
 var require_resolve_block_scalar = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-block-scalar.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-block-scalar.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     function resolveBlockScalar(ctx, scalar, onError) {
@@ -17593,9 +17593,9 @@ var require_resolve_block_scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-flow-scalar.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-flow-scalar.js
 var require_resolve_flow_scalar = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-flow-scalar.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/resolve-flow-scalar.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var resolveEnd = require_resolve_end();
@@ -17812,9 +17812,9 @@ var require_resolve_flow_scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/compose-scalar.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-scalar.js
 var require_compose_scalar = __commonJS({
-  "node_modules/yaml/dist/compose/compose-scalar.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-scalar.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -17900,9 +17900,9 @@ var require_compose_scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/util-empty-scalar-position.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-empty-scalar-position.js
 var require_util_empty_scalar_position = __commonJS({
-  "node_modules/yaml/dist/compose/util-empty-scalar-position.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/util-empty-scalar-position.js"(exports) {
     "use strict";
     function emptyScalarPosition(offset, before, pos) {
       if (before) {
@@ -17930,9 +17930,9 @@ var require_util_empty_scalar_position = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/compose-node.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-node.js
 var require_compose_node = __commonJS({
-  "node_modules/yaml/dist/compose/compose-node.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-node.js"(exports) {
     "use strict";
     var Alias = require_Alias();
     var identity = require_identity();
@@ -18031,9 +18031,9 @@ var require_compose_node = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/compose-doc.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-doc.js
 var require_compose_doc = __commonJS({
-  "node_modules/yaml/dist/compose/compose-doc.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/compose-doc.js"(exports) {
     "use strict";
     var Document = require_Document();
     var composeNode = require_compose_node();
@@ -18074,9 +18074,9 @@ var require_compose_doc = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/composer.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/composer.js
 var require_composer = __commonJS({
-  "node_modules/yaml/dist/compose/composer.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/compose/composer.js"(exports) {
     "use strict";
     var node_process = __require("process");
     var directives = require_directives();
@@ -18281,9 +18281,9 @@ ${end.comment}` : end.comment;
   }
 });
 
-// node_modules/yaml/dist/parse/cst-scalar.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst-scalar.js
 var require_cst_scalar = __commonJS({
-  "node_modules/yaml/dist/parse/cst-scalar.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst-scalar.js"(exports) {
     "use strict";
     var resolveBlockScalar = require_resolve_block_scalar();
     var resolveFlowScalar = require_resolve_flow_scalar();
@@ -18466,9 +18466,9 @@ var require_cst_scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/cst-stringify.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst-stringify.js
 var require_cst_stringify = __commonJS({
-  "node_modules/yaml/dist/parse/cst-stringify.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst-stringify.js"(exports) {
     "use strict";
     var stringify = (cst) => "type" in cst ? stringifyToken(cst) : stringifyItem(cst);
     function stringifyToken(token) {
@@ -18527,9 +18527,9 @@ var require_cst_stringify = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/cst-visit.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst-visit.js
 var require_cst_visit = __commonJS({
-  "node_modules/yaml/dist/parse/cst-visit.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst-visit.js"(exports) {
     "use strict";
     var BREAK = Symbol("break visit");
     var SKIP = Symbol("skip children");
@@ -18542,9 +18542,9 @@ var require_cst_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    visit.itemAtPath = (cst, path28) => {
+    visit.itemAtPath = (cst, path29) => {
       let item = cst;
-      for (const [field, index] of path28) {
+      for (const [field, index] of path29) {
         const tok = item == null ? void 0 : item[field];
         if (tok && "items" in tok) {
           item = tok.items[index];
@@ -18553,23 +18553,23 @@ var require_cst_visit = __commonJS({
       }
       return item;
     };
-    visit.parentCollection = (cst, path28) => {
-      const parent = visit.itemAtPath(cst, path28.slice(0, -1));
-      const field = path28[path28.length - 1][0];
+    visit.parentCollection = (cst, path29) => {
+      const parent = visit.itemAtPath(cst, path29.slice(0, -1));
+      const field = path29[path29.length - 1][0];
       const coll = parent == null ? void 0 : parent[field];
       if (coll && "items" in coll)
         return coll;
       throw new Error("Parent collection not found");
     };
-    function _visit(path28, item, visitor) {
-      let ctrl = visitor(item, path28);
+    function _visit(path29, item, visitor) {
+      let ctrl = visitor(item, path29);
       if (typeof ctrl === "symbol")
         return ctrl;
       for (const field of ["key", "value"]) {
         const token = item[field];
         if (token && "items" in token) {
           for (let i = 0; i < token.items.length; ++i) {
-            const ci = _visit(Object.freeze(path28.concat([[field, i]])), token.items[i], visitor);
+            const ci = _visit(Object.freeze(path29.concat([[field, i]])), token.items[i], visitor);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -18580,18 +18580,18 @@ var require_cst_visit = __commonJS({
             }
           }
           if (typeof ctrl === "function" && field === "key")
-            ctrl = ctrl(item, path28);
+            ctrl = ctrl(item, path29);
         }
       }
-      return typeof ctrl === "function" ? ctrl(item, path28) : ctrl;
+      return typeof ctrl === "function" ? ctrl(item, path29) : ctrl;
     }
     exports.visit = visit;
   }
 });
 
-// node_modules/yaml/dist/parse/cst.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst.js
 var require_cst = __commonJS({
-  "node_modules/yaml/dist/parse/cst.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/cst.js"(exports) {
     "use strict";
     var cstScalar = require_cst_scalar();
     var cstStringify = require_cst_stringify();
@@ -18691,9 +18691,9 @@ var require_cst = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/lexer.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/lexer.js
 var require_lexer = __commonJS({
-  "node_modules/yaml/dist/parse/lexer.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/lexer.js"(exports) {
     "use strict";
     var cst = require_cst();
     function isEmpty(ch) {
@@ -19270,9 +19270,9 @@ var require_lexer = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/line-counter.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/line-counter.js
 var require_line_counter = __commonJS({
-  "node_modules/yaml/dist/parse/line-counter.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/line-counter.js"(exports) {
     "use strict";
     var LineCounter = class {
       constructor() {
@@ -19301,9 +19301,9 @@ var require_line_counter = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/parser.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/parser.js
 var require_parser = __commonJS({
-  "node_modules/yaml/dist/parse/parser.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/parse/parser.js"(exports) {
     "use strict";
     var node_process = __require("process");
     var cst = require_cst();
@@ -19870,14 +19870,14 @@ var require_parser = __commonJS({
             case "scalar":
             case "single-quoted-scalar":
             case "double-quoted-scalar": {
-              const fs26 = this.flowScalar(this.type);
+              const fs27 = this.flowScalar(this.type);
               if (atNextItem || it.value) {
-                map2.items.push({ start, key: fs26, sep: [] });
+                map2.items.push({ start, key: fs27, sep: [] });
                 this.onKeyLine = true;
               } else if (it.sep) {
-                this.stack.push(fs26);
+                this.stack.push(fs27);
               } else {
-                Object.assign(it, { key: fs26, sep: [] });
+                Object.assign(it, { key: fs27, sep: [] });
                 this.onKeyLine = true;
               }
               return;
@@ -20006,13 +20006,13 @@ var require_parser = __commonJS({
             case "scalar":
             case "single-quoted-scalar":
             case "double-quoted-scalar": {
-              const fs26 = this.flowScalar(this.type);
+              const fs27 = this.flowScalar(this.type);
               if (!it || it.value)
-                fc.items.push({ start: [], key: fs26, sep: [] });
+                fc.items.push({ start: [], key: fs27, sep: [] });
               else if (it.sep)
-                this.stack.push(fs26);
+                this.stack.push(fs27);
               else
-                Object.assign(it, { key: fs26, sep: [] });
+                Object.assign(it, { key: fs27, sep: [] });
               return;
             }
             case "flow-map-end":
@@ -20171,9 +20171,9 @@ var require_parser = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/public-api.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/public-api.js
 var require_public_api = __commonJS({
-  "node_modules/yaml/dist/public-api.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/public-api.js"(exports) {
     "use strict";
     var composer = require_composer();
     var Document = require_Document();
@@ -20201,7 +20201,7 @@ var require_public_api = __commonJS({
         return docs;
       return Object.assign([], { empty: true }, composer$1.streamInfo());
     }
-    function parseDocument2(source, options = {}) {
+    function parseDocument3(source, options = {}) {
       const { lineCounter: lineCounter2, prettyErrors } = parseOptions(options);
       const parser$1 = new parser.Parser(lineCounter2 == null ? void 0 : lineCounter2.addNewLine);
       const composer$1 = new composer.Composer(options);
@@ -20227,7 +20227,7 @@ var require_public_api = __commonJS({
       } else if (options === void 0 && reviver && typeof reviver === "object") {
         options = reviver;
       }
-      const doc = parseDocument2(src, options);
+      const doc = parseDocument3(src, options);
       if (!doc)
         return null;
       doc.warnings.forEach((warning) => log.warn(doc.options.logLevel, warning));
@@ -20263,14 +20263,14 @@ var require_public_api = __commonJS({
     }
     exports.parse = parse3;
     exports.parseAllDocuments = parseAllDocuments;
-    exports.parseDocument = parseDocument2;
+    exports.parseDocument = parseDocument3;
     exports.stringify = stringify;
   }
 });
 
-// node_modules/yaml/dist/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/index.js
 var require_dist2 = __commonJS({
-  "node_modules/yaml/dist/index.js"(exports) {
+  "../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/yaml/dist/index.js"(exports) {
     "use strict";
     var composer = require_composer();
     var Document = require_Document();
@@ -20326,7 +20326,7 @@ import fs17 from "node:fs";
 import path18 from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 
-// node_modules/zod/v3/helpers/util.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v3/helpers/util.js
 var util;
 (function(util2) {
   util2.assertEqual = (_) => {
@@ -20460,7 +20460,7 @@ var getParsedType = (data) => {
   }
 };
 
-// node_modules/zod/v3/ZodError.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v3/ZodError.js
 var ZodIssueCode = util.arrayToEnum([
   "invalid_type",
   "invalid_literal",
@@ -20574,7 +20574,7 @@ ZodError.create = (issues) => {
   return error2;
 };
 
-// node_modules/zod/v3/locales/en.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v3/locales/en.js
 var errorMap = (issue3, _ctx) => {
   let message;
   switch (issue3.code) {
@@ -20677,16 +20677,16 @@ var errorMap = (issue3, _ctx) => {
 };
 var en_default = errorMap;
 
-// node_modules/zod/v3/errors.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v3/errors.js
 var overrideErrorMap = en_default;
 function getErrorMap() {
   return overrideErrorMap;
 }
 
-// node_modules/zod/v3/helpers/parseUtil.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v3/helpers/parseUtil.js
 var makeIssue = (params) => {
-  const { data, path: path28, errorMaps, issueData } = params;
-  const fullPath = [...path28, ...issueData.path || []];
+  const { data, path: path29, errorMaps, issueData } = params;
+  const fullPath = [...path29, ...issueData.path || []];
   const fullIssue = {
     ...issueData,
     path: fullPath
@@ -20792,20 +20792,20 @@ var isDirty = (x) => x.status === "dirty";
 var isValid = (x) => x.status === "valid";
 var isAsync = (x) => typeof Promise !== "undefined" && x instanceof Promise;
 
-// node_modules/zod/v3/helpers/errorUtil.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v3/helpers/errorUtil.js
 var errorUtil;
 (function(errorUtil2) {
   errorUtil2.errToObj = (message) => typeof message === "string" ? { message } : message || {};
   errorUtil2.toString = (message) => typeof message === "string" ? message : message == null ? void 0 : message.message;
 })(errorUtil || (errorUtil = {}));
 
-// node_modules/zod/v3/types.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v3/types.js
 var ParseInputLazyPath = class {
-  constructor(parent, value, path28, key) {
+  constructor(parent, value, path29, key) {
     this._cachedPath = [];
     this.parent = parent;
     this.data = value;
-    this._path = path28;
+    this._path = path29;
     this._key = key;
   }
   get path() {
@@ -24205,7 +24205,7 @@ var nullableType = ZodNullable.create;
 var preprocessType = ZodEffects.createWithPreprocess;
 var pipelineType = ZodPipeline.create;
 
-// node_modules/zod/v4/core/core.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/core.js
 var NEVER = Object.freeze({
   status: "aborted"
 });
@@ -24281,7 +24281,7 @@ function config(newConfig) {
   return globalConfig;
 }
 
-// node_modules/zod/v4/core/util.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/util.js
 var util_exports = {};
 __export(util_exports, {
   BIGINT_FORMAT_RANGES: () => BIGINT_FORMAT_RANGES,
@@ -24454,10 +24454,10 @@ function mergeDefs(...defs) {
 function cloneDef(schema) {
   return mergeDefs(schema._zod.def);
 }
-function getElementAtPath(obj, path28) {
-  if (!path28)
+function getElementAtPath(obj, path29) {
+  if (!path29)
     return obj;
-  return path28.reduce((acc, key) => acc == null ? void 0 : acc[key], obj);
+  return path29.reduce((acc, key) => acc == null ? void 0 : acc[key], obj);
 }
 function promiseAllObject(promisesObj) {
   const keys = Object.keys(promisesObj);
@@ -24842,11 +24842,11 @@ function aborted(x, startIndex = 0) {
   }
   return false;
 }
-function prefixIssues(path28, issues) {
+function prefixIssues(path29, issues) {
   return issues.map((iss) => {
     var _a3;
     (_a3 = iss).path ?? (_a3.path = []);
-    iss.path.unshift(path28);
+    iss.path.unshift(path29);
     return iss;
   });
 }
@@ -24963,7 +24963,7 @@ var Class = class {
   }
 };
 
-// node_modules/zod/v4/core/errors.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/errors.js
 var initializer = (inst, def) => {
   inst.name = "$ZodError";
   Object.defineProperty(inst, "_zod", {
@@ -25029,7 +25029,7 @@ function formatError(error2, mapper = (issue3) => issue3.message) {
   return fieldErrors;
 }
 
-// node_modules/zod/v4/core/parse.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/parse.js
 var _parse = (_Err) => (schema, value, _ctx, _params) => {
   const ctx = _ctx ? Object.assign(_ctx, { async: false }) : { async: false };
   const result = schema._zod.run({ value, issues: [] }, ctx);
@@ -25109,7 +25109,7 @@ var _safeDecodeAsync = (_Err) => async (schema, value, _ctx) => {
   return _safeParseAsync(_Err)(schema, value, _ctx);
 };
 
-// node_modules/zod/v4/core/regexes.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/regexes.js
 var regexes_exports = {};
 __export(regexes_exports, {
   base64: () => base64,
@@ -25266,7 +25266,7 @@ var sha512_hex = /^[0-9a-fA-F]{128}$/;
 var sha512_base64 = /* @__PURE__ */ fixedBase64(86, "==");
 var sha512_base64url = /* @__PURE__ */ fixedBase64url(86);
 
-// node_modules/zod/v4/core/checks.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/checks.js
 var $ZodCheck = /* @__PURE__ */ $constructor("$ZodCheck", (inst, def) => {
   var _a3;
   inst._zod ?? (inst._zod = {});
@@ -25815,7 +25815,7 @@ var $ZodCheckOverwrite = /* @__PURE__ */ $constructor("$ZodCheckOverwrite", (ins
   };
 });
 
-// node_modules/zod/v4/core/doc.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/doc.js
 var Doc = class {
   constructor(args = []) {
     this.content = [];
@@ -25851,14 +25851,14 @@ var Doc = class {
   }
 };
 
-// node_modules/zod/v4/core/versions.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/versions.js
 var version = {
   major: 4,
   minor: 3,
   patch: 6
 };
 
-// node_modules/zod/v4/core/schemas.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/schemas.js
 var $ZodType = /* @__PURE__ */ $constructor("$ZodType", (inst, def) => {
   var _a4;
   var _a3;
@@ -27856,7 +27856,7 @@ function handleRefineResult(result, payload, input2, inst) {
   }
 }
 
-// node_modules/zod/v4/locales/en.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/locales/en.js
 var error = () => {
   const Sizable = {
     string: { unit: "characters", verb: "to have" },
@@ -27965,7 +27965,7 @@ function en_default2() {
   };
 }
 
-// node_modules/zod/v4/core/registries.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/registries.js
 var _a;
 var $output = Symbol("ZodOutput");
 var $input = Symbol("ZodInput");
@@ -28015,7 +28015,7 @@ function registry() {
 (_a = globalThis).__zod_globalRegistry ?? (_a.__zod_globalRegistry = registry());
 var globalRegistry = globalThis.__zod_globalRegistry;
 
-// node_modules/zod/v4/core/api.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/api.js
 // @__NO_SIDE_EFFECTS__
 function _string(Class2, params) {
   return new Class2({
@@ -28860,7 +28860,7 @@ function _stringFormat(Class2, format, fnOrRegex, _params = {}) {
   return inst;
 }
 
-// node_modules/zod/v4/core/to-json-schema.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/to-json-schema.js
 function initializeContext(params) {
   let target = (params == null ? void 0 : params.target) ?? "draft-2020-12";
   if (target === "draft-4")
@@ -29216,7 +29216,7 @@ var createStandardJSONSchemaMethod = (schema, io, processors = {}) => (params) =
   return finalize(ctx, schema);
 };
 
-// node_modules/zod/v4/core/json-schema-processors.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/core/json-schema-processors.js
 var formatMap = {
   guid: "uuid",
   url: "uri",
@@ -29693,7 +29693,7 @@ var lazyProcessor = (schema, ctx, _json, params) => {
   seen.ref = innerType;
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-compat.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-compat.js
 function isZ4Schema(s) {
   const schema = s;
   return !!schema._zod;
@@ -29758,7 +29758,7 @@ function getLiteralValue(schema) {
   return void 0;
 }
 
-// node_modules/zod/v4/classic/schemas.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/schemas.js
 var schemas_exports3 = {};
 __export(schemas_exports3, {
   ZodAny: () => ZodAny2,
@@ -29927,7 +29927,7 @@ __export(schemas_exports3, {
   xor: () => xor
 });
 
-// node_modules/zod/v4/classic/checks.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/checks.js
 var checks_exports2 = {};
 __export(checks_exports2, {
   endsWith: () => _endsWith,
@@ -29961,7 +29961,7 @@ __export(checks_exports2, {
   uppercase: () => _uppercase
 });
 
-// node_modules/zod/v4/classic/iso.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/iso.js
 var iso_exports2 = {};
 __export(iso_exports2, {
   ZodISODate: () => ZodISODate,
@@ -30002,7 +30002,7 @@ function duration2(params) {
   return _isoDuration(ZodISODuration, params);
 }
 
-// node_modules/zod/v4/classic/errors.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/errors.js
 var initializer2 = (inst, issues) => {
   $ZodError.init(inst, issues);
   inst.name = "ZodError";
@@ -30042,7 +30042,7 @@ var ZodRealError = $constructor("ZodError", initializer2, {
   Parent: Error
 });
 
-// node_modules/zod/v4/classic/parse.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/parse.js
 var parse2 = /* @__PURE__ */ _parse(ZodRealError);
 var parseAsync2 = /* @__PURE__ */ _parseAsync(ZodRealError);
 var safeParse3 = /* @__PURE__ */ _safeParse(ZodRealError);
@@ -30056,7 +30056,7 @@ var safeDecode2 = /* @__PURE__ */ _safeDecode(ZodRealError);
 var safeEncodeAsync2 = /* @__PURE__ */ _safeEncodeAsync(ZodRealError);
 var safeDecodeAsync2 = /* @__PURE__ */ _safeDecodeAsync(ZodRealError);
 
-// node_modules/zod/v4/classic/schemas.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/schemas.js
 var ZodType2 = /* @__PURE__ */ $constructor("ZodType", (inst, def) => {
   $ZodType.init(inst, def);
   Object.assign(inst["~standard"], {
@@ -31136,7 +31136,7 @@ function preprocess(fn, schema) {
   return pipe(transform(fn), schema);
 }
 
-// node_modules/zod/v4/classic/compat.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/compat.js
 var ZodIssueCode2 = {
   invalid_type: "invalid_type",
   too_big: "too_big",
@@ -31154,14 +31154,14 @@ var ZodFirstPartyTypeKind2;
 /* @__PURE__ */ (function(ZodFirstPartyTypeKind3) {
 })(ZodFirstPartyTypeKind2 || (ZodFirstPartyTypeKind2 = {}));
 
-// node_modules/zod/v4/classic/from-json-schema.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/from-json-schema.js
 var z = {
   ...schemas_exports3,
   ...checks_exports2,
   iso: iso_exports2
 };
 
-// node_modules/zod/v4/classic/coerce.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/coerce.js
 var coerce_exports2 = {};
 __export(coerce_exports2, {
   bigint: () => bigint3,
@@ -31186,10 +31186,10 @@ function date4(params) {
   return _coercedDate(ZodDate2, params);
 }
 
-// node_modules/zod/v4/classic/external.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod/v4/classic/external.js
 config(en_default2());
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/types.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/types.js
 var LATEST_PROTOCOL_VERSION = "2025-11-25";
 var SUPPORTED_PROTOCOL_VERSIONS = [LATEST_PROTOCOL_VERSION, "2025-06-18", "2025-03-26", "2024-11-05", "2024-10-07"];
 var RELATED_TASK_META_KEY = "io.modelcontextprotocol/related-task";
@@ -32697,18 +32697,18 @@ var UrlElicitationRequiredError = class extends McpError {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/interfaces.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/interfaces.js
 function isTerminal(status) {
   return status === "completed" || status === "failed" || status === "cancelled";
 }
 
-// node_modules/zod-to-json-schema/dist/esm/Options.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod-to-json-schema/dist/esm/Options.js
 var ignoreOverride = Symbol("Let zodToJsonSchema decide on which parser to use");
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/string.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/zod-to-json-schema/dist/esm/parsers/string.js
 var ALPHA_NUMERIC = new Set("ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvxyz0123456789");
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-json-schema-compat.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-json-schema-compat.js
 function getMethodLiteral(schema) {
   const shape = getObjectShape(schema);
   const methodSchema = shape == null ? void 0 : shape.method;
@@ -32729,7 +32729,7 @@ function parseWithCompat(schema, data) {
   return result.data;
 }
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/protocol.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/protocol.js
 var DEFAULT_REQUEST_TIMEOUT_MSEC = 6e4;
 var Protocol = class {
   constructor(_options) {
@@ -33694,7 +33694,7 @@ function mergeCapabilities(base, additional) {
   return result;
 }
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/validation/ajv-provider.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/validation/ajv-provider.js
 var import_ajv = __toESM(require_ajv(), 1);
 var import_ajv_formats = __toESM(require_dist(), 1);
 function createDefaultAjvInstance() {
@@ -33762,7 +33762,7 @@ var AjvJsonSchemaValidator = class {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/server.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/server.js
 var ExperimentalServerTasks = class {
   constructor(_server) {
     this._server = _server;
@@ -33977,7 +33977,7 @@ var ExperimentalServerTasks = class {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/helpers.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/helpers.js
 function assertToolsCallTaskCapability(requests, method, entityName) {
   var _a3;
   if (!requests) {
@@ -34014,7 +34014,7 @@ function assertClientRequestTaskCapability(requests, method, entityName) {
   }
 }
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/server/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/index.js
 var Server = class extends Protocol {
   /**
    * Initializes this server with the given name and version information.
@@ -34406,10 +34406,10 @@ var Server = class extends Protocol {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js
 import process3 from "node:process";
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/stdio.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/stdio.js
 var ReadBuffer = class {
   append(chunk) {
     this._buffer = this._buffer ? Buffer.concat([this._buffer, chunk]) : chunk;
@@ -34437,7 +34437,7 @@ function serializeMessage(message) {
   return JSON.stringify(message) + "\n";
 }
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js
 var StdioServerTransport = class {
   constructor(_stdin = process3.stdin, _stdout = process3.stdout) {
     this._stdin = _stdin;
@@ -34501,7 +34501,7 @@ var StdioServerTransport = class {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/client.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/client.js
 var ExperimentalClientTasks = class {
   constructor(_client) {
     this._client = _client;
@@ -34655,7 +34655,7 @@ var ExperimentalClientTasks = class {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/client/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/client/index.js
 function applyElicitationDefaults(schema, data) {
   if (!schema || data === null || typeof data !== "object")
     return;
@@ -35185,7 +35185,7 @@ var Client = class extends Protocol {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/client/stdio.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/client/stdio.js
 var import_cross_spawn = __toESM(require_cross_spawn(), 1);
 import process4 from "node:process";
 import { PassThrough } from "node:stream";
@@ -37890,12 +37890,12 @@ function getBlockingRemoteSyncFailure(status) {
   };
 }
 function includeMandatoryMakerSubmitFiles(cwd, files) {
-  const unique = new Set(files);
+  const unique2 = new Set(files);
   const changedFiles = parseGitStatusFiles(readGitSync(["-C", cwd, "status", "--porcelain", "-z"]));
   if (changedFiles.includes(".gitignore")) {
-    unique.add(".gitignore");
+    unique2.add(".gitignore");
   }
-  return [...unique];
+  return [...unique2];
 }
 async function readMakerProjectLocalChanges(cwd) {
   ensureGitAvailable();
@@ -39693,9 +39693,15 @@ function resolveMakerPluginDistribution(distribution = process.env.TAPTAP_MAKER_
   if (distribution === "workbuddy_plugin") {
     return { id: distribution, client: "workbuddy", displayName: "WorkBuddy" };
   }
+  if (distribution === "dsh_plugin") {
+    return { id: distribution, client: "dsh", displayName: "DSH" };
+  }
   return void 0;
 }
 function formatMakerPluginUpdateAction(distribution) {
+  if (distribution.client === "dsh") {
+    return "Update the installed DSH plugin via `dsh plugin --profile <profile> update @taptap/dsh-maker`; do not install or upgrade the standalone npm package.";
+  }
   return `Update the installed ${distribution.displayName} plugin through its marketplace; do not install or upgrade the standalone npm package.`;
 }
 
@@ -39717,7 +39723,8 @@ var BUNDLED_SKILLS = [
 ];
 function formatMakerSkillStatus(_options = {}) {
   const pluginDistribution = resolveMakerPluginDistribution();
-  const bundledSkills = pluginDistribution ? [...BUNDLED_SKILLS, { name: MAKER_PLUGIN_LIFECYCLE_SKILL_NAME }] : BUNDLED_SKILLS;
+  const clientPluginDistribution = pluginDistribution && pluginDistribution.client !== "dsh" ? pluginDistribution : void 0;
+  const bundledSkills = clientPluginDistribution ? [...BUNDLED_SKILLS, { name: MAKER_PLUGIN_LIFECYCLE_SKILL_NAME }] : BUNDLED_SKILLS;
   const skillDocuments = bundledSkills.map((skill) => ({
     name: skill.name,
     path: path11.join(resolveMakerSkillSourceDir(skill.name), "SKILL.md")
@@ -39728,17 +39735,25 @@ function formatMakerSkillStatus(_options = {}) {
     ...skillDocuments.map((skill) => `- ${skill.name}: ${skill.path}`),
     "",
     "Use these documents as reading references for Maker local workflows.",
-    ...pluginDistribution ? [
+    ...clientPluginDistribution ? [
       "",
-      `Maker ${pluginDistribution.displayName} plugin lifecycle`,
+      `Maker ${clientPluginDistribution.displayName} plugin lifecycle`,
       `- entry: ${MAKER_PLUGIN_LIFECYCLE_SKILL_NAME}`,
-      `- Inspect a legacy ${pluginDistribution.displayName} Maker MCP registration before first use.`,
-      ...pluginDistribution.client === "codex" ? [
+      `- Inspect a legacy ${clientPluginDistribution.displayName} Maker MCP registration before first use.`,
+      ...clientPluginDistribution.client === "codex" ? [
         "- Automatically disable an active legacy Codex Maker MCP; the plugin installation request is the authorization.",
         "- Verify the legacy registration is disabled or absent before reporting the plugin ready.",
         "- Require explicit confirmation only when restoring the old MCP during plugin removal."
       ] : ["- Require explicit confirmation before disabling or restoring it."],
       "- Initialize with `taptap-maker init --skip-mcp-install`; the plugin already provides MCP.",
+      `- ${formatMakerPluginUpdateAction(clientPluginDistribution)}`
+    ] : [],
+    ...(pluginDistribution == null ? void 0 : pluginDistribution.client) === "dsh" ? [
+      "",
+      "Maker DSH plugin lifecycle",
+      "- Inspect a legacy DSH L1 MCP registration with `taptap-maker plugin inspect --client dsh` before first use.",
+      "- Migrate/disable it with `taptap-maker plugin migrate --client dsh --confirm`; restore with `taptap-maker plugin restore --client dsh --confirm`.",
+      "- Initialize with `taptap-maker init --skip-mcp-install`; the DSH plugin already provides MCP.",
       `- ${formatMakerPluginUpdateAction(pluginDistribution)}`
     ] : [],
     "",
@@ -47504,10 +47519,10 @@ function indent2(value) {
 
 // src/maker/cli/commands.ts
 import { spawnSync as spawnSync8 } from "node:child_process";
-import crypto4 from "node:crypto";
-import fs24 from "node:fs";
-import os7 from "node:os";
-import path25 from "node:path";
+import crypto5 from "node:crypto";
+import fs25 from "node:fs";
+import os8 from "node:os";
+import path26 from "node:path";
 import readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
 import { pathToFileURL } from "node:url";
@@ -49556,14 +49571,259 @@ function isRecord5(value) {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
-// src/maker/cli/workBuddyProjectSkills.ts
+// src/maker/cli/dshPluginMigration.ts
+var import_yaml2 = __toESM(require_dist2());
 import fs23 from "node:fs";
+import os7 from "node:os";
 import path24 from "node:path";
+import crypto4 from "node:crypto";
+var DSH_MAKER_MCP_NAME = "taptap-maker";
+function inspectDshLegacyMakerMcp(options = {}) {
+  const registrations = findDshMakerRegistrations(options.dshHome);
+  const configPaths = unique(registrations.map((entry) => entry.configPath));
+  if (registrations.length === 0) {
+    return createDshInspection("not_found", [], configPaths);
+  }
+  if (registrations.length > 1) {
+    return createDshInspection("ambiguous", configPaths, configPaths);
+  }
+  return createDshInspection("active", [registrations[0].configPath], configPaths);
+}
+function migrateDshLegacyMakerMcp(options = {}) {
+  const makerHome = getMakerHome();
+  const statePath = getDshPluginMigrationStatePath(makerHome);
+  const registrations = findDshMakerRegistrations(options.dshHome);
+  const inspection = inspectDshLegacyMakerMcp(options);
+  if (inspection.status === "not_found") {
+    return { ...inspection, action: "not_found", changed: false };
+  }
+  if (inspection.status === "ambiguous") {
+    throw new Error(
+      `DSH Maker MCP migration found ${inspection.registration_count} registrations in ${inspection.config_paths.join(", ")}; resolve the duplicates before migrating.`
+    );
+  }
+  if (!options.confirm) {
+    throw new Error(
+      "Removing the legacy DSH Maker MCP registration requires explicit confirmation."
+    );
+  }
+  const registration = registrations[0];
+  const previousContent = fs23.readFileSync(registration.configPath, "utf8");
+  const document = (0, import_yaml2.parseDocument)(previousContent, { prettyErrors: true });
+  if (document.errors.length > 0) {
+    throw new Error(`Invalid YAML in ${registration.configPath}: ${document.errors[0].message}`);
+  }
+  removeDshMakerRegistration(document, registration);
+  const nextContent = document.toString({ lineWidth: 0 });
+  const state = {
+    schema_version: 1,
+    client: "dsh",
+    config_path: registration.configPath,
+    removed_registration: registration.registration,
+    removed_registration_sha256: sha2562(JSON.stringify(registration.registration)),
+    migrated_at: (/* @__PURE__ */ new Date()).toISOString()
+  };
+  fs23.mkdirSync(path24.dirname(statePath), { recursive: true });
+  const write = writeConfigWithTapTapBackupIfChanged(registration.configPath, nextContent, () => {
+    const after = findDshMakerRegistrations(options.dshHome);
+    if (after.some((entry) => entry.configPath === registration.configPath)) {
+      throw new Error("DSH Maker MCP migration validation still found a registration.");
+    }
+    fs23.writeFileSync(statePath, `${JSON.stringify(state, null, 2)}
+`, "utf8");
+  });
+  return {
+    ...inspectDshLegacyMakerMcp(options),
+    action: "removed",
+    changed: write.changed,
+    ...write.backupPath ? { backup_path: write.backupPath } : {},
+    state_path: statePath
+  };
+}
+function restoreDshLegacyMakerMcp(options = {}) {
+  const makerHome = getMakerHome();
+  const statePath = getDshPluginMigrationStatePath(makerHome);
+  const inspection = inspectDshLegacyMakerMcp(options);
+  const state = readDshMigrationState(statePath);
+  if (!state) {
+    return { ...inspection, action: "not_owned", changed: false };
+  }
+  if (!options.confirm) {
+    throw new Error(
+      "Restoring the legacy DSH Maker MCP registration requires explicit confirmation."
+    );
+  }
+  if (inspection.status === "ambiguous") {
+    throw new Error(
+      `DSH Maker MCP restoration found ${inspection.registration_count} registrations; resolve the duplicates before restoring.`
+    );
+  }
+  if (inspection.status === "active") {
+    const current = findDshMakerRegistrations(options.dshHome)[0];
+    const currentSha = sha2562(JSON.stringify(current.registration));
+    if (currentSha === state.removed_registration_sha256) {
+      fs23.rmSync(statePath, { force: true });
+      return { ...inspection, action: "already_restored", changed: false, state_path: statePath };
+    }
+    return { ...inspection, action: "not_owned", changed: false };
+  }
+  const configPath = state.config_path;
+  const previousContent = fs23.readFileSync(configPath, "utf8");
+  const document = (0, import_yaml2.parseDocument)(previousContent, { prettyErrors: true });
+  if (document.errors.length > 0) {
+    throw new Error(`Invalid YAML in ${configPath}: ${document.errors[0].message}`);
+  }
+  reinsertDshMakerRegistration(document, state.removed_registration);
+  const nextContent = document.toString({ lineWidth: 0 });
+  const write = writeConfigWithTapTapBackupIfChanged(configPath, nextContent, () => {
+    const restored = findDshMakerRegistrations(options.dshHome);
+    const match = restored.find((entry) => entry.configPath === configPath);
+    if (!match || sha2562(JSON.stringify(match.registration)) !== state.removed_registration_sha256) {
+      throw new Error("DSH Maker MCP restoration changed the registration identity.");
+    }
+    fs23.rmSync(statePath, { force: true });
+  });
+  return {
+    ...inspectDshLegacyMakerMcp(options),
+    action: "restored",
+    changed: write.changed,
+    ...write.backupPath ? { backup_path: write.backupPath } : {},
+    state_path: statePath
+  };
+}
+function findDshMakerRegistrations(dshHome) {
+  const resolvedDshHome = dshHome || getDshHome();
+  const configPaths = listDshMcpConfigPaths({ homeDir: os7.homedir(), dshHome: resolvedDshHome });
+  const registrations = [];
+  for (const configPath of configPaths) {
+    if (!fs23.existsSync(configPath)) {
+      continue;
+    }
+    const content = fs23.readFileSync(configPath, "utf8");
+    const document = (0, import_yaml2.parseDocument)(content, { prettyErrors: true });
+    if (document.errors.length > 0) {
+      throw new Error(`Invalid YAML in ${configPath}: ${document.errors[0].message}`);
+    }
+    const candidates = findDshMakerCandidates(document);
+    for (const candidate of candidates) {
+      registrations.push({ configPath, ...candidate });
+    }
+  }
+  return registrations;
+}
+function findDshMakerCandidates(document) {
+  const candidates = [];
+  const top = document.contents;
+  if (!(0, import_yaml2.isSeq)(top)) {
+    return candidates;
+  }
+  top.items.forEach((rawPatch, patchIndex) => {
+    const patchNode = rawPatch;
+    const patch = patchNode.toJSON();
+    if (Array.isArray(patch == null ? void 0 : patch.insert)) {
+      const insertNode = (0, import_yaml2.isMap)(patchNode) ? patchNode.get("insert", true) : void 0;
+      if (!(0, import_yaml2.isSeq)(insertNode)) {
+        return;
+      }
+      insertNode.items.forEach((rawRow, insertIndex) => {
+        const rowNode = rawRow;
+        const row = rowNode.toJSON();
+        if (isDshMakerPluginCandidate(row)) {
+          candidates.push({
+            patchIndex,
+            insertIndex,
+            registration: row
+          });
+        }
+      });
+      return;
+    }
+    if (isDshMakerPluginCandidate(patch)) {
+      candidates.push({
+        patchIndex,
+        registration: patch
+      });
+    }
+  });
+  return candidates;
+}
+function removeDshMakerRegistration(document, registration) {
+  const top = document.contents;
+  if (!(0, import_yaml2.isSeq)(top)) {
+    throw new Error("DSH config top-level value must be a plugin array.");
+  }
+  if (registration.insertIndex !== void 0) {
+    const patchNode = top.items[registration.patchIndex];
+    const insertNode = (0, import_yaml2.isMap)(patchNode) ? patchNode.get("insert", true) : void 0;
+    if (!(0, import_yaml2.isSeq)(insertNode)) {
+      throw new Error("Invalid DSH insert patch.");
+    }
+    insertNode.items.splice(registration.insertIndex, 1);
+    if (insertNode.items.length === 0) {
+      top.items.splice(registration.patchIndex, 1);
+    }
+    return;
+  }
+  top.items.splice(registration.patchIndex, 1);
+}
+function reinsertDshMakerRegistration(document, registration) {
+  const top = document.contents;
+  if (!(0, import_yaml2.isSeq)(top)) {
+    throw new Error("DSH config top-level value must be a plugin array.");
+  }
+  top.items.push(document.createNode({ insert: [registration] }));
+}
+function isDshMakerPluginCandidate(value) {
+  if (!isRecord6(value)) {
+    return false;
+  }
+  if (value.id === DSH_MAKER_PLUGIN_ID) {
+    return true;
+  }
+  const config2 = isRecord6(value.config) ? value.config : void 0;
+  return value.name === DSH_MCP_PLUGIN_NAME && (config2 == null ? void 0 : config2.serverName) === DSH_MAKER_MCP_NAME;
+}
+function getDshPluginMigrationStatePath(makerHome) {
+  return path24.join(makerHome, "plugin-migrations", "dsh.json");
+}
+function readDshMigrationState(statePath) {
+  if (!fs23.existsSync(statePath)) {
+    return void 0;
+  }
+  try {
+    const state = JSON.parse(fs23.readFileSync(statePath, "utf8"));
+    return (state == null ? void 0 : state.schema_version) === 1 && state.client === "dsh" ? state : void 0;
+  } catch {
+    return void 0;
+  }
+}
+function createDshInspection(status, primaryPaths, allPaths) {
+  return {
+    client: "dsh",
+    status,
+    config_path: primaryPaths[0] ?? "",
+    config_paths: allPaths,
+    registration_count: primaryPaths.length
+  };
+}
+function sha2562(content) {
+  return crypto4.createHash("sha256").update(content).digest("hex");
+}
+function isRecord6(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+function unique(values) {
+  return [...new Set(values)];
+}
+
+// src/maker/cli/workBuddyProjectSkills.ts
+import fs24 from "node:fs";
+import path25 from "node:path";
 function syncWorkBuddyProjectSkills(targetDir, options = {}) {
   const platform = options.platform ?? process.platform;
-  const projectDir = path24.resolve(targetDir);
-  const sourceDir = path24.join(projectDir, ".installer", "skills");
-  const workBuddySkillsDir = path24.join(projectDir, ".workbuddy", "skills");
+  const projectDir = path25.resolve(targetDir);
+  const sourceDir = path25.join(projectDir, ".installer", "skills");
+  const workBuddySkillsDir = path25.join(projectDir, ".workbuddy", "skills");
   const result = {
     status: "skipped",
     sourceDir,
@@ -49575,18 +49835,18 @@ function syncWorkBuddyProjectSkills(targetDir, options = {}) {
     result.reason = "source_not_found";
     return result;
   }
-  const sourceSkills = fs23.readdirSync(sourceDir, { withFileTypes: true }).filter(
-    (entry) => entry.isDirectory() && fs23.existsSync(path24.join(sourceDir, entry.name, "SKILL.md"))
+  const sourceSkills = fs24.readdirSync(sourceDir, { withFileTypes: true }).filter(
+    (entry) => entry.isDirectory() && fs24.existsSync(path25.join(sourceDir, entry.name, "SKILL.md"))
   ).map((entry) => entry.name).sort();
   for (const sourceSkillName of sourceSkills) {
     const workBuddySkillName = `taptap-maker-${sourceSkillName}`;
-    const workBuddySkillDir = path24.join(workBuddySkillsDir, workBuddySkillName);
+    const workBuddySkillDir = path25.join(workBuddySkillsDir, workBuddySkillName);
     if (pathEntryExists(workBuddySkillDir)) {
       result.skippedSkills.push(workBuddySkillName);
       continue;
     }
-    fs23.mkdirSync(workBuddySkillsDir, { recursive: true });
-    installSkillContents(path24.join(sourceDir, sourceSkillName), workBuddySkillDir, platform);
+    fs24.mkdirSync(workBuddySkillsDir, { recursive: true });
+    installSkillContents(path25.join(sourceDir, sourceSkillName), workBuddySkillDir, platform);
     result.installedSkills.push(workBuddySkillName);
   }
   if (result.installedSkills.length > 0) {
@@ -49595,29 +49855,29 @@ function syncWorkBuddyProjectSkills(targetDir, options = {}) {
   return result;
 }
 function installSkillContents(sourceDir, targetDir, platform) {
-  fs23.mkdirSync(targetDir);
+  fs24.mkdirSync(targetDir);
   try {
-    for (const entry of fs23.readdirSync(sourceDir)) {
-      linkOrCopyEntry(path24.join(sourceDir, entry), path24.join(targetDir, entry), platform);
+    for (const entry of fs24.readdirSync(sourceDir)) {
+      linkOrCopyEntry(path25.join(sourceDir, entry), path25.join(targetDir, entry), platform);
     }
   } catch (error2) {
-    fs23.rmSync(targetDir, { recursive: true, force: true });
+    fs24.rmSync(targetDir, { recursive: true, force: true });
     throw error2;
   }
 }
 function linkOrCopyEntry(source, target, platform) {
-  const stat = fs23.statSync(source);
+  const stat = fs24.statSync(source);
   if (platform === "win32" && stat.isFile()) {
-    fs23.copyFileSync(source, target);
+    fs24.copyFileSync(source, target);
     return;
   }
   try {
-    const linkTarget = platform === "win32" ? source : path24.relative(path24.dirname(target), source);
+    const linkTarget = platform === "win32" ? source : path25.relative(path25.dirname(target), source);
     const linkType = stat.isDirectory() ? platform === "win32" ? "junction" : "dir" : "file";
-    fs23.symlinkSync(linkTarget, target, linkType);
+    fs24.symlinkSync(linkTarget, target, linkType);
   } catch (error2) {
     try {
-      fs23.cpSync(source, target, { recursive: stat.isDirectory() });
+      fs24.cpSync(source, target, { recursive: stat.isDirectory() });
     } catch (copyError) {
       throw new Error(
         `Failed to install WorkBuddy project skill entry ${source}: ${formatError3(error2)}; copy fallback: ${formatError3(copyError)}`
@@ -49627,14 +49887,14 @@ function linkOrCopyEntry(source, target, platform) {
 }
 function isDirectory(value) {
   try {
-    return fs23.statSync(value).isDirectory();
+    return fs24.statSync(value).isDirectory();
   } catch {
     return false;
   }
 }
 function pathEntryExists(value) {
   try {
-    fs23.lstatSync(value);
+    fs24.lstatSync(value);
     return true;
   } catch {
     return false;
@@ -49756,29 +50016,29 @@ async function runMakerCli(argv) {
 function runPluginLifecycle(parsed, ctx) {
   const subcommand = parsed.command[1];
   const client = stringOption(parsed, "client") || "codex";
-  if (client !== "codex" && client !== "workbuddy") {
+  if (client !== "codex" && client !== "workbuddy" && client !== "dsh") {
     throw new Error(
-      `Unsupported Maker plugin client: ${client}. Supported clients: codex, workbuddy.`
+      `Unsupported Maker plugin client: ${client}. Supported clients: codex, workbuddy, dsh.`
     );
   }
   if (subcommand === "inspect") {
     writePluginLifecycleResult(
       ctx,
-      client === "codex" ? inspectCodexLegacyMakerMcp() : inspectWorkBuddyLegacyMakerMcp()
+      client === "codex" ? inspectCodexLegacyMakerMcp() : client === "workbuddy" ? inspectWorkBuddyLegacyMakerMcp() : inspectDshLegacyMakerMcp()
     );
     return;
   }
   if (subcommand === "migrate") {
     writePluginLifecycleResult(
       ctx,
-      client === "codex" ? migrateCodexLegacyMakerMcp({ confirm: booleanOption(parsed, "confirm") }) : migrateWorkBuddyLegacyMakerMcp({ confirm: booleanOption(parsed, "confirm") })
+      client === "codex" ? migrateCodexLegacyMakerMcp({ confirm: booleanOption(parsed, "confirm") }) : client === "workbuddy" ? migrateWorkBuddyLegacyMakerMcp({ confirm: booleanOption(parsed, "confirm") }) : migrateDshLegacyMakerMcp({ confirm: booleanOption(parsed, "confirm") })
     );
     return;
   }
   if (subcommand === "restore") {
     writePluginLifecycleResult(
       ctx,
-      client === "codex" ? restoreCodexLegacyMakerMcp({ confirm: booleanOption(parsed, "confirm") }) : restoreWorkBuddyLegacyMakerMcp({ confirm: booleanOption(parsed, "confirm") })
+      client === "codex" ? restoreCodexLegacyMakerMcp({ confirm: booleanOption(parsed, "confirm") }) : client === "workbuddy" ? restoreWorkBuddyLegacyMakerMcp({ confirm: booleanOption(parsed, "confirm") }) : restoreDshLegacyMakerMcp({ confirm: booleanOption(parsed, "confirm") })
     );
     return;
   }
@@ -49851,7 +50111,7 @@ function toOptionKey(value) {
 }
 async function runInit(parsed, ctx) {
   rejectPackageOption(parsed);
-  const targetDir = path25.resolve(stringOption(parsed, "target_dir") || process.cwd());
+  const targetDir = path26.resolve(stringOption(parsed, "target_dir") || process.cwd());
   const env = makerEnvOption(parsed);
   const skipConfirm = booleanOption(parsed, "skip_confirm");
   const skipMcpInstall = booleanOption(parsed, "skip_mcp_install");
@@ -49966,7 +50226,7 @@ async function runInit(parsed, ctx) {
 }
 async function runDoctor(parsed, ctx) {
   var _a3, _b;
-  const targetDir = path25.resolve(stringOption(parsed, "target_dir") || process.cwd());
+  const targetDir = path26.resolve(stringOption(parsed, "target_dir") || process.cwd());
   const env = makerEnvOption(parsed);
   const git = checkGitEnvironment();
   const python = checkMakerPythonEnvironment();
@@ -50057,8 +50317,8 @@ async function runDoctor(parsed, ctx) {
   );
 }
 function inspectMakerDoctorExecutionContext(options) {
-  const doctorCwd = path25.resolve(process.cwd());
-  const makerProjectDir = options.makerProjectDir ? path25.resolve(options.makerProjectDir) : void 0;
+  const doctorCwd = path26.resolve(process.cwd());
+  const makerProjectDir = options.makerProjectDir ? path26.resolve(options.makerProjectDir) : void 0;
   if (!makerProjectDir) {
     return {
       active_client_session: "not_checked",
@@ -50093,9 +50353,9 @@ function samePath2(left, right) {
   return normalizePathForCompare3(left) === normalizePathForCompare3(right);
 }
 function normalizePathForCompare3(value) {
-  const resolved = path25.resolve(value);
+  const resolved = path26.resolve(value);
   try {
-    return fs24.realpathSync.native(resolved);
+    return fs25.realpathSync.native(resolved);
   } catch {
     return resolved;
   }
@@ -50413,7 +50673,7 @@ async function runPatSet(parsed, ctx) {
 }
 async function resolvePatSet(parsed, ctx) {
   if (booleanOption(parsed, "pat_stdin") || booleanOption(parsed, "pat_from_stdin")) {
-    const pat = fs24.readFileSync(0, "utf8").trim();
+    const pat = fs25.readFileSync(0, "utf8").trim();
     if (!pat) {
       throw new Error("No PAT found on stdin.");
     }
@@ -50468,17 +50728,17 @@ async function prepareMcpLauncher(options) {
     if (options.mode === "self") {
       launcher = materializeMakerSelfLauncher({
         version: VERSION2,
-        bundleUrl: typeof __MAKER_BUNDLE_URL__ !== "undefined" ? __MAKER_BUNDLE_URL__ : pathToFileURL(path25.resolve(process.cwd(), "dist", "maker.js")).href,
+        bundleUrl: typeof __MAKER_BUNDLE_URL__ !== "undefined" ? __MAKER_BUNDLE_URL__ : pathToFileURL(path26.resolve(process.cwd(), "dist", "maker.js")).href,
         makerHome: getMakerHome()
       });
     } else {
       const packageSpec = resolveMakerPackageSpec(MAKER_NPM_PACKAGE, VERSION2);
       launcher = resolveMakerMcpLauncher({ packageName: packageSpec });
       const configuredCache = process.env.npm_config_cache || process.env.NPM_CONFIG_CACHE;
-      const npmCacheDir = path25.resolve(
-        configuredCache || path25.join(getMakerHome(), "cache", "npm")
+      const npmCacheDir = path26.resolve(
+        configuredCache || path26.join(getMakerHome(), "cache", "npm")
       );
-      fs24.mkdirSync(npmCacheDir, { recursive: true });
+      fs25.mkdirSync(npmCacheDir, { recursive: true });
       launcherEnv = { npm_config_cache: npmCacheDir };
     }
   } catch (error2) {
@@ -50611,7 +50871,7 @@ ${indent3(payload.stderr)}` : "",
 }
 async function runMcpReport(parsed, ctx) {
   rejectPackageOption(parsed);
-  const targetDir = path25.resolve(stringOption(parsed, "target_dir") || process.cwd());
+  const targetDir = path26.resolve(stringOption(parsed, "target_dir") || process.cwd());
   const contextInput = booleanOption(parsed, "context_stdin") ? await readStdinText() : "";
   const context = parseMakerMcpReportContext(contextInput);
   const reportRuntime = resolveMakerMcpReportRuntime({
@@ -50664,7 +50924,7 @@ async function runMcpReport(parsed, ctx) {
   const issue3 = buildMakerMcpIssue({
     context,
     diagnostics,
-    homeDir: os7.homedir()
+    homeDir: os8.homedir()
   });
   const submission = booleanOption(parsed, "consent") ? submitMakerMcpIssue(issue3) : {
     status: "consent_required",
@@ -50691,7 +50951,7 @@ async function runMcpReport(parsed, ctx) {
   );
 }
 async function runAgentsUpdate(parsed, ctx) {
-  const targetDir = path25.resolve(stringOption(parsed, "target_dir") || process.cwd());
+  const targetDir = path26.resolve(stringOption(parsed, "target_dir") || process.cwd());
   const result = updateMakerAgentsPolicy(targetDir);
   if (ctx.json) {
     writeJson(result);
@@ -50710,21 +50970,25 @@ async function runAgentsUpdate(parsed, ctx) {
 async function runUpgrade(parsed, ctx) {
   rejectPackageOption(parsed);
   const explicitTargetDir = stringOption(parsed, "target_dir");
-  const targetDir = path25.resolve(explicitTargetDir || process.cwd());
+  const targetDir = path26.resolve(explicitTargetDir || process.cwd());
   const env = makerEnvOption(parsed);
   const ides = parseIdeList(stringOption(parsed, "ide") || stringOption(parsed, "ides") || "");
-  const prepared = await prepareMcpLauncher({ env, mode: mcpLauncherOption(parsed) });
-  if (!prepared.ok) {
-    writeMcpLauncherFailure(ctx, prepared);
-    return;
+  const pluginDistribution = resolveMakerPluginDistribution();
+  let installResults = [];
+  if (!pluginDistribution) {
+    const prepared = await prepareMcpLauncher({ env, mode: mcpLauncherOption(parsed) });
+    if (!prepared.ok) {
+      writeMcpLauncherFailure(ctx, prepared);
+      return;
+    }
+    installResults = installMcpConfigs({
+      ides: ides.length > 0 ? ides : getDefaultMcpInstallIdes(),
+      env: makerMcpConfigEnvOption(parsed),
+      mcpName: stringOption(parsed, "name") || DEFAULT_MCP_NAME,
+      launcher: prepared.launcher,
+      launcherEnv: prepared.launcherEnv
+    });
   }
-  const installResults = installMcpConfigs({
-    ides: ides.length > 0 ? ides : getDefaultMcpInstallIdes(),
-    env: makerMcpConfigEnvOption(parsed),
-    mcpName: stringOption(parsed, "name") || DEFAULT_MCP_NAME,
-    launcher: prepared.launcher,
-    launcherEnv: prepared.launcherEnv
-  });
   const identify = identifyMakerProject({ cwd: targetDir });
   const agentsResult = identify.projectRoot ? updateMakerAgentsPolicy(identify.projectRoot) : void 0;
   const payload = {
@@ -50735,7 +50999,8 @@ async function runUpgrade(parsed, ctx) {
     agents_policy: agentsResult,
     restart_required: false,
     apply_mode: "next_mcp_start",
-    current_session: "preserved"
+    current_session: "preserved",
+    plugin_distribution: pluginDistribution == null ? void 0 : pluginDistribution.id
   };
   if (!payload.ok) {
     process.exitCode = 1;
@@ -50746,9 +51011,9 @@ async function runUpgrade(parsed, ctx) {
   }
   process.stdout.write(
     [
-      payload.ok ? "TapTap Maker upgrade completed" : "TapTap Maker upgrade completed with errors",
+      pluginDistribution ? "TapTap Maker project policy update completed" : payload.ok ? "TapTap Maker upgrade completed" : "TapTap Maker upgrade completed with errors",
       "",
-      ...installResults.map((result) => result.message),
+      ...pluginDistribution ? [`✓ Standalone MCP registration unchanged (${pluginDistribution.displayName} plugin)`] : installResults.map((result) => result.message),
       "",
       agentsResult ? [
         agentsResult.changed ? "✓ AGENTS.md managed policy updated" : "✓ AGENTS.md managed policy current",
@@ -50756,8 +51021,8 @@ async function runUpgrade(parsed, ctx) {
         `- previous_status: ${agentsResult.previousStatus}`
       ].join("\n") : "AGENTS.md managed policy skipped: current directory is not bound to a Maker project.",
       "",
-      "Current MCP session remains unchanged and continues using the existing version.",
-      "The updated package and AGENTS.md will take effect on the next MCP start or user-requested reconnect.",
+      pluginDistribution ? formatMakerPluginUpdateAction(pluginDistribution) : "Current MCP session remains unchanged and continues using the existing version.",
+      pluginDistribution ? "The updated AGENTS.md policy is available to the current project." : "The updated package and AGENTS.md will take effect on the next MCP start or user-requested reconnect.",
       ""
     ].join("\n")
   );
@@ -50794,7 +51059,7 @@ function getMcpVerifyNextSteps(mode, commandText) {
   ];
 }
 async function runDevKitUpdate(parsed, ctx) {
-  const targetDir = path25.resolve(stringOption(parsed, "target_dir") || process.cwd());
+  const targetDir = path26.resolve(stringOption(parsed, "target_dir") || process.cwd());
   const result = await installAiDevKit({
     targetDir,
     preserveExisting: false,
@@ -50807,7 +51072,7 @@ async function runDevKitUpdate(parsed, ctx) {
   emitDevKitSkillInstallerFailure(ctx, result.skillInstaller, "AI skills install failed");
 }
 async function runLogsWatch(parsed, ctx) {
-  const targetDir = path25.resolve(stringOption(parsed, "target_dir") || process.cwd());
+  const targetDir = path26.resolve(stringOption(parsed, "target_dir") || process.cwd());
   const intervalMs = parseDurationMs(stringOption(parsed, "interval") || "5s");
   const timeoutMs = numberOption(parsed, "timeout_ms") ?? DEFAULT_TOOL_CALL_TIMEOUT_MS;
   const maxPolls = numberOption(parsed, "max_polls");
@@ -50817,9 +51082,9 @@ async function runLogsWatch(parsed, ctx) {
     serverUrl: stringOption(parsed, "server_url"),
     env: makerEnvOption(parsed)
   });
-  const runtimeDir = path25.join(proxy.projectRoot, ".maker", "logs", "runtime");
-  const runtimeLog = path25.join(runtimeDir, "runtime.log");
-  const pidFile = path25.join(runtimeDir, "watcher.pid");
+  const runtimeDir = path26.join(proxy.projectRoot, ".maker", "logs", "runtime");
+  const runtimeLog = path26.join(runtimeDir, "runtime.log");
+  const pidFile = path26.join(runtimeDir, "watcher.pid");
   const replacedWatcher = registerRuntimeLogWatcherProcess(pidFile);
   const runtimeLogClient = createRemoteRuntimeLogClient(proxy, timeoutMs);
   emit(ctx, "logs_watch_start", "Maker runtime log watcher started", {
@@ -50864,10 +51129,10 @@ async function runLogsWatch(parsed, ctx) {
   }
 }
 function registerRuntimeLogWatcherProcess(pidFile) {
-  fs24.mkdirSync(path25.dirname(pidFile), { recursive: true });
+  fs25.mkdirSync(path26.dirname(pidFile), { recursive: true });
   const existingPid = readPidFile(pidFile);
   const previous = existingPid && existingPid !== process.pid ? stopExistingRuntimeLogWatcher(pidFile) : {};
-  fs24.writeFileSync(
+  fs25.writeFileSync(
     pidFile,
     `${JSON.stringify(
       {
@@ -50885,10 +51150,10 @@ function registerRuntimeLogWatcherProcess(pidFile) {
   return previous;
 }
 function readPidFile(pidFile) {
-  if (!fs24.existsSync(pidFile)) {
+  if (!fs25.existsSync(pidFile)) {
     return void 0;
   }
-  const raw = fs24.readFileSync(pidFile, "utf8").trim();
+  const raw = fs25.readFileSync(pidFile, "utf8").trim();
   let pid = Number(raw);
   if (!Number.isInteger(pid) || pid <= 0) {
     try {
@@ -50908,7 +51173,7 @@ function installRuntimeLogWatcherPidCleanup(pidFile) {
     }
     cleaned = true;
     if (readPidFile(pidFile) === process.pid) {
-      fs24.rmSync(pidFile, { force: true });
+      fs25.rmSync(pidFile, { force: true });
     }
   };
   process.once("exit", cleanup);
@@ -51059,7 +51324,7 @@ async function prepareDevKit(targetDir, ctx, options = {}) {
         onStart: (event) => emitSkillInstallerStart(ctx, event)
       });
       writeDevKitStagedGitignore(
-        path25.join(targetDir, DEV_KIT_GITIGNORE_STAGING_FILE),
+        path26.join(targetDir, DEV_KIT_GITIGNORE_STAGING_FILE),
         listPresentDevKitManagedEntries(targetDir)
       );
       syncWorkBuddyDevKitSkills(targetDir, ctx);
@@ -51077,7 +51342,7 @@ async function prepareDevKit(targetDir, ctx, options = {}) {
       );
     } catch (error2) {
       writeDevKitStagedGitignore(
-        path25.join(targetDir, DEV_KIT_GITIGNORE_STAGING_FILE),
+        path26.join(targetDir, DEV_KIT_GITIGNORE_STAGING_FILE),
         listPresentDevKitManagedEntries(targetDir)
       );
       if (options.finalizeGitignore) {
@@ -51124,10 +51389,10 @@ function syncWorkBuddyDevKitSkills(targetDir, ctx) {
   try {
     const result = syncWorkBuddyProjectSkills(targetDir);
     const managedSkillPaths = [...result.installedSkills, ...result.skippedSkills].map(
-      (skillName) => path25.join(".workbuddy", "skills", skillName)
+      (skillName) => path26.join(".workbuddy", "skills", skillName)
     );
     if (managedSkillPaths.length > 0) {
-      writeDevKitStagedGitignore(path25.join(targetDir, DEV_KIT_GITIGNORE_STAGING_FILE), [
+      writeDevKitStagedGitignore(path26.join(targetDir, DEV_KIT_GITIGNORE_STAGING_FILE), [
         ...listPresentDevKitManagedEntries(targetDir),
         ...managedSkillPaths
       ]);
@@ -51204,12 +51469,12 @@ function installMcpConfig(ide, options) {
 }
 function installMcpConfigUnsafe(ide, options) {
   if (ide === "codex") {
-    const configPath = path25.join(os7.homedir(), ".codex", "config.toml");
+    const configPath = path26.join(os8.homedir(), ".codex", "config.toml");
     const write = mergeCodexMcpConfig(configPath, withClientIde(options, "codex"));
     return [createMcpInstallResult(ide, "Codex", configPath, write)];
   }
   if (ide === "cursor") {
-    const configPath = path25.join(os7.homedir(), ".cursor", "mcp.json");
+    const configPath = path26.join(os8.homedir(), ".cursor", "mcp.json");
     const write = mergeJsonMcpConfig(configPath, withClientIde(options, "cursor"));
     return [createMcpInstallResult(ide, "Cursor", configPath, write)];
   }
@@ -51226,7 +51491,7 @@ function installMcpConfigUnsafe(ide, options) {
         }
       ];
     }
-    const configPath = path25.join(os7.homedir(), ".claude.json");
+    const configPath = path26.join(os8.homedir(), ".claude.json");
     const write = mergeJsonMcpConfig(configPath, claudeOptions);
     return [createMcpInstallResult(ide, "Claude fallback", configPath, write)];
   }
@@ -51240,7 +51505,7 @@ function installMcpConfigUnsafe(ide, options) {
   }
   if (ide === "opencode") {
     const configPath = getOpenCodeMcpConfigPath();
-    if (!fs24.existsSync(configPath)) {
+    if (!fs25.existsSync(configPath)) {
       return [{ ide, ok: false, message: "Skipped OpenCode: no supported config file found" }];
     }
     const write = mergeOpenCodeMcpConfig(configPath, withClientIde(options, "opencode"));
@@ -51323,13 +51588,13 @@ function getDefaultMcpInstallIdes() {
   if (getTraeMcpInstallPaths().length > 0) {
     ides.push("trae");
   }
-  if (fs24.existsSync(getOpenCodeMcpConfigPath())) {
+  if (fs25.existsSync(getOpenCodeMcpConfigPath())) {
     ides.push("opencode");
   }
   if (getWorkBuddyMcpInstallPaths().length > 0) {
     ides.push("workbuddy");
   }
-  if (fs24.existsSync(getDshHome())) {
+  if (fs25.existsSync(getDshHome())) {
     ides.push("dsh");
   }
   return ides;
@@ -51343,7 +51608,7 @@ function getExistingTraeUserConfigPaths(paths) {
   const seen = /* @__PURE__ */ new Set();
   return paths.filter((configPath) => {
     const key = normalizeConfigPathKey(configPath);
-    if (seen.has(key) || !fs24.existsSync(path25.dirname(configPath))) {
+    if (seen.has(key) || !fs25.existsSync(path26.dirname(configPath))) {
       return false;
     }
     seen.add(key);
@@ -51354,7 +51619,7 @@ function getExistingConfigPaths(paths) {
   const seen = /* @__PURE__ */ new Set();
   return paths.filter((configPath) => {
     const key = normalizeConfigPathKey(configPath);
-    if (seen.has(key) || !fs24.existsSync(configPath)) {
+    if (seen.has(key) || !fs25.existsSync(configPath)) {
       return false;
     }
     seen.add(key);
@@ -51362,62 +51627,62 @@ function getExistingConfigPaths(paths) {
   });
 }
 function normalizeConfigPathKey(configPath) {
-  const resolved = path25.resolve(configPath);
+  const resolved = path26.resolve(configPath);
   return process.platform === "win32" || process.platform === "darwin" ? resolved.toLowerCase() : resolved;
 }
 function getTraeSoloMcpConfigPaths() {
   if (process.platform === "win32") {
-    const roaming = process.env.APPDATA || path25.join(os7.homedir(), "AppData", "Roaming");
+    const roaming = process.env.APPDATA || path26.join(os8.homedir(), "AppData", "Roaming");
     return [
-      path25.join(roaming, "TRAE SOLO", "User", "mcp.json"),
-      path25.join(roaming, "TRAE SOLO CN", "User", "mcp.json")
+      path26.join(roaming, "TRAE SOLO", "User", "mcp.json"),
+      path26.join(roaming, "TRAE SOLO CN", "User", "mcp.json")
     ];
   }
-  const appSupport = path25.join(os7.homedir(), "Library", "Application Support");
+  const appSupport = path26.join(os8.homedir(), "Library", "Application Support");
   return [
-    path25.join(appSupport, "TRAE SOLO CN", "User", "mcp.json"),
-    path25.join(appSupport, "TRAE SOLO", "User", "mcp.json")
+    path26.join(appSupport, "TRAE SOLO CN", "User", "mcp.json"),
+    path26.join(appSupport, "TRAE SOLO", "User", "mcp.json")
   ];
 }
 function getTraeUnverifiedMcpConfigPaths() {
   if (process.platform === "win32") {
-    const roaming = process.env.APPDATA || path25.join(os7.homedir(), "AppData", "Roaming");
+    const roaming = process.env.APPDATA || path26.join(os8.homedir(), "AppData", "Roaming");
     return [
-      path25.join(roaming, "Trae", "User", "mcp.json"),
-      path25.join(roaming, "TRAE", "User", "mcp.json"),
-      path25.join(roaming, "Trae CN", "User", "mcp.json")
+      path26.join(roaming, "Trae", "User", "mcp.json"),
+      path26.join(roaming, "TRAE", "User", "mcp.json"),
+      path26.join(roaming, "Trae CN", "User", "mcp.json")
     ];
   }
-  const appSupport = path25.join(os7.homedir(), "Library", "Application Support");
+  const appSupport = path26.join(os8.homedir(), "Library", "Application Support");
   return [
-    path25.join(appSupport, "Trae", "User", "mcp.json"),
-    path25.join(appSupport, "TRAE", "User", "mcp.json"),
-    path25.join(appSupport, "Trae CN", "User", "mcp.json")
+    path26.join(appSupport, "Trae", "User", "mcp.json"),
+    path26.join(appSupport, "TRAE", "User", "mcp.json"),
+    path26.join(appSupport, "Trae CN", "User", "mcp.json")
   ];
 }
 function getOpenCodeMcpConfigPath() {
-  return path25.join(os7.homedir(), ".config", "opencode", "opencode.jsonc");
+  return path26.join(os8.homedir(), ".config", "opencode", "opencode.jsonc");
 }
 function getWorkBuddyHome() {
-  return path25.join(os7.homedir(), ".workbuddy");
+  return path26.join(os8.homedir(), ".workbuddy");
 }
 function getWorkBuddyMcpInstallPaths(options = {}) {
-  const primary = path25.join(getWorkBuddyHome(), "mcp.json");
-  if (fs24.existsSync(primary) || options.createPrimary) {
+  const primary = path26.join(getWorkBuddyHome(), "mcp.json");
+  if (fs25.existsSync(primary) || options.createPrimary) {
     return [primary];
   }
-  const legacy = path25.join(getWorkBuddyHome(), ".mcp.json");
-  if (fs24.existsSync(legacy)) {
+  const legacy = path26.join(getWorkBuddyHome(), ".mcp.json");
+  if (fs25.existsSync(legacy)) {
     return [legacy];
   }
   return [];
 }
 function inspectWorkBuddyTrustState(mcpName) {
   const workbuddyHome = getWorkBuddyHome();
-  const connectorsDir = path25.join(workbuddyHome, "connectors");
+  const connectorsDir = path26.join(workbuddyHome, "connectors");
   const accounts = [];
   const stateFiles = [];
-  if (!fs24.existsSync(connectorsDir)) {
+  if (!fs25.existsSync(connectorsDir)) {
     return {
       status: "not_found",
       mcp_name: mcpName,
@@ -51427,12 +51692,12 @@ function inspectWorkBuddyTrustState(mcpName) {
       accounts
     };
   }
-  for (const entry of fs24.readdirSync(connectorsDir, { withFileTypes: true })) {
+  for (const entry of fs25.readdirSync(connectorsDir, { withFileTypes: true })) {
     if (!entry.isDirectory()) {
       continue;
     }
-    const statePath = path25.join(connectorsDir, entry.name, "connector-states.json");
-    if (!fs24.existsSync(statePath)) {
+    const statePath = path26.join(connectorsDir, entry.name, "connector-states.json");
+    if (!fs25.existsSync(statePath)) {
       continue;
     }
     stateFiles.push(statePath);
@@ -51511,7 +51776,7 @@ function mergeJsonMcpConfig(configPath, options) {
   );
 }
 function mergeOpenCodeMcpConfig(configPath, options) {
-  const rawContent = fs24.readFileSync(configPath, "utf8");
+  const rawContent = fs25.readFileSync(configPath, "utf8");
   const rewroteJsonc = normalizeJsonConfigContent(rawContent, { jsonc: true }) !== rawContent;
   const existing = readJsonObject(configPath, { jsonc: true });
   const mcp = asObject(existing.mcp);
@@ -51543,7 +51808,7 @@ function mergeOpenCodeMcpConfig(configPath, options) {
   return { ...write, rewroteJsonc: write.changed && rewroteJsonc };
 }
 function mergeCodexMcpConfig(configPath, options) {
-  const existing = fs24.existsSync(configPath) ? fs24.readFileSync(configPath, "utf8") : "";
+  const existing = fs25.existsSync(configPath) ? fs25.readFileSync(configPath, "utf8") : "";
   const withoutOld = removeCodexMcpTables(existing, options.mcpName).trimEnd();
   const launch = options.launcher;
   const envValues = createMcpEnvironmentValues(options.env, options.clientIde, options.launcherEnv);
@@ -51577,7 +51842,7 @@ function mergeCodexMcpConfig(configPath, options) {
   );
 }
 function tryClaudeMcpAdd(options) {
-  const configPath = path25.join(os7.homedir(), ".claude.json");
+  const configPath = path26.join(os8.homedir(), ".claude.json");
   try {
     const existing = readJsonObject(configPath);
     const server = asObject(asObject(existing.mcpServers)[options.mcpName]);
@@ -51670,10 +51935,10 @@ function rejectPackageOption(parsed) {
   }
 }
 function readJsonObject(filePath, options = {}) {
-  if (!fs24.existsSync(filePath)) {
+  if (!fs25.existsSync(filePath)) {
     return {};
   }
-  const raw = fs24.readFileSync(filePath, "utf8");
+  const raw = fs25.readFileSync(filePath, "utf8");
   try {
     const normalized = normalizeJsonConfigContent(raw, options);
     const parsed = JSON.parse(normalized);
@@ -51845,10 +52110,10 @@ function formatMcpInstallMessage(label, configPath, write) {
   ].filter(Boolean).join("\n");
 }
 function saveInitState(targetDir, state) {
-  fs24.mkdirSync(getMakerHome(), { recursive: true });
-  const key = crypto4.createHash("sha256").update(path25.resolve(targetDir)).digest("hex").slice(0, 16);
-  fs24.writeFileSync(
-    path25.join(getMakerHome(), `init-state-${key}.json`),
+  fs25.mkdirSync(getMakerHome(), { recursive: true });
+  const key = crypto5.createHash("sha256").update(path26.resolve(targetDir)).digest("hex").slice(0, 16);
+  fs25.writeFileSync(
+    path26.join(getMakerHome(), `init-state-${key}.json`),
     `${JSON.stringify({ ...state, updated_at: (/* @__PURE__ */ new Date()).toISOString() }, null, 2)}
 `,
     "utf8"
@@ -51996,7 +52261,7 @@ function makerEnvOption(parsed) {
     return env;
   }
   const targetDir = stringOption(parsed, "target_dir");
-  return getMakerEnvironment(void 0, targetDir ? path25.resolve(targetDir) : process.cwd());
+  return getMakerEnvironment(void 0, targetDir ? path26.resolve(targetDir) : process.cwd());
 }
 function makerMcpConfigEnvOption(parsed) {
   return stringOption(parsed, "env") === "rnd" ? "rnd" : "production";
@@ -52068,9 +52333,9 @@ function printHelp() {
       "                            [--context-stdin] [--consent] [--json]",
       "                            # Run only after the user agrees to submit",
       "  taptap-maker agents update [--target-dir DIR] [--json]",
-      "  taptap-maker plugin inspect --client codex|workbuddy [--json]",
-      "  taptap-maker plugin migrate --client codex|workbuddy --confirm [--json]",
-      "  taptap-maker plugin restore --client codex|workbuddy --confirm [--json]",
+      "  taptap-maker plugin inspect --client codex|workbuddy|dsh [--json]",
+      "  taptap-maker plugin migrate --client codex|workbuddy|dsh --confirm [--json]",
+      "  taptap-maker plugin restore --client codex|workbuddy|dsh --confirm [--json]",
       "  taptap-maker upgrade [--launcher self|npx] [--target-dir DIR] [--json]",
       "  taptap-maker dev-kit update [--target-dir DIR] [--json]",
       "  taptap-maker logs watch [--target-dir DIR] [--interval 5s] [--reset] [--json]",
@@ -52112,7 +52377,7 @@ function formatCliError(error2) {
   return error2 instanceof Error ? error2.message : String(error2);
 }
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/transport.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/transport.js
 function normalizeHeaders(headers) {
   if (!headers)
     return {};
@@ -52139,14 +52404,14 @@ function createFetchWithInit(baseFetch = fetch, baseInit) {
   };
 }
 
-// node_modules/pkce-challenge/dist/index.node.js
-var crypto5;
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/pkce-challenge/dist/index.node.js
+var crypto6;
 var _a2;
-crypto5 = ((_a2 = globalThis.crypto) == null ? void 0 : _a2.webcrypto) ?? // Node.js [18-16] REPL
+crypto6 = ((_a2 = globalThis.crypto) == null ? void 0 : _a2.webcrypto) ?? // Node.js [18-16] REPL
 globalThis.crypto ?? // Node.js >18
 import("node:crypto").then((m) => m.webcrypto);
 async function getRandomValues(size) {
-  return (await crypto5).getRandomValues(new Uint8Array(size));
+  return (await crypto6).getRandomValues(new Uint8Array(size));
 }
 async function random(size) {
   const mask2 = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~";
@@ -52162,7 +52427,7 @@ async function generateVerifier(length) {
   return await random(length);
 }
 async function generateChallenge(code_verifier) {
-  const buffer = await (await crypto5).subtle.digest("SHA-256", new TextEncoder().encode(code_verifier));
+  const buffer = await (await crypto6).subtle.digest("SHA-256", new TextEncoder().encode(code_verifier));
   return btoa(String.fromCharCode(...new Uint8Array(buffer))).replace(/\//g, "_").replace(/\+/g, "-").replace(/=/g, "");
 }
 async function pkceChallenge(length) {
@@ -52179,7 +52444,7 @@ async function pkceChallenge(length) {
   };
 }
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/auth.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/auth.js
 var SafeUrlSchema = url().superRefine((val, ctx) => {
   if (!URL.canParse(val)) {
     ctx.addIssue({
@@ -52323,7 +52588,7 @@ var OAuthTokenRevocationRequestSchema = object2({
   token_type_hint: string2().optional()
 }).strip();
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/auth-utils.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/auth-utils.js
 function resourceUrlFromServerUrl(url2) {
   const resourceURL = typeof url2 === "string" ? new URL(url2) : new URL(url2.href);
   resourceURL.hash = "";
@@ -52343,7 +52608,7 @@ function checkResourceAllowed({ requestedResource, configuredResource }) {
   return requestedPath.startsWith(configuredPath);
 }
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/server/auth/errors.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/auth/errors.js
 var OAuthError = class extends Error {
   constructor(message, errorUri) {
     super(message);
@@ -52438,7 +52703,7 @@ var OAUTH_ERRORS = {
   [InvalidTargetError.errorCode]: InvalidTargetError
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/client/auth.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/client/auth.js
 var UnauthorizedError = class extends Error {
   constructor(message) {
     super(message ?? "Unauthorized");
@@ -52978,7 +53243,7 @@ async function registerClient(authorizationServerUrl, { metadata, clientMetadata
   return OAuthClientInformationFullSchema.parse(await response.json());
 }
 
-// node_modules/eventsource-parser/dist/index.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/eventsource-parser/dist/index.js
 var ParseError = class extends Error {
   constructor(message, options) {
     super(message), this.name = "ParseError", this.type = options.type, this.field = options.field, this.value = options.value, this.line = options.line;
@@ -53081,7 +53346,7 @@ function splitLines(chunk) {
   return [lines, incompleteLine];
 }
 
-// node_modules/eventsource-parser/dist/stream.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/eventsource-parser/dist/stream.js
 var EventSourceParserStream = class extends TransformStream {
   constructor({ onError, onRetry, onComment } = {}) {
     let parser;
@@ -53105,7 +53370,7 @@ var EventSourceParserStream = class extends TransformStream {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/client/streamableHttp.js
+// ../../../Users/liangdong/Documents/Mcp/taptap_minigame_open_mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/client/streamableHttp.js
 var DEFAULT_STREAMABLE_HTTP_RECONNECTION_OPTIONS = {
   initialReconnectionDelay: 1e3,
   maxReconnectionDelay: 3e4,
@@ -53517,8 +53782,8 @@ var StreamableHTTPClientTransport = class {
 };
 
 // src/mcp-proxy/proxy.ts
-import * as path27 from "node:path";
-import * as crypto7 from "node:crypto";
+import * as path28 from "node:path";
+import * as crypto8 from "node:crypto";
 
 // src/mcp-proxy/cookieJar.ts
 var CookieJar = class {
@@ -53699,9 +53964,9 @@ function createCookieFetch(cookieJar) {
 }
 
 // src/core/utils/logWriter.ts
-import * as fs25 from "node:fs";
-import * as path26 from "node:path";
-import * as crypto6 from "node:crypto";
+import * as fs26 from "node:fs";
+import * as path27 from "node:path";
+import * as crypto7 from "node:crypto";
 
 // src/core/types/log.ts
 var LOG_LEVEL_PRIORITY = {
@@ -53741,7 +54006,7 @@ var LogWriter = class {
       return;
     }
     try {
-      await fs25.promises.mkdir(this.config.logDir, { recursive: true });
+      await fs26.promises.mkdir(this.config.logDir, { recursive: true });
       await this.cleanupOldLogs();
       this.initialized = true;
     } catch (error2) {
@@ -53764,7 +54029,7 @@ var LogWriter = class {
    */
   getLogFilePath(date5) {
     const d = date5 || this.getCurrentDate();
-    return path26.join(this.config.logDir, `${this.config.prefix}-${d}.log`);
+    return path27.join(this.config.logDir, `${this.config.prefix}-${d}.log`);
   }
   /**
    * 获取或创建写入流
@@ -53779,7 +54044,7 @@ var LogWriter = class {
       }
       this.currentDate = date5;
       try {
-        this.writeStream = fs25.createWriteStream(this.getLogFilePath(date5), {
+        this.writeStream = fs26.createWriteStream(this.getLogFilePath(date5), {
           flags: "a",
           encoding: "utf8"
         });
@@ -53831,11 +54096,11 @@ var LogWriter = class {
     if (this.shouldWriteToFile(level) && this.initialized && this.config.enabled) {
       try {
         const filePath = this.getLogFilePath();
-        const dir = path26.dirname(filePath);
-        if (!fs25.existsSync(dir)) {
-          fs25.mkdirSync(dir, { recursive: true });
+        const dir = path27.dirname(filePath);
+        if (!fs26.existsSync(dir)) {
+          fs26.mkdirSync(dir, { recursive: true });
         }
-        fs25.appendFileSync(filePath, message, "utf8");
+        fs26.appendFileSync(filePath, message, "utf8");
       } catch {
       }
     }
@@ -53846,7 +54111,7 @@ var LogWriter = class {
   async cleanupOldLogs() {
     if (this.config.maxDays <= 0) return;
     try {
-      const files = await fs25.promises.readdir(this.config.logDir);
+      const files = await fs26.promises.readdir(this.config.logDir);
       const cutoffDate = /* @__PURE__ */ new Date();
       cutoffDate.setDate(cutoffDate.getDate() - this.config.maxDays);
       const prefix = this.config.prefix;
@@ -53861,7 +54126,7 @@ var LogWriter = class {
           if (!Number.isNaN(year) && !Number.isNaN(month) && !Number.isNaN(day)) {
             const fileDate = new Date(year, month - 1, day);
             if (fileDate < cutoffDate) {
-              await fs25.promises.unlink(path26.join(this.config.logDir, file2));
+              await fs26.promises.unlink(path27.join(this.config.logDir, file2));
               process.stderr.write(`[LogWriter] Deleted old log: ${file2}
 `);
             }
@@ -53905,7 +54170,7 @@ function convertMcpApplicationErrorToToolResult(error2) {
     return void 0;
   }
   const data = error2.data;
-  if (!isRecord6(data) || !("remote_result" in data) || data.remote_result === void 0) {
+  if (!isRecord7(data) || !("remote_result" in data) || data.remote_result === void 0) {
     return void 0;
   }
   return {
@@ -53922,7 +54187,7 @@ function convertMcpApplicationErrorToToolResult(error2) {
     ]
   };
 }
-function isRecord6(value) {
+function isRecord7(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 function formatProxyDiagnosticValue(value) {
@@ -53982,10 +54247,10 @@ var TapTapMCPProxy = class {
     const { user_id, project_id } = this.config.tenant;
     let logDir;
     if (user_id && project_id) {
-      logDir = path27.join(logRoot, "proxy", user_id, project_id);
+      logDir = path28.join(logRoot, "proxy", user_id, project_id);
     } else {
-      const kidHash = crypto7.createHash("sha256").update(this.config.auth.kid).digest("hex").substring(0, 8);
-      logDir = path27.join(logRoot, "proxy", kidHash);
+      const kidHash = crypto8.createHash("sha256").update(this.config.auth.kid).digest("hex").substring(0, 8);
+      logDir = path28.join(logRoot, "proxy", kidHash);
     }
     return new LogWriter({
       logDir,

--- a/scripts/bundle-maker.js
+++ b/scripts/bundle-maker.js
@@ -76,6 +76,7 @@ const __MAKER_BUNDLE_URL__ = import.meta.url;
     minify: false,
     sourcemap: false,
     treeShaking: true,
+    preserveSymlinks: true,
     logLevel: 'info',
     charset: 'utf8',
   });

--- a/src/__tests__/makerCodexPluginPackage.test.ts
+++ b/src/__tests__/makerCodexPluginPackage.test.ts
@@ -172,6 +172,16 @@ describe('TapTap Maker Codex plugin package', () => {
     expect(bundledRuntime).not.toMatch(/[\t ]+$/mu);
   });
 
+  test('does not leak the checkout dependency path into the bundled runtime', () => {
+    const bundledRuntime = fs.readFileSync(path.join(pluginRoot, 'dist', 'maker.js'), 'utf8');
+    const realNodeModulesPath = fs
+      .realpathSync(path.join(projectRoot, 'node_modules'))
+      .replaceAll('\\', '/')
+      .replace(/^\/+/, '');
+
+    expect(bundledRuntime).not.toContain(realNodeModulesPath);
+  });
+
   test('documents both plugin and embedded Maker versions with stable release downloads', () => {
     const readme = fs.readFileSync(path.join(pluginRoot, 'README.md'), 'utf8');
 


### PR DESCRIPTION
## 问题

首版插件发布 workflow 在 `Verify generated plugins are current` 步骤失败：main 中 Codex 和 WorkBuddy 的 committed bundle 未用最终源码重新生成。

## 修复

- 重新生成 `plugins/taptap-maker/dist/maker.js`
- 重新生成 `plugins/workbuddy/taptap-maker/dist/maker.js`
- 不修改源代码、workflow、插件版本或 Maker npm 版本

## 验证

- 连续运行两次 Codex/WorkBuddy prepare，bundle SHA-256 保持一致
- 两份 bundle SHA-256 相同
- 39 项 Codex、WorkBuddy 和 Release 打包契约测试通过
- `git diff --check` 通过

## 合并后

手动在 main 重跑 `Publish Maker Plugin`，发布 `maker-plugin-v0.0.1`。