### PR TITLE
fix(maker): 合并已验证的插件运行时修复

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,6 +365,9 @@ Maker 本地开发的默认路径是 CLI-first + PAT-first：
 - 客户端专属源文件必须放在 `plugin-sources/taptap-maker/<client>/`；生成产物必须按客户端隔离。
   不得把 WorkBuddy manifest、commands、Skills 或 MCP 配置写入 Codex 插件目录。新增客户端时复用
   `src/maker/` 的 runtime/CLI，不复制 Maker tools、resources 或 proxy 业务逻辑。
+- 插件 runtime 必须设置非空的 `TAPTAP_MAKER_DISTRIBUTION`；任意非空值都表示由插件渠道管理，
+  Maker 不执行 npm 包版本检查或输出 npm 升级提示。具体值只用于识别 Codex、WorkBuddy、DSH 或
+  外部插件分发渠道；独立 Maker MCP 不设置该变量并保持现有 npm 更新策略。
 - 插件模式必须先按 `taptap-maker-plugin-lifecycle` 检查对应客户端的旧 Maker MCP。Codex 安装请求
   即授权自动迁移：安装前后都要检查，活动旧注册只写 `enabled = false`，无需再次确认；只有状态为
   `disabled` 或 `not_found` 才能报告插件可用，`ambiguous` 必须在安装前停止。WorkBuddy 同时检查
@@ -380,7 +383,9 @@ Maker 本地开发的默认路径是 CLI-first + PAT-first：
   Codex 插件产物必须使用插件专用 `update-taptap-mcp`，不得复制 npm 发行版的更新 Skill。旧 MCP
   restore 必须校验迁移注册指纹；插件模式故障上报只检查插件 `.mcp.json` 和当前 bundle，不能把
   已禁用的独立 `taptap-maker` 注册或物化 self runtime 当作插件运行证据。
-- Maker CLI-first 重构后的正式说明在 `docs/MAKER.md`；面向团队介绍的功能总览在 `docs/MAKER_CLI_MCP_SKILL_REWORK_OVERVIEW.md`。上下文压缩或长时间中断后，先读这两份文档再继续。
+- Maker CLI-first 重构后的正式说明在 `docs/MAKER.md`；完整环境变量契约在
+  `docs/MAKER_ENVIRONMENT_VARIABLES.md`；面向团队介绍的功能总览在
+  `docs/MAKER_CLI_MCP_SKILL_REWORK_OVERVIEW.md`。上下文压缩或长时间中断后，先读这些文档再继续。
 - 用户说“我要开发maker游戏 / 本地maker开发 / 拉取maker游戏到本地 / 把maker游戏代码拉到本地 / clone maker项目 / 下载maker游戏代码 / 初始化maker开发目录 / 配置maker本地开发 / 继续开发maker项目”时，应触发 `taptap-maker init`，由该 CLI 展示 app 列表并让用户选择已有 app 或 `0`/`new`。只有用户明确说“创建/新建项目或游戏”时，才使用 `taptap-maker init --create`。
 - 如果本地没有当前环境的 Maker PAT，CLI 默认运行 CLI 登录：生成满足 `^[A-Za-z0-9_-]{16,128}$` 的临时 code，按需打开当前环境的 `/pat-tokens?code=<code>`，用户登录并点击“创建 token”后，CLI 轮询 `/api/v1/cli-auth/result?code=<code>`，拿到授权结果后完成本地鉴权配置。
 - Maker 鉴权文件必须沿用线上已发布版本的原始本地保存路径，不要新建环境子目录；不要在用户文档或普通用户说明里暴露具体凭证缓存路径。

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -946,24 +946,11 @@ push
 
 ## 环境变量
 
-| 变量                                 | 说明                                              |
-| ------------------------------------ | ------------------------------------------------- |
-| `TAPTAP_MAKER_HOME`                  | 覆盖用户级 Maker 存储目录，默认 `~/.taptap-maker` |
-| `MAKER_PROJECT_ID`                   | MCP server 项目识别的环境变量覆盖                 |
-| `TAPTAP_MAKER_API_BASE`              | 可选：覆盖当前环境的 Maker 项目列表接口 base URL  |
-| `TAPTAP_MAKER_PAT_URL`               | 可选：覆盖当前环境的 Maker PAT 换取接口           |
-| `TAPTAP_MAKER_TAP_TOKEN_URL`         | 可选：覆盖当前环境的 PAT 获取 TapTap token 接口   |
-| `TAPTAP_MAKER_GIT_BASE`              | 可选：覆盖当前环境的 Maker git base URL           |
-| `TAPTAP_MAKER_REMOTE_MCP_SERVER_URL` | 可选：覆盖当前环境的远端 Maker MCP server URL     |
-| `TAPTAP_MAKER_WEB_URL`               | 可选：覆盖当前环境的 Maker 网页地址               |
-| `TAPTAP_MAKER_GIT_BIN`               | 可选：覆盖 Git 可执行文件路径                     |
-| `TAPTAP_MAKER_GIT_RETRY_DELAY_MS`    | 可选：覆盖 Git 临时错误重试基础延迟，默认 5000ms  |
-| `SCE_MCP_URL`                        | 云端 SCE MCP endpoint 默认值                      |
+完整清单、默认值、设置方、兼容变量、插件接入约束和新增规则统一维护在
+[Maker MCP 环境变量参考](MAKER_ENVIRONMENT_VARIABLES.md)。不要在其它文档复制环境变量表。
 
-Maker 后端默认地址集中在 `src/maker/config.ts`。兼容旧变量名：`MAKER_API_BASE`、
-`MAKER_PAT_URL`、`MAKER_TAP_TOKEN_URL`、`MAKER_GIT_BASE`、
-`TAPTAP_REMOTE_MCP_SERVER_URL`、`MAKER_WEB_URL`。新配置优先使用 `TAPTAP_MAKER_*`
-前缀。`TAPTAP_MAKER_REMOTE_MCP_SERVER_URL` 可覆盖当前环境的远端 Maker MCP server URL。
+关键边界：独立 Maker MCP 不设置 `TAPTAP_MAKER_DISTRIBUTION`；插件 runtime 必须设置非空分发
+标识。任意非空值都表示版本由插件渠道管理，Maker 不执行或提示 npm 包更新。
 
 ## CLI 登录联调
 

--- a/docs/MAKER_ENVIRONMENT_VARIABLES.md
+++ b/docs/MAKER_ENVIRONMENT_VARIABLES.md
@@ -1,0 +1,136 @@
+# Maker MCP 环境变量参考
+
+本文档是 TapTap Maker MCP、CLI 和客户端插件环境变量的单一事实来源。新增、重命名或改变
+环境变量语义时，必须同时更新本文档和对应测试。普通用户不需要设置大多数变量；没有明确场景时，
+应使用代码内默认值、CLI 参数或项目级 `.maker/taptap-maker.local.json`。
+
+## 命名与新增规则
+
+- Maker runtime 新变量统一使用 `TAPTAP_MAKER_*`，不要新增含义相同的短名称。
+- `TAPTAP_MCP_*` 只用于仓库内多个 MCP 共享的既有配置，不为 Maker 专属功能新增该前缀变量。
+- 宿主注入变量由对应客户端拥有，Maker 只能读取，不能改变其语义。
+- 一个变量只表达一个概念。客户端差异使用 `TAPTAP_MAKER_DISTRIBUTION` 的具体值，不再增加
+  `IS_PLUGIN`、`DISABLE_NPM_UPDATE` 等重复开关。
+- 新变量必须写清设置方、读取方、默认值、是否可持久化和敏感性，并添加行为测试。
+- 凭证不得写入插件 manifest、MCP 配置、日志、Issue、命令参数示例或项目文件。
+
+## Runtime 与客户端身份
+
+| 变量                        | 设置方                      | 取值/默认值                                                                           | 用途与边界                                                                                                                                                                                                          |
+| --------------------------- | --------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TAPTAP_MAKER_DISTRIBUTION` | 插件启动器或插件 MCP 配置   | 独立 MCP 不设置；插件使用非空分发标识                                                 | 任意非空值表示 runtime 由插件管理：不执行或提示 npm 包更新。`codex_plugin`、`workbuddy_plugin`、`dsh_plugin` 用于内置客户端专属行为；外部插件使用自己的稳定标识，如 `cindy_plugin`。不得把该变量写入独立 MCP 配置。 |
+| `TAPTAP_MCP_CLIENT_IDE`     | MCP 安装器或插件            | `codex`、`cursor`、`claude`、`trae`、`opencode`、`workbuddy`、`dsh`，或外部客户端标识 | 标记当前 MCP 请求来源，用于诊断、配置检查和故障上报。它不表示插件模式，不能替代 `TAPTAP_MAKER_DISTRIBUTION`。                                                                                                       |
+| `TAPTAP_MCP_ENV`            | CLI、MCP 配置或内部研发环境 | `production`（默认）或 `rnd`                                                          | 选择 Maker/TapTap 服务环境。面向普通用户和正式插件保持 `production`；项目研发覆盖优先写 `.maker/taptap-maker.local.json`。                                                                                          |
+| `TAPTAP_MAKER_HOME`         | 用户、测试或安装器          | `~/.taptap-maker`                                                                     | 覆盖 Maker 用户级存储根目录，包括鉴权、版本缓存、runtime、Python 和崩溃日志。不要在共享插件中固定到项目目录。                                                                                                       |
+| `TAPTAP_MAKER_CLIENT_ID`    | 内部联调或构建环境          | 默认按正式版本策略解析                                                                | Maker 登录流程的 client ID 覆盖。普通用户和客户端插件不要设置。                                                                                                                                                     |
+| `TAPTAP_MCP_CLIENT_ID`      | 仓库共享认证层或内部联调    | 无                                                                                    | 共享 TapTap client ID；Maker OAuth 仅把它作为既有共享配置使用。优先使用 Maker 自身默认登录流程。                                                                                                                    |
+
+共享认证层仍兼容 `TDS_MCP_ENV`、`TDS_MCP_CLIENT_ID` 和 `TDS_MCP_CLIENT_TOKEN`，分别对应
+`TAPTAP_MCP_ENV`、`TAPTAP_MCP_CLIENT_ID` 和 `TAPTAP_MCP_CLIENT_SECRET`。这些名称已废弃，只用于
+读取历史环境；新配置和插件不得写入。
+
+插件接入的最小 MCP 子进程环境如下。外部插件不需要伪装成内置客户端：
+
+```json
+{
+  "TAPTAP_MAKER_DISTRIBUTION": "cindy_plugin",
+  "TAPTAP_MCP_CLIENT_IDE": "cindy"
+}
+```
+
+## 本地工具与诊断
+
+| 变量                                     | 默认值                            | 用途与边界                                                            |
+| ---------------------------------------- | --------------------------------- | --------------------------------------------------------------------- |
+| `TAPTAP_MAKER_GIT_BIN`                   | `git`                             | 覆盖 Git 可执行文件路径，主要用于 Windows、企业环境或非标准安装位置。 |
+| `TAPTAP_MAKER_PYTHON_BIN`                | 自动探测或 Maker 管理的 Python    | 覆盖 Python 可执行文件路径。仅在自动探测不能满足环境要求时设置。      |
+| `TAPTAP_MAKER_GIT_RETRY_DELAY_MS`        | `5000`                            | Git 临时网络错误的基础重试延迟，单位毫秒；`0` 只用于测试。            |
+| `TAPTAP_MAKER_CRASH_LOG_MAX_BYTES`       | `1048576`                         | `mcp-crash.log` 最大字节数；仅接受正整数。                            |
+| `TAPTAP_MAKER_CRASH_LOG_MAX_ENTRY_BYTES` | `16384`                           | 单条崩溃记录最大字节数；仅接受正整数，且不会超过日志总上限。          |
+| `TAPTAP_MAKER_VERSION_POLICY_URL`        | GitHub `main` 上的 Maker 版本策略 | 覆盖 npm 版本策略地址，供测试和发布联调使用。插件模式会跳过该检查。   |
+
+## 服务地址覆盖
+
+以下变量只用于内部研发、测试或应急联调。普通用户、正式插件和用户级 MCP 配置不应设置服务地址。
+当前名称优先于兼容旧名称。
+
+| 当前变量                             | 兼容旧变量                     | 用途                                                                                    |
+| ------------------------------------ | ------------------------------ | --------------------------------------------------------------------------------------- |
+| `TAPTAP_MAKER_API_BASE`              | `MAKER_API_BASE`               | Maker 项目列表和 CLI API base URL。                                                     |
+| `TAPTAP_MAKER_PAT_URL`               | `MAKER_PAT_URL`                | Maker PAT 接口 URL。                                                                    |
+| `TAPTAP_MAKER_TAP_TOKEN_URL`         | `MAKER_TAP_TOKEN_URL`          | PAT 换取 TapTap token 的接口 URL。                                                      |
+| `TAPTAP_MAKER_GIT_BASE`              | `MAKER_GIT_BASE`               | Maker Git 服务 base URL。                                                               |
+| `TAPTAP_MAKER_REMOTE_MCP_SERVER_URL` | `TAPTAP_REMOTE_MCP_SERVER_URL` | 远端 Maker MCP server URL。                                                             |
+| `TAPTAP_MAKER_WEB_URL`               | `MAKER_WEB_URL`                | Maker 网页和 CLI 登录页面地址。                                                         |
+| `SCE_MCP_URL`                        | 无                             | app 数据未返回 `sce_endpoint` 时的内部 SCE endpoint 兜底。不要持久化到用户级 MCP 配置。 |
+
+旧变量只为已存在的内部环境兼容，不得出现在新配置、插件或新文档示例中。
+
+## 凭证兼容变量
+
+正常流程使用 `taptap-maker login` 或 `taptap-maker pat set --pat-stdin`，并由 Maker 用户级存储
+保存凭证。以下变量只用于 CI、自动化或应急联调，均属于敏感信息：
+
+| 变量                     | 状态   | 说明                                                      |
+| ------------------------ | ------ | --------------------------------------------------------- |
+| `MAKER_PAT`              | 兼容   | 非交互 Maker PAT。优先于已保存 PAT，但低于显式 CLI 输入。 |
+| `PAT`                    | 旧兼容 | `MAKER_PAT` 的历史短名称。不得用于新集成，名称过于通用。  |
+| `MAKER_JWT`              | 兼容   | legacy Maker JWT。只用于仍依赖 JWT 的内部流程。           |
+| `JWT`                    | 旧兼容 | `MAKER_JWT` 的历史短名称。不得用于新集成。                |
+| `MAKER_JWT_EXCHANGE_URL` | 内部   | legacy TapTap token 换 Maker JWT 的接口地址。             |
+
+`TAPTAP_MCP_CLIENT_SECRET` 是仓库共享认证/构建变量，不属于 Maker 插件配置。它只能存在于受控
+构建或内部联调环境，不能进入客户端插件、MCP 配置和日志。
+
+## 项目与基础设施兼容变量
+
+| 变量                    | 状态                         | 说明                                                                                                      |
+| ----------------------- | ---------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `MAKER_PROJECT_ID`      | 兼容/测试                    | 强制覆盖 MCP 项目标识。正常项目必须从 `.maker-mcp/config.json` 和 MCP Roots/`target_dir` 解析，不应设置。 |
+| `DSH_HOME`              | DSH 宿主配置                 | DSH 配置根目录，默认 `~/.dsh`。Maker CLI 用它定位 Cordis patch。                                          |
+| `DSH_TAPTAP_MAKER_BIN`  | DSH 插件注入                 | DSH 插件内置 Maker CLI 的绝对路径，供 Agent 执行一次性命令。用户不手动持久化。                            |
+| `CODEBUDDY_PLUGIN_ROOT` | WorkBuddy/CodeBuddy 宿主注入 | 当前插件根目录，用于定位 bundle、hook 和启动器。                                                          |
+| `WORKBUDDY_EXTRA_PATHS` | WorkBuddy 宿主注入           | WorkBuddy 管理的可执行文件搜索目录；启动器优先从中寻找 Node.js。                                          |
+| `WORKBUDDY_CONFIG_DIR`  | WorkBuddy 宿主或测试         | WorkBuddy 配置根目录覆盖。                                                                                |
+| `CODEBUDDY_CONFIG_DIR`  | CodeBuddy 兼容宿主           | `WORKBUDDY_CONFIG_DIR` 未设置时的兼容回退。                                                               |
+
+`HOME`、`USERPROFILE`、`APPDATA`、`PATH`、`HTTP_PROXY`、`HTTPS_PROXY`、`NO_PROXY`、
+`NPM_CONFIG_CACHE`、`npm_config_cache` 和 `npm_execpath` 是操作系统、代理或 npm 提供的标准变量，
+不是 Maker 配置 API。Maker 只读取它们做路径兼容、诊断或显式 npx fallback，不得为其创建 Maker
+别名。
+
+## 构建与发布变量
+
+这些变量只供仓库脚本和 CI 使用，不会写入 Maker MCP 或客户端插件运行环境。
+
+| 变量                    | 默认值             | 使用脚本                                                   |
+| ----------------------- | ------------------ | ---------------------------------------------------------- |
+| `MAKER_PACKAGE_VERSION` | `dev`              | `scripts/bundle-maker.js` 注入 Maker bundle 版本。         |
+| `MAKER_BUNDLE_OUTFILE`  | `dist/maker.js`    | 覆盖 Maker bundle 输出路径，插件准备脚本用它生成隔离产物。 |
+| `MAKER_VERSION_MODE`    | `auto-last-number` | Maker npm 版本解析模式。                                   |
+| `MAKER_MANUAL_VERSION`  | 无                 | `MAKER_VERSION_MODE=manual` 时要求的明确版本。             |
+| `MAKER_NPM_TAG`         | `beta`             | Maker npm 发布 tag。                                       |
+
+`GITHUB_REF_NAME` 和 `GITHUB_OUTPUT` 由 GitHub Actions 提供，不属于 Maker 自定义变量。
+
+## 配置优先级
+
+1. 当前命令显式参数或函数参数。
+2. 当前名称的环境变量，例如 `TAPTAP_MAKER_API_BASE`。
+3. 兼容旧变量，例如 `MAKER_API_BASE`。
+4. 项目级 `.maker/taptap-maker.local.json`（仅环境选择）。
+5. 代码内 production 默认值。
+
+插件身份是例外：只要 `TAPTAP_MAKER_DISTRIBUTION` 去除首尾空白后非空，就进入插件托管模式；
+具体值无法识别时仍应用通用插件行为，但不会猜测客户端专属配置或更新方式。
+
+## 变更检查清单
+
+新增或修改环境变量前必须确认：
+
+1. 现有变量或 CLI 参数不能表达该需求。
+2. 名称符合所属层级，且没有与兼容旧变量重复。
+3. 默认行为在变量未设置时完全兼容。
+4. 敏感值不会进入 argv、日志、诊断、插件产物或 Git。
+5. Windows、macOS 和 Linux 的路径/分隔符语义明确。
+6. 本文档和 `src/__tests__/makerEnvironmentVariables.test.ts` 已更新。

--- a/plugins/taptap-maker/dist/maker.js
+++ b/plugins/taptap-maker/dist/maker.js
@@ -39686,6 +39686,9 @@ import path11 from "node:path";
 import { fileURLToPath } from "node:url";
 
 // src/maker/pluginDistribution.ts
+function hasMakerPluginDistribution(distribution = process.env.TAPTAP_MAKER_DISTRIBUTION) {
+  return Boolean(distribution == null ? void 0 : distribution.trim());
+}
 function resolveMakerPluginDistribution(distribution = process.env.TAPTAP_MAKER_DISTRIBUTION) {
   if (distribution === "codex_plugin") {
     return { id: distribution, client: "codex", displayName: "Codex" };
@@ -40275,6 +40278,9 @@ function decideMakerPackageUpdate(currentVersion, policy) {
 async function checkMakerPackageUpdate(options) {
   const now = options.now ?? /* @__PURE__ */ new Date();
   const currentVersion = options.currentVersion;
+  if (hasMakerPluginDistribution()) {
+    return buildPluginManagedStatus(currentVersion);
+  }
   if (currentVersion === "dev") {
     return {
       status: "skipped",
@@ -40333,6 +40339,9 @@ async function checkMakerPackageUpdate(options) {
 async function getMakerPackageUpdateStatus(options) {
   var _a3, _b;
   const currentVersion = options.currentVersion;
+  if (hasMakerPluginDistribution()) {
+    return buildPluginManagedStatus(currentVersion);
+  }
   if (currentVersion === "dev") {
     return {
       status: "skipped",
@@ -40384,6 +40393,9 @@ async function getMakerPackageUpdateStatus(options) {
 }
 var backgroundCheck;
 function startMakerPackageUpdateCheck(options) {
+  if (hasMakerPluginDistribution()) {
+    return;
+  }
   const key = `${options.currentVersion}
 ${resolvePolicyUrl(options.policyUrl)}`;
   if ((backgroundCheck == null ? void 0 : backgroundCheck.key) === key) {
@@ -40417,7 +40429,7 @@ function formatMakerPackageUpdateStatus(status) {
   }
   if (status.blacklist_match) {
     lines.push(`- blacklist_match: ${status.blacklist_match}`);
-  } else if (status.status !== "skipped") {
+  } else if (status.status !== "skipped" && status.status !== "managed_by_plugin") {
     lines.push("- blacklist_match: no");
   }
   if (status.checked_at) {
@@ -40445,6 +40457,13 @@ function formatMakerPackageUpdateStatus(status) {
     lines.push(`- restart_required: ${status.restart_required ? "yes" : "no"}`);
   }
   return lines.join("\n");
+}
+function buildPluginManagedStatus(currentVersion) {
+  return {
+    status: "managed_by_plugin",
+    current_version: currentVersion,
+    restart_required: false
+  };
 }
 function formatUnavailableNonBlockingError(previousError, backgroundRefresh) {
   if (backgroundRefresh) {
@@ -45462,7 +45481,7 @@ async function formatStatus(options = {}) {
     `- status: ${packageUpdateStatus.status}`,
     pluginDistribution ? `- distribution: ${pluginDistribution.id}` : "",
     packageUpdateStatus.target_version ? `- target_version: ${packageUpdateStatus.target_version}` : "",
-    pluginDistribution ? `- next_action: ${formatMakerPluginUpdateAction(pluginDistribution)}` : packageUpdateStatus.next_action ? `- next_action: ${packageUpdateStatus.next_action}` : "",
+    pluginDistribution && packageUpdateStatus.status !== "managed_by_plugin" ? `- next_action: ${formatMakerPluginUpdateAction(pluginDistribution)}` : packageUpdateStatus.next_action ? `- next_action: ${packageUpdateStatus.next_action}` : "",
     projectInitialization ? `- project_initialization: ${projectInitialization.status}` : "",
     projectHealth ? `- project_health: ${projectHealth.status}` : "",
     formatMakerClientRootsSummary(projectContext.roots),
@@ -45565,11 +45584,14 @@ function formatMakerPackageUpdateStatusForDistribution(status, distribution) {
   if (!pluginDistribution) {
     return formatted;
   }
-  return [
+  const lines = [
     ...formatted.split("\n").filter((line) => !line.startsWith("- next_action:")),
-    `- distribution: ${pluginDistribution.id}`,
-    `- next_action: ${formatMakerPluginUpdateAction(pluginDistribution)}`
-  ].join("\n");
+    `- distribution: ${pluginDistribution.id}`
+  ];
+  if (status.status !== "managed_by_plugin") {
+    lines.push(`- next_action: ${formatMakerPluginUpdateAction(pluginDistribution)}`);
+  }
+  return lines.join("\n");
 }
 function formatAuthNextStep(options) {
   if (!options.hasTapAuth) {

--- a/plugins/workbuddy/taptap-maker/dist/maker.js
+++ b/plugins/workbuddy/taptap-maker/dist/maker.js
@@ -39686,6 +39686,9 @@ import path11 from "node:path";
 import { fileURLToPath } from "node:url";
 
 // src/maker/pluginDistribution.ts
+function hasMakerPluginDistribution(distribution = process.env.TAPTAP_MAKER_DISTRIBUTION) {
+  return Boolean(distribution == null ? void 0 : distribution.trim());
+}
 function resolveMakerPluginDistribution(distribution = process.env.TAPTAP_MAKER_DISTRIBUTION) {
   if (distribution === "codex_plugin") {
     return { id: distribution, client: "codex", displayName: "Codex" };
@@ -40275,6 +40278,9 @@ function decideMakerPackageUpdate(currentVersion, policy) {
 async function checkMakerPackageUpdate(options) {
   const now = options.now ?? /* @__PURE__ */ new Date();
   const currentVersion = options.currentVersion;
+  if (hasMakerPluginDistribution()) {
+    return buildPluginManagedStatus(currentVersion);
+  }
   if (currentVersion === "dev") {
     return {
       status: "skipped",
@@ -40333,6 +40339,9 @@ async function checkMakerPackageUpdate(options) {
 async function getMakerPackageUpdateStatus(options) {
   var _a3, _b;
   const currentVersion = options.currentVersion;
+  if (hasMakerPluginDistribution()) {
+    return buildPluginManagedStatus(currentVersion);
+  }
   if (currentVersion === "dev") {
     return {
       status: "skipped",
@@ -40384,6 +40393,9 @@ async function getMakerPackageUpdateStatus(options) {
 }
 var backgroundCheck;
 function startMakerPackageUpdateCheck(options) {
+  if (hasMakerPluginDistribution()) {
+    return;
+  }
   const key = `${options.currentVersion}
 ${resolvePolicyUrl(options.policyUrl)}`;
   if ((backgroundCheck == null ? void 0 : backgroundCheck.key) === key) {
@@ -40417,7 +40429,7 @@ function formatMakerPackageUpdateStatus(status) {
   }
   if (status.blacklist_match) {
     lines.push(`- blacklist_match: ${status.blacklist_match}`);
-  } else if (status.status !== "skipped") {
+  } else if (status.status !== "skipped" && status.status !== "managed_by_plugin") {
     lines.push("- blacklist_match: no");
   }
   if (status.checked_at) {
@@ -40445,6 +40457,13 @@ function formatMakerPackageUpdateStatus(status) {
     lines.push(`- restart_required: ${status.restart_required ? "yes" : "no"}`);
   }
   return lines.join("\n");
+}
+function buildPluginManagedStatus(currentVersion) {
+  return {
+    status: "managed_by_plugin",
+    current_version: currentVersion,
+    restart_required: false
+  };
 }
 function formatUnavailableNonBlockingError(previousError, backgroundRefresh) {
   if (backgroundRefresh) {
@@ -45462,7 +45481,7 @@ async function formatStatus(options = {}) {
     `- status: ${packageUpdateStatus.status}`,
     pluginDistribution ? `- distribution: ${pluginDistribution.id}` : "",
     packageUpdateStatus.target_version ? `- target_version: ${packageUpdateStatus.target_version}` : "",
-    pluginDistribution ? `- next_action: ${formatMakerPluginUpdateAction(pluginDistribution)}` : packageUpdateStatus.next_action ? `- next_action: ${packageUpdateStatus.next_action}` : "",
+    pluginDistribution && packageUpdateStatus.status !== "managed_by_plugin" ? `- next_action: ${formatMakerPluginUpdateAction(pluginDistribution)}` : packageUpdateStatus.next_action ? `- next_action: ${packageUpdateStatus.next_action}` : "",
     projectInitialization ? `- project_initialization: ${projectInitialization.status}` : "",
     projectHealth ? `- project_health: ${projectHealth.status}` : "",
     formatMakerClientRootsSummary(projectContext.roots),
@@ -45565,11 +45584,14 @@ function formatMakerPackageUpdateStatusForDistribution(status, distribution) {
   if (!pluginDistribution) {
     return formatted;
   }
-  return [
+  const lines = [
     ...formatted.split("\n").filter((line) => !line.startsWith("- next_action:")),
-    `- distribution: ${pluginDistribution.id}`,
-    `- next_action: ${formatMakerPluginUpdateAction(pluginDistribution)}`
-  ].join("\n");
+    `- distribution: ${pluginDistribution.id}`
+  ];
+  if (status.status !== "managed_by_plugin") {
+    lines.push(`- next_action: ${formatMakerPluginUpdateAction(pluginDistribution)}`);
+  }
+  return lines.join("\n");
 }
 function formatAuthNextStep(options) {
   if (!options.hasTapAuth) {

--- a/src/__tests__/makerBuildLocalChanges.test.ts
+++ b/src/__tests__/makerBuildLocalChanges.test.ts
@@ -3612,7 +3612,7 @@ describe('maker build local-change guard', () => {
     }
   });
 
-  test('Codex plugin status directs upgrades to the plugin instead of standalone npm', async () => {
+  test('Codex plugin status does not prompt for package or plugin updates', async () => {
     process.env.TAPTAP_MAKER_DISTRIBUTION = 'codex_plugin';
 
     const summary = await formatStatus({ targetDir: tempDir });
@@ -3620,12 +3620,14 @@ describe('maker build local-change guard', () => {
 
     for (const output of [summary, detail]) {
       expect(output).toContain('- distribution: codex_plugin');
-      expect(output).toContain('Update the installed Codex plugin');
+      expect(output).toContain('- status: managed_by_plugin');
+      expect(output).not.toContain('- next_action: Update the installed Codex plugin');
+      expect(output).not.toContain('- target_version:');
       expect(output).not.toContain('npx -y -p @taptap/maker');
     }
   });
 
-  test('WorkBuddy plugin status directs upgrades to WorkBuddy instead of standalone npm', async () => {
+  test('WorkBuddy plugin status does not prompt for package or plugin updates', async () => {
     process.env.TAPTAP_MAKER_DISTRIBUTION = 'workbuddy_plugin';
 
     const summary = await formatStatus({ targetDir: tempDir });
@@ -3633,8 +3635,10 @@ describe('maker build local-change guard', () => {
 
     for (const output of [summary, detail]) {
       expect(output).toContain('- distribution: workbuddy_plugin');
-      expect(output).toContain('Update the installed WorkBuddy plugin');
-      expect(output).not.toContain('Update the installed Codex plugin');
+      expect(output).toContain('- status: managed_by_plugin');
+      expect(output).not.toContain('- next_action: Update the installed WorkBuddy plugin');
+      expect(output).not.toContain('- next_action: Update the installed Codex plugin');
+      expect(output).not.toContain('- target_version:');
       expect(output).not.toContain('npx -y -p @taptap/maker');
     }
   });

--- a/src/__tests__/makerEnvironmentVariables.test.ts
+++ b/src/__tests__/makerEnvironmentVariables.test.ts
@@ -1,0 +1,92 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const projectRoot = path.resolve(__dirname, '../..');
+const referencePath = path.join(projectRoot, 'docs', 'MAKER_ENVIRONMENT_VARIABLES.md');
+const sourceRoots = [
+  path.join(projectRoot, 'src', 'maker'),
+  path.join(projectRoot, 'scripts'),
+  path.join(projectRoot, 'plugin-sources', 'taptap-maker'),
+  path.join(projectRoot, 'packages', 'dsh-maker'),
+];
+const scannedExtensions = new Set([
+  '.ts',
+  '.js',
+  '.cjs',
+  '.mjs',
+  '.sh',
+  '.cmd',
+  '.json',
+  '.yml',
+  '.yaml',
+  '.md',
+]);
+
+describe('Maker environment variable reference', () => {
+  test('documents every Maker-owned environment variable used by source and plugin integrations', () => {
+    const reference = fs.readFileSync(referencePath, 'utf8');
+    const variables = new Set<string>();
+
+    for (const root of sourceRoots) {
+      for (const filePath of listFiles(root)) {
+        if (!scannedExtensions.has(path.extname(filePath)) || filePath.includes('/dist/')) {
+          continue;
+        }
+        const content = fs.readFileSync(filePath, 'utf8');
+        for (const match of content.matchAll(/\bTAPTAP_MAKER_[A-Z0-9_]+\b/gu)) {
+          variables.add(match[0]);
+        }
+      }
+    }
+
+    const undocumented = [...variables]
+      .sort()
+      .filter((variable) => !reference.includes(`\`${variable}\``));
+    expect(undocumented).toEqual([]);
+  });
+
+  test('documents shared, compatibility, host, and release variables used by Maker', () => {
+    const reference = fs.readFileSync(referencePath, 'utf8');
+    const requiredVariables = [
+      'TAPTAP_MCP_ENV',
+      'TAPTAP_MCP_CLIENT_ID',
+      'TAPTAP_MCP_CLIENT_SECRET',
+      'TAPTAP_MCP_CLIENT_IDE',
+      'TDS_MCP_ENV',
+      'TDS_MCP_CLIENT_ID',
+      'TDS_MCP_CLIENT_TOKEN',
+      'MAKER_PAT',
+      'PAT',
+      'MAKER_JWT',
+      'JWT',
+      'MAKER_PROJECT_ID',
+      'SCE_MCP_URL',
+      'DSH_HOME',
+      'DSH_TAPTAP_MAKER_BIN',
+      'CODEBUDDY_PLUGIN_ROOT',
+      'WORKBUDDY_EXTRA_PATHS',
+      'WORKBUDDY_CONFIG_DIR',
+      'CODEBUDDY_CONFIG_DIR',
+      'MAKER_PACKAGE_VERSION',
+      'MAKER_BUNDLE_OUTFILE',
+      'MAKER_VERSION_MODE',
+      'MAKER_MANUAL_VERSION',
+      'MAKER_NPM_TAG',
+    ];
+
+    const undocumented = requiredVariables.filter(
+      (variable) => !reference.includes(`\`${variable}\``)
+    );
+    expect(undocumented).toEqual([]);
+  });
+});
+
+function listFiles(root: string): string[] {
+  if (!fs.existsSync(root)) {
+    return [];
+  }
+  return fs.readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(root, entry.name);
+    return entry.isDirectory() ? listFiles(entryPath) : [entryPath];
+  });
+}

--- a/src/__tests__/makerMcpVersionStatus.test.ts
+++ b/src/__tests__/makerMcpVersionStatus.test.ts
@@ -162,9 +162,20 @@ jest.mock('../maker/cli/devKit', () => ({
 }));
 
 describe('maker MCP version status integration', () => {
+  const originalDistribution = process.env.TAPTAP_MAKER_DISTRIBUTION;
+
   beforeEach(() => {
     mockServers.length = 0;
     jest.clearAllMocks();
+    delete process.env.TAPTAP_MAKER_DISTRIBUTION;
+  });
+
+  afterEach(() => {
+    if (originalDistribution === undefined) {
+      delete process.env.TAPTAP_MAKER_DISTRIBUTION;
+    } else {
+      process.env.TAPTAP_MAKER_DISTRIBUTION = originalDistribution;
+    }
   });
 
   test('starts package update check on MCP startup and includes update status in maker_status_lite', async () => {
@@ -224,6 +235,48 @@ describe('maker MCP version status integration', () => {
       allowRemoteFetch: false,
       backgroundRefresh: false,
     });
+  });
+
+  test('does not add an update action when a plugin distribution manages the package', async () => {
+    process.env.TAPTAP_MAKER_DISTRIBUTION = 'codex_plugin';
+    const versionCheck = await import('../maker/versionCheck');
+    jest.mocked(versionCheck.getMakerPackageUpdateStatus).mockResolvedValue({
+      status: 'managed_by_plugin',
+      current_version: '0.0.30',
+      restart_required: false,
+    });
+    jest
+      .mocked(versionCheck.formatMakerPackageUpdateStatus)
+      .mockReturnValue(
+        [
+          'Maker MCP package update',
+          '',
+          '- status: managed_by_plugin',
+          '- current_version: 0.0.30',
+        ].join('\n')
+      );
+    const { startMakerMcpServer } = await import('../maker/server/mcp');
+    const { CallToolRequestSchema } = await import('@modelcontextprotocol/sdk/types.js');
+
+    await startMakerMcpServer();
+    const handler = mockServers[0].handlers.get(CallToolRequestSchema);
+    const result = await handler(
+      {
+        params: {
+          name: 'maker_status_lite',
+          arguments: {
+            target_dir: '/tmp/maker-project',
+            skip_remote_sync: true,
+            detail: true,
+          },
+        },
+      },
+      {}
+    );
+
+    expect(result.content[0].text).toContain('- status: managed_by_plugin');
+    expect(result.content[0].text).not.toContain('- target_version:');
+    expect(result.content[0].text).not.toContain('Update the installed Codex plugin');
   });
 
   test('marks a blocked Maker submission as a tool error', async () => {

--- a/src/__tests__/makerVersionCheck.test.ts
+++ b/src/__tests__/makerVersionCheck.test.ts
@@ -26,6 +26,7 @@ describe('maker package version check', () => {
 
   const originalMakerHome = process.env.TAPTAP_MAKER_HOME;
   const originalPolicyUrl = process.env.TAPTAP_MAKER_VERSION_POLICY_URL;
+  const originalDistribution = process.env.TAPTAP_MAKER_DISTRIBUTION;
 
   let tempDir: string;
 
@@ -38,6 +39,40 @@ describe('maker package version check', () => {
     fs.rmSync(tempDir, { recursive: true, force: true });
     restoreEnv('TAPTAP_MAKER_HOME', originalMakerHome);
     restoreEnv('TAPTAP_MAKER_VERSION_POLICY_URL', originalPolicyUrl);
+    restoreEnv('TAPTAP_MAKER_DISTRIBUTION', originalDistribution);
+  });
+
+  test('treats any non-empty distribution as plugin-managed without checking for updates', async () => {
+    process.env.TAPTAP_MAKER_DISTRIBUTION = 'cindy_plugin';
+    const cachePath = getCachePath();
+    writeCache({
+      checked_at: '2026-06-23T00:00:00.000Z',
+      policy_url: 'https://example.com/policy.json',
+      policy,
+      decision: {
+        status: 'required_upgrade',
+        current_version: '0.0.5',
+        target_version: '0.0.8',
+      },
+    });
+    const fetchImpl = jest.fn<typeof fetch>(async () => jsonResponse(policy));
+
+    const status = await getMakerPackageUpdateStatus({
+      currentVersion: '0.0.5',
+      fetchImpl,
+      policyUrl: 'https://example.com/policy.json',
+    });
+
+    expect(status).toEqual({
+      status: 'managed_by_plugin',
+      current_version: '0.0.5',
+      restart_required: false,
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(formatMakerPackageUpdateStatus(status)).not.toMatch(
+      /target_version|update_available|required_upgrade|next_action/u
+    );
+    expect(fs.existsSync(cachePath)).toBe(true);
   });
 
   test('decides required and optional updates with stable beta and dev rules', () => {

--- a/src/maker/README.md
+++ b/src/maker/README.md
@@ -30,6 +30,11 @@ Codex 插件位于 [`plugins/taptap-maker`](../../plugins/taptap-maker)。当前
 Codex 和 WorkBuddy 插件共用 `config/maker-plugin-version.json` 的独立版本号。Maker MCP 自身版本
 仍由 `config/maker-version-policy.json` 管理，插件发布不会触发 npm 发布。
 
+插件启动 Maker runtime 时必须设置非空的 `TAPTAP_MAKER_DISTRIBUTION`。该变量非空表示当前
+runtime 由插件渠道管理，因此 Maker 不检查或提示 npm 包更新；具体值（如 `codex_plugin`、
+`workbuddy_plugin`、`dsh_plugin` 或外部插件自己的标识）只用于识别分发渠道。独立 Maker MCP
+不得设置该变量，并继续使用正常的 npm 版本策略。
+
 ## WorkBuddy Plugin
 
 WorkBuddy 插件位于
@@ -78,6 +83,10 @@ npm run maker:codex-plugin:prepare
 npm run maker:workbuddy-plugin:prepare
 npm run maker:plugins:package -- --output-dir artifacts/maker-plugins
 ```
+
+环境变量的完整契约见
+[Maker MCP 环境变量参考](../../docs/MAKER_ENVIRONMENT_VARIABLES.md)。新增或修改变量前必须先检查该
+文档，避免重复开关和跨层级配置。
 
 Maker 代码位于当前目录，打包入口为 `src/maker/index.ts`，本地 MCP server 位于
 `src/maker/server/`，CLI 位于 `src/maker/cli/`。

--- a/src/maker/pluginDistribution.ts
+++ b/src/maker/pluginDistribution.ts
@@ -6,6 +6,12 @@ export type MakerPluginDistribution = {
   displayName: 'Codex' | 'WorkBuddy' | 'DSH';
 };
 
+export function hasMakerPluginDistribution(
+  distribution: string | undefined = process.env.TAPTAP_MAKER_DISTRIBUTION
+): boolean {
+  return Boolean(distribution?.trim());
+}
+
 export function resolveMakerPluginDistribution(
   distribution: string | undefined = process.env.TAPTAP_MAKER_DISTRIBUTION
 ): MakerPluginDistribution | undefined {

--- a/src/maker/server/mcp.ts
+++ b/src/maker/server/mcp.ts
@@ -1097,7 +1097,7 @@ export async function formatStatus(
     packageUpdateStatus.target_version
       ? `- target_version: ${packageUpdateStatus.target_version}`
       : '',
-    pluginDistribution
+    pluginDistribution && packageUpdateStatus.status !== 'managed_by_plugin'
       ? `- next_action: ${formatMakerPluginUpdateAction(pluginDistribution)}`
       : packageUpdateStatus.next_action
         ? `- next_action: ${packageUpdateStatus.next_action}`
@@ -1220,11 +1220,14 @@ function formatMakerPackageUpdateStatusForDistribution(
   if (!pluginDistribution) {
     return formatted;
   }
-  return [
+  const lines = [
     ...formatted.split('\n').filter((line) => !line.startsWith('- next_action:')),
     `- distribution: ${pluginDistribution.id}`,
-    `- next_action: ${formatMakerPluginUpdateAction(pluginDistribution)}`,
-  ].join('\n');
+  ];
+  if (status.status !== 'managed_by_plugin') {
+    lines.push(`- next_action: ${formatMakerPluginUpdateAction(pluginDistribution)}`);
+  }
+  return lines.join('\n');
 }
 
 function formatAuthNextStep(options: {

--- a/src/maker/versionCheck.ts
+++ b/src/maker/versionCheck.ts
@@ -8,6 +8,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fetchWithTimeout } from './fetchTimeout.js';
+import { hasMakerPluginDistribution } from './pluginDistribution.js';
 import { getMakerHome } from './storage.js';
 
 const DEFAULT_POLICY_URL =
@@ -22,6 +23,7 @@ type MakerPackageUpdateDecisionStatus =
   | 'current'
   | 'update_available'
   | 'required_upgrade'
+  | 'managed_by_plugin'
   | 'unavailable'
   | 'skipped';
 
@@ -167,6 +169,10 @@ export async function checkMakerPackageUpdate(
   const now = options.now ?? new Date();
   const currentVersion = options.currentVersion;
 
+  if (hasMakerPluginDistribution()) {
+    return buildPluginManagedStatus(currentVersion);
+  }
+
   if (currentVersion === 'dev') {
     return {
       status: 'skipped',
@@ -231,6 +237,9 @@ export async function getMakerPackageUpdateStatus(
   options: MakerPackageUpdateCheckOptions
 ): Promise<MakerPackageUpdateStatus> {
   const currentVersion = options.currentVersion;
+  if (hasMakerPluginDistribution()) {
+    return buildPluginManagedStatus(currentVersion);
+  }
   if (currentVersion === 'dev') {
     return {
       status: 'skipped',
@@ -308,6 +317,9 @@ let backgroundCheck:
   | undefined;
 
 export function startMakerPackageUpdateCheck(options: MakerPackageUpdateCheckOptions): void {
+  if (hasMakerPluginDistribution()) {
+    return;
+  }
   const key = `${options.currentVersion}\n${resolvePolicyUrl(options.policyUrl)}`;
   if (backgroundCheck?.key === key) {
     return;
@@ -346,7 +358,7 @@ export function formatMakerPackageUpdateStatus(status: MakerPackageUpdateStatus)
   }
   if (status.blacklist_match) {
     lines.push(`- blacklist_match: ${status.blacklist_match}`);
-  } else if (status.status !== 'skipped') {
+  } else if (status.status !== 'skipped' && status.status !== 'managed_by_plugin') {
     lines.push('- blacklist_match: no');
   }
   if (status.checked_at) {
@@ -375,6 +387,14 @@ export function formatMakerPackageUpdateStatus(status: MakerPackageUpdateStatus)
   }
 
   return lines.join('\n');
+}
+
+function buildPluginManagedStatus(currentVersion: string): MakerPackageUpdateStatus {
+  return {
+    status: 'managed_by_plugin',
+    current_version: currentVersion,
+    restart_required: false,
+  };
 }
 
 function formatUnavailableNonBlockingError(


### PR DESCRIPTION
## 改动说明

- 合并 develop 中已完成 beta 验证的 Maker 插件运行时修复
- 插件分发模式下跳过独立 npm 包更新提示
- 补充 Maker 环境变量说明和对应回归测试
- 同步 Codex 与 WorkBuddy 插件内置运行时产物

## 发布验证

- `@taptap/maker@0.0.31-beta.2` 已发布并由用户测试通过
- `npm test -- --runInBand`：62 suites / 877 tests passed
- `npm run lint`：passed
- `npm run format:check`：passed

## 合并范围

- base: `main`
- head: `develop`
- 不包含本地主工作区未跟踪的 DSH 发布 TODO