### PR TITLE
fix(maker): 修复 Windows Node 26 远端调用超时

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -441,6 +441,9 @@ Maker 本地开发的默认路径是 CLI-first + PAT-first：
 - 远端 proxy tool 调用必须先确认解析出的目录存在有效 `.maker-mcp/config.json`。MCP Roots 不可用
   且进程 cwd 未绑定时，只让该项目相关调用快速失败，错误必须包含 `evaluated_target_dir`、
   `project_context_source` 和显式 `target_dir` 指引；不得阻止 MCP server、status 或 tools/list 启动。
+- Maker 内嵌 proxy 必须设置 `disable_standalone_sse=true`，不打开可选的 standalone SSE GET；
+  远端 RPC 响应与 progress 继续使用 POST SSE。该设置用于避免 Node.js 26 中长连接阻塞后续
+  `tools/list` 并触发 SDK 固定 60 秒超时。普通 MCP Proxy 默认保持 standalone SSE 可用，不能全局关闭。
 - 疑似 Maker MCP、proxy、客户端集成或服务端基础设施缺陷（启动/连接失败、tools 异常缺失、超时、反复重连失败、HTTP 5xx/unavailable、未分类内部错误）时，AI 应先按错误码、操作和稳定错误信息形成故障指纹，并在当前会话只询问用户一次是否允许上报。用户明确同意后，把已脱敏的错误、当前 tools、workspace roots、客户端版本和复现步骤通过 stdin 交给 Maker 报告 CLI。优先原样复用当前客户端 `taptap-maker` 配置中的 command 和有序 args，再追加 `mcp report --ide <client> --target-dir <project> --context-stdin --consent --json`；不得依赖全局 PATH 中存在 `taptap-maker`，也不得用无版本的 `@taptap/maker` 启动可能落后的 npm `latest`。只有确认精确安装版本时才可使用 `npx -y --package @taptap/maker@<exact-version> taptap-maker ...` 作为 fallback；Windows 的 `npx` 不可用时继续使用配置内的绝对 `node.exe` 和 `npm-cli.js` argv。不要上传完整聊天、项目源码、其它 MCP server、PAT/token 或完整环境变量。普通参数错误、已有明确恢复路径的登录问题、项目文件缺失、用户取消、Lua 编译或业务校验错误不提示上报。返回 `manual_required` 表示 GitHub 不可达、未登录或自动提交失败；展示脱敏报告和手动 Issue 地址后继续原任务，不得把上报失败当作 Maker 任务失败。
 - MCP 公共能力保留 `maker://status`、`maker_status_lite` 和
   `maker_build_current_directory`；初始化、PAT 保存、app 列表和 clone 由 CLI/skill 承担。

--- a/README.md
+++ b/README.md
@@ -555,6 +555,9 @@ maker_build_current_directory
 远端 proxy tools 使用版本化的本地完整定义在首次 `tools/list` 时立即注册，不等待 cwd、Maker 项目绑定、
 PAT/TapTap token 或远端 proxy 连接。项目定位和鉴权只在实际调用 tool 时校验；远端 schema 不会在运行时
 替换本地定义。schema 变更通过本地 MCP 版本更新发布，远端不可用不会让 proxy tools 从当前会话消失。
+Maker 内嵌代理不打开可选的 standalone SSE GET，远端 RPC 响应和构建进度统一通过 POST SSE 返回；
+这避免 Node.js 26 中长连接占用后续 `tools/list` 请求而触发固定 60 秒超时。普通 MCP Proxy 默认仍保留
+standalone SSE，只有显式设置 `disable_standalone_sse` 才会关闭。
 
 `taptap-maker doctor` 会检查 Git、Python 环境、maker-lua-lsp、PAT、TapTap token、项目绑定、
 AI dev kit 版本和 MCP 配置。`maker://status` 和 `maker_status_lite` 会输出

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -426,6 +426,10 @@ access token、refresh token、MAC key 和 URL 凭证，但保留 user_id、proj
   只重试明确的 proxy unavailable、连接关闭、请求超时和 HTTP 5xx 等传输故障。重连后重放请求若
   再次断线，当前请求和剩余队列会保留到下一轮退避重连；排查构建问题时先读取工具结果中的
   `remote_result`，不要用 generic unavailable 覆盖原始编译错误，也不要重复发起同一次构建。
+- Maker 内嵌代理会对 MCP Streamable HTTP 的可选 standalone SSE GET 返回规范允许的 `405`，
+  远端 `tools/list`、tool call、响应和 progress 均继续使用 POST SSE。Node.js 26.4.0 对照测试中，
+  standalone GET 会阻塞后续 `tools/list` 并在 60 秒后超时；关闭该可选流后，Node.js 24.19.0 与
+  26.4.0 均可在约 10 秒内完成同一远端构建。该行为只用于 Maker 内嵌代理，普通 Proxy 默认不变。
 - 运行时日志：不作为本地公开 MCP tool 暴露。构建成功后 `taptap-maker logs watch`
   内部调用远端 `query_runtime_logs`，默认只拉 `engine`、`user_script`（客户端 Lua 脚本）和
   `server_user_script`（服务端 Lua 脚本）。本地只追加写入一份

--- a/docs/PROXY.md
+++ b/docs/PROXY.md
@@ -1257,6 +1257,7 @@ cat config.json | node proxy.js
     "reset_timeout_on_progress": true,
     "health_check_interval": 30000,
     "enable_cookie_sticky": true,
+    "disable_standalone_sse": false,
     "inject_params_per_call": true,
     "force_inject_progress_token": false,
     "log": {
@@ -1300,6 +1301,8 @@ node proxy.js
   - 当客户端传入 `progressToken` 时，Proxy 会透传下游 `notifications/progress`
 - `options.health_check_interval` - 健康检查间隔（毫秒，默认 `30000`）- 定期验证 Server 会话是否有效
 - `options.enable_cookie_sticky` - 启用 Cookie 会话粘性（默认 `true`）- 用于 K8s 多副本部署时的会话粘性
+- `options.disable_standalone_sse` - 对可选 standalone SSE GET 返回 `405`（默认 `false`）
+  - 开启后，MCP 请求、响应和 progress 仍通过 POST SSE 传输；只关闭服务端主动消息的独立 GET 长连接
 - `options.inject_params_per_call` - 每次工具调用时注入私有参数（默认 `true`）- 为兼容不同 MCP Server 实现，默认每次调用都注入；如果目标 Server 支持从 Session 获取参数，可设为 `false` 以减少数据传输
 - `options.force_inject_progress_token` - 始终注册 onprogress 回调（默认 `false`）
   - 仅在 client 未提供 `progressToken` 时生效：proxy 会注册一个空的 onprogress 哨兵，借此触发 SDK 自动给 `proxy → 上游` 出站请求注入 `_meta.progressToken = messageId`，让上游工具发的 `notifications/progress` 能命中 `resetTimeoutOnProgress` 路径，把 `tool_call_timeout` 的 deadline 持续重置
@@ -1529,6 +1532,7 @@ interface ProxyConfig {
     reset_timeout_on_progress?: boolean; // 收到 progress 通知时重置超时（默认 true）
     health_check_interval?: number; // 健康检查间隔（默认 30000ms）
     enable_cookie_sticky?: boolean; // 启用 Cookie 会话粘性（默认 true）
+    disable_standalone_sse?: boolean; // 禁用可选 standalone SSE GET，改用 POST SSE（默认 false）
     inject_params_per_call?: boolean; // 每次工具调用时注入私有参数（默认 true）
     force_inject_progress_token?: boolean; // 始终注册 onprogress 哨兵以注入 outbound progressToken（默认 false；仅在 client 未带 token 时生效）
     log?: {
@@ -1586,6 +1590,7 @@ function generateProxyConfig(
       reset_timeout_on_progress: true, // 收到 progress 通知时重置超时
       health_check_interval: 30000, // 健康检查间隔 30 秒
       enable_cookie_sticky: true, // 启用 Cookie 会话粘性
+      disable_standalone_sse: false, // 默认保留可选 standalone SSE GET
       inject_params_per_call: true, // 每次调用都注入私有参数（推荐）
       // force_inject_progress_token: true, // （可选）对接旧版 Claude Code 等不主动带 progressToken 的 client 时开启，让 SDK 给上游注入 token、命中 reset 路径；默认 false
       log: {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "./scripts/build.sh --skip-native",
+    "build": "node scripts/build-cross-platform.js",
     "build:all": "./scripts/build.sh",
     "build:native": "./scripts/build.sh --native-only",
     "start": "node bin/instant-games-open-mcp",
@@ -33,7 +33,7 @@
     "lint": "eslint \"src/**/*.ts\"",
     "lint:fix": "eslint \"src/**/*.ts\" --fix",
     "format": "prettier --write \"src/**/*.ts\"",
-    "format:check": "prettier --check \"src/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\" --end-of-line auto",
     "prepare": "husky",
     "prepublishOnly": "npm run build"
   },

--- a/scripts/build-cross-platform.js
+++ b/scripts/build-cross-platform.js
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import dotenv from 'dotenv';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.dirname(scriptDir);
+
+dotenv.config({ path: path.join(projectRoot, '.env'), quiet: true });
+
+const plan = {
+  server: true,
+  proxy: true,
+  maker: true,
+  native: false,
+};
+
+for (const arg of process.argv.slice(2)) {
+  switch (arg) {
+    case '--skip-native':
+    case '-sn':
+      plan.native = false;
+      break;
+    case '--skip-server':
+    case '-ss':
+      plan.server = false;
+      break;
+    case '--skip-proxy':
+    case '-sp':
+      plan.proxy = false;
+      break;
+    case '--skip-maker':
+    case '-sm':
+      plan.maker = false;
+      break;
+    case '--native-only':
+    case '-no':
+      plan.server = false;
+      plan.proxy = false;
+      plan.maker = false;
+      plan.native = true;
+      break;
+    case '--server-only':
+    case '-so':
+      plan.server = true;
+      plan.proxy = false;
+      plan.maker = false;
+      plan.native = false;
+      break;
+    case '--js-only':
+    case '-jo':
+      plan.server = true;
+      plan.proxy = true;
+      plan.maker = true;
+      plan.native = false;
+      break;
+    default:
+      throw new Error(`Unknown build option: ${arg}`);
+  }
+}
+
+/** Run one Node script and preserve its exit status. */
+function runNodeScript(relativePath, options = {}) {
+  const result = spawnSync(process.execPath, [path.join(projectRoot, relativePath)], {
+    cwd: options.cwd || projectRoot,
+    env: options.env || process.env,
+    stdio: 'inherit',
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+/** Build the native signer or reuse checked-in binaries when credentials are unavailable. */
+function buildNativeSigner() {
+  const nativeDir = path.join(projectRoot, 'native');
+  const clientId = process.env.BUILD_CLIENT_ID || process.env.TAPTAP_MCP_CLIENT_ID;
+  const clientSecret = process.env.BUILD_CLIENT_SECRET || process.env.TAPTAP_MCP_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    const binaries = fs.existsSync(nativeDir)
+      ? fs.readdirSync(nativeDir).filter((name) => name.endsWith('.node'))
+      : [];
+    if (binaries.length === 0) {
+      throw new Error(
+        'BUILD_CLIENT_ID and BUILD_CLIENT_SECRET are required when no native/*.node binaries exist.'
+      );
+    }
+    process.stdout.write('Native credentials not set; reusing existing native/*.node binaries.\n');
+    return;
+  }
+
+  const npmCli = process.env.npm_execpath;
+  if (!npmCli) {
+    throw new Error('npm_execpath is unavailable; run this build through npm.');
+  }
+  const result = spawnSync(process.execPath, [npmCli, 'run', 'build'], {
+    cwd: nativeDir,
+    env: {
+      ...process.env,
+      BUILD_CLIENT_ID: clientId,
+      BUILD_CLIENT_SECRET: clientSecret,
+    },
+    stdio: 'inherit',
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+if (plan.native) buildNativeSigner();
+if (plan.server) runNodeScript('scripts/bundle-server.js');
+if (plan.proxy) runNodeScript('scripts/bundle-proxy.js');
+if (plan.maker) runNodeScript('scripts/bundle-maker.js');

--- a/src/__tests__/makerBuildLocalChanges.test.ts
+++ b/src/__tests__/makerBuildLocalChanges.test.ts
@@ -139,15 +139,20 @@ describe('maker build local-change guard', () => {
     expect(changes.files).toEqual(['scripts/main.lua']);
   });
 
-  test('reports local Maker project changes when filenames contain arrow text', async () => {
-    const fileName = 'scripts/name -> arrow.lua';
-    fs.writeFileSync(path.join(tempDir, fileName), '-- changed\n', 'utf8');
+  const testArrowFilename = process.platform === 'win32' ? test.skip : test;
 
-    const changes = await readMakerProjectLocalChanges(tempDir);
+  testArrowFilename(
+    'reports local Maker project changes when filenames contain arrow text',
+    async () => {
+      const fileName = 'scripts/name -> arrow.lua';
+      fs.writeFileSync(path.join(tempDir, fileName), '-- changed\n', 'utf8');
 
-    expect(changes.hasChanges).toBe(true);
-    expect(changes.files).toContain(fileName);
-  });
+      const changes = await readMakerProjectLocalChanges(tempDir);
+
+      expect(changes.hasChanges).toBe(true);
+      expect(changes.files).toContain(fileName);
+    }
+  );
 
   test('remote proxy context uses project local rnd environment config', () => {
     process.env.TAPTAP_MCP_ENV = 'production';
@@ -1082,7 +1087,9 @@ describe('maker build local-change guard', () => {
     expect(result.mode).toBe('project_invalid_before_build');
     expect(submitLocalChanges).not.toHaveBeenCalled();
     expect(formatBuildResult(result, emptyProgressSummary())).toContain('misplaced_config');
-    expect(formatBuildResult(result, emptyProgressSummary())).toContain('.project/project.json');
+    expect(formatBuildResult(result, emptyProgressSummary())).toContain(
+      path.join('.project', 'project.json')
+    );
   });
 
   test('build proceeds when settings exists but project.json is absent', async () => {
@@ -1177,7 +1184,7 @@ describe('maker build local-change guard', () => {
 
     expect(output).toContain('Maker project structure');
     expect(output).toContain('misplaced_config');
-    expect(output).toContain('.project/settings.json');
+    expect(output).toContain(path.join('.project', 'settings.json'));
   });
 
   test('QR proxy preflight uses the unified project health check', () => {

--- a/src/__tests__/makerBuildLocalChanges.test.ts
+++ b/src/__tests__/makerBuildLocalChanges.test.ts
@@ -193,6 +193,7 @@ describe('maker build local-change guard', () => {
     expect(proxyConfig.options).not.toHaveProperty('tool_call_timeout');
     expect(proxyConfig.options.reset_timeout_on_progress).toBe(true);
     expect(proxyConfig.options.force_inject_progress_token).toBe(true);
+    expect(proxyConfig.options.disable_standalone_sse).toBe(true);
   });
 
   test('remote proxy progress handler keeps upstream progress active without client token', () => {

--- a/src/__tests__/makerProxyBundle.test.ts
+++ b/src/__tests__/makerProxyBundle.test.ts
@@ -8,7 +8,13 @@ import { resolveEmbeddedProxyCommand } from '../maker/server/mcp';
 
 describe('maker embedded proxy command', () => {
   test('starts the proxy through the current taptap-maker entry', () => {
-    const makerEntry = path.join('/tmp', 'package', 'bin', 'taptap-maker');
+    const makerEntry = path.join(
+      path.parse(process.cwd()).root,
+      'tmp',
+      'package',
+      'bin',
+      'taptap-maker'
+    );
     const result = resolveEmbeddedProxyCommand({ makerEntry });
 
     expect(result).toEqual({

--- a/src/__tests__/mcpProxyCookieFetch.test.ts
+++ b/src/__tests__/mcpProxyCookieFetch.test.ts
@@ -1,0 +1,65 @@
+import { CookieJar, createCookieFetch } from '../mcp-proxy/cookieJar.js';
+
+describe('MCP proxy cookie fetch', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  test('reports standalone SSE GET as unsupported without opening a network request', async () => {
+    const upstreamFetch = jest.fn<Promise<Response>, Parameters<typeof fetch>>(() =>
+      Promise.resolve(new Response(null, { status: 200 }))
+    );
+    global.fetch = upstreamFetch as typeof fetch;
+    const cookieFetch = createCookieFetch(new CookieJar(), { rejectStandaloneSse: true });
+
+    const response = await cookieFetch('https://maker.example.test/mcp', {
+      method: 'GET',
+      headers: { Accept: 'text/event-stream' },
+    });
+
+    expect(response.status).toBe(405);
+    expect(upstreamFetch).not.toHaveBeenCalled();
+  });
+
+  test('keeps standalone SSE enabled unless the proxy explicitly disables it', async () => {
+    const upstreamFetch = jest.fn<Promise<Response>, Parameters<typeof fetch>>(() =>
+      Promise.resolve(new Response(null, { status: 200 }))
+    );
+    global.fetch = upstreamFetch as typeof fetch;
+    const cookieFetch = createCookieFetch(new CookieJar());
+
+    const response = await cookieFetch('https://mcp.example.test', {
+      method: 'GET',
+      headers: { Accept: 'text/event-stream' },
+    });
+
+    expect(response.status).toBe(200);
+    expect(upstreamFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('continues forwarding POST requests with sticky session cookies', async () => {
+    const cookieJar = new CookieJar();
+    cookieJar.setCookiesFromResponse(
+      new Response(null, { headers: { 'Set-Cookie': 'MCP_ROUTE=pod-a; Path=/' } })
+    );
+    const upstreamFetch = jest.fn<Promise<Response>, Parameters<typeof fetch>>(() =>
+      Promise.resolve(new Response(null, { status: 202 }))
+    );
+    global.fetch = upstreamFetch as typeof fetch;
+    const cookieFetch = createCookieFetch(cookieJar, { rejectStandaloneSse: true });
+
+    const response = await cookieFetch('https://maker.example.test/mcp', {
+      method: 'POST',
+      headers: { Accept: 'application/json, text/event-stream' },
+      body: '{}',
+    });
+
+    expect(response.status).toBe(202);
+    expect(upstreamFetch).toHaveBeenCalledTimes(1);
+    const requestInit = upstreamFetch.mock.calls[0][1];
+    expect(new Headers(requestInit?.headers).get('cookie')).toBe('MCP_ROUTE=pod-a');
+  });
+});

--- a/src/maker/server/mcp.ts
+++ b/src/maker/server/mcp.ts
@@ -2225,6 +2225,7 @@ export function createRemoteProxyContext(options: {
       verbose: true,
       reset_timeout_on_progress: true,
       force_inject_progress_token: true,
+      disable_standalone_sse: true,
       exposed_tools: options.exposedTools,
     },
   };

--- a/src/mcp-proxy/README.md
+++ b/src/mcp-proxy/README.md
@@ -194,13 +194,17 @@ const sessionResult = await connection.newSession({
 
 ### options（可选）
 
-| 字段                 | 类型    | 必需 | 说明                           | 默认值  |
-| -------------------- | ------- | ---- | ------------------------------ | ------- |
-| `verbose`            | boolean | ⚪   | 详细日志模式                   | `false` |
-| `reconnect_interval` | number  | ⚪   | 重连间隔（毫秒）               | `5000`  |
-| `monitor_interval`   | number  | ⚪   | 监控间隔（毫秒）               | `10000` |
-| `exposed_tools`      | array   | ⚪   | 对客户端暴露的 tool 名称白名单 | 不限制  |
-| `log`                | object  | ⚪   | 日志配置                       | 见下表  |
+| 字段                     | 类型    | 必需 | 说明                                              | 默认值  |
+| ------------------------ | ------- | ---- | ------------------------------------------------- | ------- |
+| `verbose`                | boolean | ⚪   | 详细日志模式                                      | `false` |
+| `reconnect_interval`     | number  | ⚪   | 重连间隔（毫秒）                                  | `5000`  |
+| `monitor_interval`       | number  | ⚪   | 监控间隔（毫秒）                                  | `10000` |
+| `disable_standalone_sse` | boolean | ⚪   | 对可选 standalone SSE GET 返回 405，改用 POST SSE | `false` |
+| `exposed_tools`          | array   | ⚪   | 对客户端暴露的 tool 名称白名单                    | 不限制  |
+| `log`                    | object  | ⚪   | 日志配置                                          | 见下表  |
+
+`disable_standalone_sse` 只影响用于接收服务端主动消息的可选 GET 长连接。MCP 请求、响应和 progress
+仍通过 POST SSE 传输。默认关闭该选项以保持通用 Proxy 的历史行为；Maker 内嵌代理会显式开启。
 
 ### options.exposed_tools（Proxy tool 白名单）
 

--- a/src/mcp-proxy/config.example.json
+++ b/src/mcp-proxy/config.example.json
@@ -25,6 +25,7 @@
     "reconnect_interval": 5000,
     "monitor_interval": 10000,
     "enable_cookie_sticky": true,
+    "disable_standalone_sse": false,
     "exposed_tools": [
       "generate_image",
       "batch_generate_images",

--- a/src/mcp-proxy/config.ts
+++ b/src/mcp-proxy/config.ts
@@ -194,6 +194,7 @@ function applyDefaults(config: ProxyConfig): ProxyConfig {
       reset_timeout_on_progress: config.options?.reset_timeout_on_progress ?? true,
       health_check_interval: config.options?.health_check_interval ?? 30000,
       enable_cookie_sticky: config.options?.enable_cookie_sticky ?? true,
+      disable_standalone_sse: config.options?.disable_standalone_sse ?? false,
       inject_params_per_call: config.options?.inject_params_per_call ?? true,
       force_inject_progress_token: config.options?.force_inject_progress_token ?? false,
       exposed_tools: config.options?.exposed_tools,

--- a/src/mcp-proxy/cookieJar.ts
+++ b/src/mcp-proxy/cookieJar.ts
@@ -242,13 +242,27 @@ export class CookieJar {
  * @param verbose 是否输出详细日志
  * @returns 包装后的 fetch 函数
  */
-export function createCookieFetch(cookieJar: CookieJar): typeof fetch {
-  return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+export interface CookieFetchOptions {
+  /** Return the MCP-spec 405 response instead of opening the optional standalone SSE stream. */
+  rejectStandaloneSse?: boolean;
+  /** Preserve historical Cookie handling by default. */
+  enableCookies?: boolean;
+}
+
+export function createCookieFetch(
+  cookieJar: CookieJar,
+  options: CookieFetchOptions = {}
+): typeof fetch {
+  return async (input: Parameters<typeof fetch>[0], init?: RequestInit): Promise<Response> => {
+    if (options.rejectStandaloneSse && isStandaloneSseRequest(input, init)) {
+      return new Response(null, { status: 405, statusText: 'Method Not Allowed' });
+    }
+
     // 克隆 init 以避免修改原始对象
     const modifiedInit: RequestInit = { ...init };
 
     // 添加 Cookie 到请求头
-    const cookieHeader = cookieJar.getCookieHeader();
+    const cookieHeader = options.enableCookies === false ? undefined : cookieJar.getCookieHeader();
     if (cookieHeader) {
       const headers = new Headers(modifiedInit.headers);
       headers.set('Cookie', cookieHeader);
@@ -263,4 +277,21 @@ export function createCookieFetch(cookieJar: CookieJar): typeof fetch {
 
     return response;
   };
+}
+
+function isStandaloneSseRequest(input: Parameters<typeof fetch>[0], init?: RequestInit): boolean {
+  const method = (init?.method || (input instanceof Request ? input.method : 'GET')).toUpperCase();
+  if (method !== 'GET') {
+    return false;
+  }
+
+  const headers = new Headers(
+    init?.headers || (input instanceof Request ? input.headers : undefined)
+  );
+  return (
+    headers
+      .get('accept')
+      ?.split(',')
+      .some((value) => value.trim().split(';', 1)[0].toLowerCase() === 'text/event-stream') === true
+  );
 }

--- a/src/mcp-proxy/proxy.ts
+++ b/src/mcp-proxy/proxy.ts
@@ -389,10 +389,21 @@ export class TapTapMCPProxy {
     try {
       // 创建支持 Cookie 的 fetch（用于 K8s Ingress 会话粘性）
       const cookieEnabled = this.config.options?.enable_cookie_sticky ?? true;
-      const customFetch = cookieEnabled ? createCookieFetch(this.cookieJar) : undefined;
+      const standaloneSseDisabled = this.config.options?.disable_standalone_sse ?? false;
+      const customFetch =
+        cookieEnabled || standaloneSseDisabled
+          ? createCookieFetch(this.cookieJar, {
+              enableCookies: cookieEnabled,
+              rejectStandaloneSse: standaloneSseDisabled,
+            })
+          : undefined;
 
       if (cookieEnabled && this.config.options?.verbose) {
         this.log('debug', 'Cookie sticky session enabled');
+      }
+
+      if (standaloneSseDisabled && this.config.options?.verbose) {
+        this.log('debug', 'Standalone SSE disabled; using POST response streams');
       }
 
       // 构建会话 Headers（包含认证和上下文信息）

--- a/src/mcp-proxy/types.ts
+++ b/src/mcp-proxy/types.ts
@@ -105,6 +105,13 @@ export interface ProxyConfig {
      */
     enable_cookie_sticky?: boolean;
     /**
+     * 禁用可选的 standalone SSE GET（默认 false）
+     *
+     * 开启后，Proxy 对该 GET 返回 MCP 规范允许的 405，并继续通过 POST SSE
+     * 接收请求响应和 progress。用于规避部分 Node.js 运行时中长连接占用后续请求的问题。
+     */
+    disable_standalone_sse?: boolean;
+    /**
      * 每次工具调用时也注入私有参数（默认 true）
      *
      * 私有参数（_mac_token, _user_id, _project_id, _project_path, _custom_fields）会在两个时机传递：


### PR DESCRIPTION
## 改动内容
- 修复 Node 26 下 Maker Proxy standalone SSE GET 阻塞 `tools/list` POST 导致 60 秒超时的问题
- Maker 内嵌 Proxy 对可选 standalone SSE GET 返回规范允许的 405，保留 POST SSE、progress 和 Cookie 会话粘性
- 增加 Windows 跨平台构建入口，避免 Unix shell 构建脚本导致 Windows 验证失败
- 修正 Windows 路径相关测试断言，并保留 Proxy 与 Maker 回归测试

## 影响面
- 覆盖 `generate_image`、fresh project build 和 old project build 的远端调用链路
- 通用 Proxy 默认行为保持不变，仅 Maker 内嵌 Proxy 启用 standalone SSE 规避
- Windows Node 26.4.0 已由报错用户验证修复后正常；本地目标测试 171 项、lint、format 和 build 均通过

## Beta 发布
- PR 合并到 `develop` 后，从 `develop` 手动运行 `Publish Maker Package`
- `version_mode=auto-last-number`
- `tag=beta`
- `version` 留空
