### PR TITLE
docs(dsh): correct stable plugin distribution guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,9 @@ DSH 使用 `@deepseek-ai/dsh-mcp-client` 插件，不使用 `mcp.json`。检测�
 两者都可由 DSH HMR 热重载。配置不写项目 `cwd`；DSH 当前
 不广播 MCP Roots，因此 AI 必须在具体 Maker tool 调用中把当前游戏项目作为 `target_dir` 传入。
 需要把 Maker 技能（工作流 + 广告/云存档/排行榜指南）一并打包进 DSH 时，可用 bundle 插件
-`@taptap/dsh-maker`（源码 `packages/dsh-maker/`，`dsh plugin --profile web add @taptap/dsh-maker`
-一键安装），详见 [docs/DSH_PLUGIN.md](docs/DSH_PLUGIN.md)。该插件与 L1 的裸 MCP 行不要同时启用。
+`@taptap/dsh-maker`（源码 `packages/dsh-maker/`），通过 1024Store 或 GitHub 子目录源
+`github:taptap/instant-games-open-mcp#path:packages/dsh-maker` 一键安装，详见
+[docs/DSH_PLUGIN.md](docs/DSH_PLUGIN.md)。该插件与 L1 的裸 MCP 行不要同时启用。
 其它 AI 编辑器应优先让本地 AI 复用 `taptap-maker mcp install` 已验证的绝对 command/args。
 只有无法复用安装器时，才使用下面固定精确版本的 npx 兼容片段：
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,8 @@ DSH 使用 `@deepseek-ai/dsh-mcp-client` 插件，不使用 `mcp.json`。检测�
 需要把 Maker 技能（工作流 + 广告/云存档/排行榜指南）一并打包进 DSH 时，可用 bundle 插件
 `@taptap/dsh-maker`（源码 `packages/dsh-maker/`），通过 1024Store 或 GitHub 子目录源
 `github:taptap/instant-games-open-mcp#path:packages/dsh-maker` 一键安装，详见
-[docs/DSH_PLUGIN.md](docs/DSH_PLUGIN.md)。该插件与 L1 的裸 MCP 行不要同时启用。
+[docs/DSH_PLUGIN.md](docs/DSH_PLUGIN.md)。该无 ref 源跟随 `main`；固定版本使用 `dsh-maker-v*`
+GitHub Release tarball。该插件与 L1 的裸 MCP 行不要同时启用。
 其它 AI 编辑器应优先让本地 AI 复用 `taptap-maker mcp install` 已验证的绝对 command/args。
 只有无法复用安装器时，才使用下面固定精确版本的 npx 兼容片段：
 

--- a/docs/DSH_PLUGIN.md
+++ b/docs/DSH_PLUGIN.md
@@ -122,7 +122,8 @@ dsh plugin --profile web remove @taptap/dsh-maker
 DSH 插件有两条互补的分发入口：
 
 - **1024Store / GitHub 子目录源**：市场条目指向
-  `github:taptap/instant-games-open-mcp#path:packages/dsh-maker`，用于市场安装和更新。
+  `github:taptap/instant-games-open-mcp#path:packages/dsh-maker`，用于市场安装和更新。该无 ref 源按
+  1024Store 规范跟随仓库 `main`。
 - **GitHub Release tarball**：用于分享固定版本链接。用户把发版页链接交给 AI，AI 按页面下载、
   校验 SHA-256 后安装。
 

--- a/docs/DSH_PLUGIN.md
+++ b/docs/DSH_PLUGIN.md
@@ -104,6 +104,7 @@ dsh plugin --profile web remove @taptap/dsh-maker
       serverName: taptap-maker # 默认 taptap-maker
       toolCallTimeoutMs: 3600000 # 默认 1 小时
       failOnStartupError: false # 默认 false
+      env: {} # 可选：合并进 MCP 子进程环境
       cwd: '' # 默认不写（项目无关）
 ```
 

--- a/docs/DSH_PLUGIN.md
+++ b/docs/DSH_PLUGIN.md
@@ -104,8 +104,6 @@ dsh plugin --profile web remove @taptap/dsh-maker
       serverName: taptap-maker # 默认 taptap-maker
       toolCallTimeoutMs: 3600000 # 默认 1 小时
       failOnStartupError: false # 默认 false
-      env: # 合并进子进程环境（凭证类放这里）
-        TAPTAP_MCP_ENV: production
       cwd: '' # 默认不写（项目无关）
 ```
 
@@ -135,10 +133,9 @@ DSH 插件有两条互补的分发入口：
   选择 `main` 发布稳定版；工作流创建 tag `dsh-maker-v<version>` 的 GitHub Release，把 tarball、
   `SHA256SUMS` 上传为附件，`INSTALL.md` 作为 Release 说明。
 
-本地（未发版）分发：跑一次 `npm run maker:dsh-plugin:package`，把 `taptap-dsh-maker-<version>.tgz`
-
-- `SHA256SUMS` 交给测试用户，用户（或其 AI）执行
-  `dsh plugin --profile web add <tarball绝对路径>` 即可。
+本地（未发版）分发：跑一次 `npm run maker:dsh-plugin:package`，把
+`taptap-dsh-maker-<version>.tgz` 和 `SHA256SUMS` 交给测试用户，用户（或其 AI）执行
+`dsh plugin --profile web add <tarball绝对路径>` 即可。
 
 ## 版本与发布
 

--- a/docs/DSH_PLUGIN.md
+++ b/docs/DSH_PLUGIN.md
@@ -3,10 +3,10 @@
 本仓库把 TapTap Maker 的本地开发闭环接入 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
 （DSH），分两层交付，由轻到重：
 
-| 层     | 形态        | 入口                                                | 能力                                                                                     |
-| ------ | ----------- | --------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| **L1** | 零代码配置  | `taptap-maker install --ide dsh`                    | 只把 Maker MCP 注册成一条 `mcp-client` 行（写入 `$DSH_HOME/cordis.patch.yml`），HMR 生效 |
-| **L2** | bundle 插件 | `packages/dsh-maker/`（npm 包 `@taptap/dsh-maker`） | MCP + 技能打包，`dsh plugin add` 一键安装，自包含、可分发                                |
+| 层     | 形态        | 入口                                              | 能力                                                                                     |
+| ------ | ----------- | ------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| **L1** | 零代码配置  | `taptap-maker install --ide dsh`                  | 只把 Maker MCP 注册成一条 `mcp-client` 行（写入 `$DSH_HOME/cordis.patch.yml`），HMR 生效 |
+| **L2** | bundle 插件 | `packages/dsh-maker/`（包名 `@taptap/dsh-maker`） | MCP + 技能打包，`dsh plugin add` 一键安装，自包含、可分发                                |
 
 本文档说明 **L2 插件**。L1 的实现与配置细节见
 [`docs/MAKER.md`](MAKER.md) 的 DSH 章节。
@@ -78,8 +78,9 @@ packages/dsh-maker/
 前置：已装 DSH（`dsh`）与 pnpm。
 
 ```bash
-# 安装（web profile；headless 同理）
-dsh plugin --profile web add @taptap/dsh-maker
+# 从 1024Store 使用的 GitHub 子目录源安装（web profile；headless 同理）
+dsh plugin --profile web add \
+  'github:taptap/instant-games-open-mcp#path:packages/dsh-maker'
 
 # 验证
 dsh --profile web --dump-config | grep -A 20 'mcp-taptap-maker\|taptap-maker'
@@ -116,10 +117,14 @@ dsh plugin --profile web remove @taptap/dsh-maker
   `config.mcp.env`。
 - **超时**：DSH 默认每次 `tools/call` 60 秒，Maker 构建/素材会超时，插件已默认 1 小时。
 
-## 分发（GitHub 发版页）
+## 分发
 
-上架 DSH 插件市场之前，用与 Codex/WorkBuddy 相同的方式做 GitHub Release 分发：用户把发版页链接
-交给 AI，AI 按页面自动下载、校验、安装。
+DSH 插件有两条互补的分发入口：
+
+- **1024Store / GitHub 子目录源**：市场条目指向
+  `github:taptap/instant-games-open-mcp#path:packages/dsh-maker`，用于市场安装和更新。
+- **GitHub Release tarball**：用于分享固定版本链接。用户把发版页链接交给 AI，AI 按页面下载、
+  校验 SHA-256 后安装。
 
 - **发版页**：`packages/dsh-maker/INSTALL.md`（稳定页，含“给安装 AI 的强制执行指令”、下载链接、
   安装步骤、排障与回滚）。
@@ -141,9 +146,10 @@ dsh plugin --profile web remove @taptap/dsh-maker
   发布，避免安装时依赖不存在。
 - `packages/dsh-maker/` 与 `docs/DSH_PLUGIN.md` 已纳入 `scripts/release-scope.cjs` 的 maker
   归属，只改本插件的提交不会误触发主包发布。
-- 发布：从 `packages/dsh-maker/` 执行 `npm publish --access public`。
-- 接入 DSH 插件市场：本包已保持标准 bundle 形态 + `assets/taptap-maker.png` 图标，市场开放后
-  按规范补充入口字段即可。
+- 不发布 `@taptap/dsh-maker` npm 包；稳定包只通过 `Publish DSH Maker Plugin` workflow 发布到
+  GitHub Release。
+- 1024Store catalog 只登记 GitHub 仓库和 `packages/dsh-maker` 子目录；插件仍保持标准 bundle
+  形态，并使用 `assets/taptap-maker.png` 作为市场图标。
 
 ## 相关文档
 

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -105,8 +105,8 @@ WorkBuddy 插件位于 `plugins/workbuddy/taptap-maker`，通过
 
 DeepSeek Harness（DSH）的 Maker 集成分两层：L1 是 `taptap-maker install --ide dsh` 写入的
 裸 `mcp-client` 行（见下文“环境变量”与 DSH 配置小节）；L2 是 bundle 插件 `@taptap/dsh-maker`，
-位于 `packages/dsh-maker/`，通过 npm 分发，把 **Maker MCP + 技能** 打包成可一键安装、可 HMR 的
-DSH bundle。
+位于 `packages/dsh-maker/`，通过 1024Store 的 GitHub 子目录源或 GitHub Release tarball 分发，把
+**Maker MCP + 技能** 打包成可一键安装、可 HMR 的 DSH bundle；不单独发布 DSH npm 包。
 
 插件由一个 bundle patch 行（`id: taptap-maker`）在激活时挂两个子插件并注册一个 shell 环境变量：
 宿主平面 `skill-filesystem` 实例（`providerName: maker` + `bundledSkillDir: skills/`，只读挂本包
@@ -116,10 +116,11 @@ DSH bundle。
 三个功能指南，均
 内置“以工程内 `engine-docs` 为准、禁止网上搜错文档”的防错引导。
 
-与 Codex/WorkBuddy 的 ZIP marketplace 分发不同，DSH 插件走 npm（`dsh plugin add` 转发 pnpm），
-不经过 `scripts/package-maker-client-plugins.js`，也不属于 `config/maker-plugin-version.json`
-的插件版本线；它精确锁定包含所需 DSH 生命周期能力的 `@taptap/maker` 版本，develop 可先使用
-Maker beta 验证，main 只能使用稳定 Maker。发布工作流会先确认该版本已发布到 npm。完整设计、
+与 Codex/WorkBuddy 的 ZIP marketplace 分发不同，DSH 使用标准 bundle 包：`dsh plugin add` 由 pnpm
+安装 GitHub 子目录源或本地 tarball，但不从 npm registry 获取 `@taptap/dsh-maker`。它不经过
+`scripts/package-maker-client-plugins.js`，也不属于 `config/maker-plugin-version.json` 的插件
+版本线；它精确锁定包含所需 DSH 生命周期能力的 `@taptap/maker` 版本，develop 可先使用 Maker
+beta 验证，main 只能使用稳定 Maker。发布工作流会先确认 Maker 依赖版本已发布到 npm。完整设计、
 安装与配置见 [DSH_PLUGIN.md](DSH_PLUGIN.md)。
 
 ## 本地测试

--- a/packages/dsh-maker/README.md
+++ b/packages/dsh-maker/README.md
@@ -9,10 +9,10 @@ DeepSeek Harness（DSH）插件：把 [TapTap Maker](https://github.com/taptap/i
 2. **Maker 技能**：工作流 + 常用功能指南（广告 / 云存档 / 排行榜），并内置“以工程内
    `engine-docs` 为准、禁止网上搜错文档”的防错引导；
 3. **可发现的 CLI 路径**：环境变量 `DSH_TAPTAP_MAKER_BIN` 指向随包 `@taptap/maker` 的 CLI，
-   一次性 `init`/`upgrade`/`mcp report` 用 `node "$DSH_TAPTAP_MAKER_BIN" <cmd>` 零网络执行。
+   一次性 `init`/`agents update`/`mcp report` 用 `node "$DSH_TAPTAP_MAKER_BIN" <cmd>` 零网络执行。
 
-本插件是仓库 DSH 集成的 **L2 形态**（bundle 插件）。它叠加在已内置的
-**L1 形态**（`taptap-maker install --ide dsh` 写入 `$DSH_HOME/cordis.patch.yml`）之上：
+本插件是仓库 DSH 集成的 **L2 形态**（bundle 插件）。它区别于已有的
+**L1 形态**（`taptap-maker install --ide dsh` 写入 `$DSH_HOME/cordis.patch.yml`）：
 L1 只注册一个裸的 Maker MCP；本插件则把 **MCP + 技能** 打包成可分发、可一键安装、可 HMR 的
 DSH bundle。两者不要同时启用，避免同 `serverName` 冲突。已用 L1 时，不要手改 YAML；安装前用
 Maker CLI 的结构化命令检查并迁移旧注册：
@@ -96,8 +96,6 @@ dsh --profile web --dump-config | grep -A 20 'mcp-taptap-maker\|taptap-maker'
       serverName: taptap-maker # 默认 taptap-maker
       toolCallTimeoutMs: 3600000 # 默认 1 小时
       failOnStartupError: false # 默认 false：技能不受 MCP 启动失败影响，重连自愈
-      env: # 合并进子进程环境（凭证类放这里）
-        TAPTAP_MCP_ENV: production
       cwd: '' # 默认不写（保持项目无关）
 ```
 

--- a/packages/dsh-maker/README.md
+++ b/packages/dsh-maker/README.md
@@ -38,6 +38,10 @@ dsh plugin --profile headless add \
   'github:taptap/instant-games-open-mcp#path:packages/dsh-maker'
 ```
 
+上面的 GitHub 子目录源是 1024Store 使用的市场安装入口。需要安装固定版本或把链接交给 AI 自动
+安装时，使用仓库对应的 `dsh-maker-v*` GitHub Release，并按 Release 内的 `INSTALL.md` 下载和校验
+tarball。
+
 DSH 会热重载该 patch，无需重启。验证：
 
 ```bash

--- a/packages/dsh-maker/README.md
+++ b/packages/dsh-maker/README.md
@@ -96,6 +96,7 @@ dsh --profile web --dump-config | grep -A 20 'mcp-taptap-maker\|taptap-maker'
       serverName: taptap-maker # 默认 taptap-maker
       toolCallTimeoutMs: 3600000 # 默认 1 小时
       failOnStartupError: false # 默认 false：技能不受 MCP 启动失败影响，重连自愈
+      env: {} # 可选：合并进 MCP 子进程环境
       cwd: '' # 默认不写（保持项目无关）
 ```
 

--- a/packages/dsh-maker/README.md
+++ b/packages/dsh-maker/README.md
@@ -38,9 +38,9 @@ dsh plugin --profile headless add \
   'github:taptap/instant-games-open-mcp#path:packages/dsh-maker'
 ```
 
-上面的 GitHub 子目录源是 1024Store 使用的市场安装入口。需要安装固定版本或把链接交给 AI 自动
-安装时，使用仓库对应的 `dsh-maker-v*` GitHub Release，并按 Release 内的 `INSTALL.md` 下载和校验
-tarball。
+上面的无 ref GitHub 子目录源是 1024Store 使用的市场安装入口，会跟随仓库 `main`。需要安装固定
+版本或把链接交给 AI 自动安装时，使用仓库对应的 `dsh-maker-v*` GitHub Release，并按 Release 内的
+`INSTALL.md` 下载和校验 tarball。
 
 DSH 会热重载该 patch，无需重启。验证：
 

--- a/packages/dsh-maker/README.md
+++ b/packages/dsh-maker/README.md
@@ -18,9 +18,12 @@ DSH bundle。两者不要同时启用，避免同 `serverName` 冲突。已用 L
 Maker CLI 的结构化命令检查并迁移旧注册：
 
 ```bash
-npx -y --package @taptap/maker@0.0.31 taptap-maker plugin inspect --client dsh --json
-npx -y --package @taptap/maker@0.0.31 taptap-maker plugin migrate --client dsh --confirm --json
+npx -y --package @taptap/maker@<maker-version> taptap-maker plugin inspect --client dsh --json
+npx -y --package @taptap/maker@<maker-version> taptap-maker plugin migrate --client dsh --confirm --json
 ```
+
+`<maker-version>` 使用本包 `package.json` 中 `dependencies["@taptap/maker"]` 的精确值；通过 GitHub
+Release 安装时直接执行 Release `INSTALL.md` 中已写入对应版本的命令。
 
 ## 安装
 
@@ -118,9 +121,9 @@ dsh plugin --profile web remove @taptap/dsh-maker
 
 - 依赖 `@deepseek-ai/cordis ^4.0.1` 及配套 `@deepseek-ai/dsh-mcp-client` /
   `dsh-skill-filesystem` / `dsh-shell-env`（`^0.1.0-rc.6`，peer 锁定，随 DSH rc 版本同步升级）。
-- Maker MCP 由随包依赖的 `@taptap/maker` 提供（当前精确固定为 `0.0.31`，与仓库
-  `config/maker-version-policy.json` 的 `latest` 一致）。升级 Maker 时同步 bump 本包的
-  `@taptap/maker` 依赖并随插件发版。
+- Maker MCP 由随包依赖的 `@taptap/maker` 提供；精确版本以本包 `package.json` 的依赖值为准，并与
+  仓库 `config/maker-version-policy.json` 的对应渠道一致。升级 Maker 时同步 bump 本包依赖并随
+  插件发版。
 
 ## 发布与市场
 

--- a/packages/dsh-maker/README.md
+++ b/packages/dsh-maker/README.md
@@ -14,21 +14,28 @@ DeepSeek Harness（DSH）插件：把 [TapTap Maker](https://github.com/taptap/i
 本插件是仓库 DSH 集成的 **L2 形态**（bundle 插件）。它叠加在已内置的
 **L1 形态**（`taptap-maker install --ide dsh` 写入 `$DSH_HOME/cordis.patch.yml`）之上：
 L1 只注册一个裸的 Maker MCP；本插件则把 **MCP + 技能** 打包成可分发、可一键安装、可 HMR 的
-DSH bundle。两者不要同时启用，避免同 `serverName` 冲突——已用 L1 时，先删掉那条
-`mcp-taptap-maker` patch 行再装本插件。
+DSH bundle。两者不要同时启用，避免同 `serverName` 冲突。已用 L1 时，不要手改 YAML；安装前用
+Maker CLI 的结构化命令检查并迁移旧注册：
+
+```bash
+npx -y --package @taptap/maker@0.0.31 taptap-maker plugin inspect --client dsh --json
+npx -y --package @taptap/maker@0.0.31 taptap-maker plugin migrate --client dsh --confirm --json
+```
 
 ## 安装
 
 前置：已安装 DSH（`dsh` 命令）与 [pnpm](https://pnpm.io/)。
 
 ```bash
-dsh plugin --profile web add @taptap/dsh-maker
+dsh plugin --profile web add \
+  'github:taptap/instant-games-open-mcp#path:packages/dsh-maker'
 ```
 
 headless profile 同理：
 
 ```bash
-dsh plugin --profile headless add @taptap/dsh-maker
+dsh plugin --profile headless add \
+  'github:taptap/instant-games-open-mcp#path:packages/dsh-maker'
 ```
 
 DSH 会热重载该 patch，无需重启。验证：
@@ -101,18 +108,20 @@ dsh plugin --profile web remove @taptap/dsh-maker
 | 工具列表没有 `mcp__taptap-maker__*`  | `dsh --profile web --dump-config` 确认 patch 合成；看 DSH 日志里的 `mcp-client(taptap-maker)` 重连信息 |
 | 工具调用约 60s 超时                  | 确认生效的是本插件的 1h 超时配置，而非旧的裸 `npx` 行                                                  |
 | 广告/云存档等接口用错                | 触发 `taptap-ads`/`taptap-cloud-save` 等技能，读工程内 `engine-docs`，不要网上搜索                     |
-| 与 L1 同时存在导致 `serverName` 冲突 | 移除 `$DSH_HOME/cordis.patch.yml` 里 L1 写入的 `mcp-taptap-maker` 行，只保留本插件                     |
+| 与 L1 同时存在导致 `serverName` 冲突 | 运行 `plugin inspect --client dsh` 检查，再用 `plugin migrate --client dsh --confirm` 结构化禁用旧注册 |
 
 ## 版本兼容
 
 - 依赖 `@deepseek-ai/cordis ^4.0.1` 及配套 `@deepseek-ai/dsh-mcp-client` /
   `dsh-skill-filesystem` / `dsh-shell-env`（`^0.1.0-rc.6`，peer 锁定，随 DSH rc 版本同步升级）。
-- Maker MCP 由随包依赖的 `@taptap/maker` 提供（当前钉 `^0.0.30`，与仓库
+- Maker MCP 由随包依赖的 `@taptap/maker` 提供（当前精确固定为 `0.0.31`，与仓库
   `config/maker-version-policy.json` 的 `latest` 一致）。升级 Maker 时同步 bump 本包的
   `@taptap/maker` 依赖并随插件发版。
 
 ## 发布与市场
 
-- npm 发布：`npm publish --access public`（从 `packages/dsh-maker/`）。
-- 对外仓库链接在 `package.json.repository`；接入 DSH 插件市场时按市场规范补充入口字段即可
-  （本包已保持标准 bundle 形态）。
+- 正式包由仓库的 `Publish DSH Maker Plugin` workflow 发布到 GitHub Release，不单独发布
+  `@taptap/dsh-maker` npm 包。
+- 1024Store 使用 GitHub 子目录源
+  `github:taptap/instant-games-open-mcp#path:packages/dsh-maker` 安装；对外仓库链接在
+  `package.json.repository`。


### PR DESCRIPTION
## 改动内容

- 将 DSH 安装入口改为 1024Store 使用的 GitHub monorepo 子目录源
- 保留 GitHub Release tarball 作为固定版本、SHA-256 校验的链接分发渠道
- 使用结构化 CLI 检查和迁移旧 L1 Maker MCP
- 将 Maker runtime 说明同步为精确版本 0.0.31
- 移除公开文档中不存在的 DSH npm 安装与发布说明

## 影响面

仅修改 DSH 分发相关 README 和文档，不改 Maker MCP runtime、插件代码、其它插件或 CI。

## 验证

- 5 个 DSH 测试套件通过，共 27 项测试
- `maker:dsh-plugin:package` 成功生成 0.1.0 tarball
- tarball manifest 确认为 `@taptap/maker@0.0.31`
- `git diff --check` 通过