### PR TITLE
ci(maker): test trusted publishing on beta

### DIFF
--- a/.github/workflows/publish-maker.yml
+++ b/.github/workflows/publish-maker.yml
@@ -115,6 +115,12 @@ jobs:
         env:
           MAKER_PACKAGE_VERSION: ${{ needs.resolve-version.outputs.version }}
 
+      - name: Upgrade npm for trusted publishing
+        run: |
+          npm install -g npm@11.5.1
+          node --version
+          npm --version
+
       - name: Verify version is still unpublished before npm publish
         run: |
           set -euo pipefail
@@ -131,13 +137,11 @@ jobs:
         run: |
           set -euo pipefail
           tarball="./packages/maker/taptap-maker-${MAKER_PACKAGE_VERSION}.tgz"
-          npm publish "$tarball" --access public --tag "$NPM_TAG" --provenance \
-            || npm publish "$tarball" --access public --tag "$NPM_TAG"
+          npm publish "$tarball" --access public --tag "$NPM_TAG" --provenance
           echo "Published @taptap/maker@$MAKER_PACKAGE_VERSION"
         env:
           MAKER_PACKAGE_VERSION: ${{ needs.resolve-version.outputs.version }}
           NPM_TAG: ${{ inputs.tag }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Update Maker version policy
         id: version-policy


### PR DESCRIPTION
## Purpose

Test the npm Trusted Publishing workflow from the current `beta` branch without changing `main`.

## Changes

- Apply PR #268's npm 11.5.1 upgrade.
- Require `npm publish --provenance` with no NPM_TOKEN fallback.

## Test plan

- Merge this isolated workflow change into `beta`.
- Run `Publish Maker Package` with `version_mode=auto-last-number` and `tag=beta`.
- Verify the published prerelease and npm provenance attestation.

## Rollback

If the publish fails, revert the merge commit on `beta`. The test prerelease version, if already published, cannot be overwritten; restore the `beta` dist-tag to the previous version if needed.
