### PR TITLE
ci(maker): use npm trusted publishing on develop

### DIFF
--- a/.github/workflows/publish-maker.yml
+++ b/.github/workflows/publish-maker.yml
@@ -115,6 +115,12 @@ jobs:
         env:
           MAKER_PACKAGE_VERSION: ${{ needs.resolve-version.outputs.version }}
 
+      - name: Upgrade npm for trusted publishing
+        run: |
+          npm install -g npm@11.5.1
+          node --version
+          npm --version
+
       - name: Verify version is still unpublished before npm publish
         run: |
           set -euo pipefail
@@ -131,13 +137,11 @@ jobs:
         run: |
           set -euo pipefail
           tarball="./packages/maker/taptap-maker-${MAKER_PACKAGE_VERSION}.tgz"
-          npm publish "$tarball" --access public --tag "$NPM_TAG" --provenance \
-            || npm publish "$tarball" --access public --tag "$NPM_TAG"
+          npm publish "$tarball" --access public --tag "$NPM_TAG" --provenance
           echo "Published @taptap/maker@$MAKER_PACKAGE_VERSION"
         env:
           MAKER_PACKAGE_VERSION: ${{ needs.resolve-version.outputs.version }}
           NPM_TAG: ${{ inputs.tag }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Update Maker version policy
         id: version-policy


### PR DESCRIPTION
## Summary

- Upgrade npm to 11.5.1 before publishing `@taptap/maker`.
- Require npm Trusted Publishing/OIDC with `--provenance`.
- Remove the NPM_TOKEN fallback from the Maker publish step.

## Validation

- This is the same workflow change verified successfully on `beta`.
- `ruby -ryaml` parsed `.github/workflows/publish-maker.yml`.
- `git diff --check` passed.
- Verified publish: `@taptap/maker@0.0.32-beta.1` from `beta` with provenance.

## Follow-up

After merge, run `Publish Maker Package` from `develop` with `version_mode=auto-last-number` and `tag=beta` for the next OIDC publish test.
