### PR TITLE
feat(dsh): 接入 npm 插件市场发布

### DIFF
--- a/.github/workflows/publish-dsh-maker-plugin.yml
+++ b/.github/workflows/publish-dsh-maker-plugin.yml
@@ -218,6 +218,20 @@ jobs:
           set -euo pipefail
           (cd artifacts/dsh-maker && sha256sum -c SHA256SUMS)
           tarball="artifacts/dsh-maker/taptap-dsh-maker-${RELEASE_VERSION}.tgz"
+          tar_contents="$RUNNER_TEMP/dsh-maker-tar-contents.txt"
+          tar -tzf "$tarball" > "$tar_contents"
+          required_paths=(
+            package/lib/index.js
+            package/cordis.patch.yml
+            package/skills/taptap-maker-dsh/SKILL.md
+            package/assets/taptap-maker.png
+          )
+          for required_path in "${required_paths[@]}"; do
+            if ! grep -Fxq "$required_path" "$tar_contents"; then
+              echo "::error::Missing required npm package entry: $required_path"
+              exit 1
+            fi
+          done
           local_shasum="$(sha1sum "$tarball" | awk '{print $1}')"
           view_error_file="$RUNNER_TEMP/dsh-maker-npm-view-error.txt"
 

--- a/.github/workflows/publish-dsh-maker-plugin.yml
+++ b/.github/workflows/publish-dsh-maker-plugin.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       maker_version:
-        description: 'Exact @taptap/maker version for a develop preview, for example 0.0.31-beta.1'
+        description: 'Exact @taptap/maker version for a develop preview, for example 0.0.32-beta.1'
         required: false
         type: string
 
@@ -16,11 +16,14 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  publish:
-    name: Publish TapTap Maker DSH plugin
+  prepare:
+    name: Prepare TapTap Maker DSH plugin
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    outputs:
+      channel: ${{ steps.version.outputs.channel }}
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
+      maker_version: ${{ steps.version.outputs.maker_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -167,12 +170,106 @@ jobs:
           fi
           npm run maker:dsh-plugin:package -- --output-dir artifacts/dsh-maker
 
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: dsh-maker-release
+          path: artifacts/dsh-maker/*
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-npm:
+    name: Publish stable DSH package to npm
+    needs: prepare
+    if: github.ref_name == 'main' && needs.prepare.outputs.channel == 'stable'
+    runs-on: ubuntu-latest
+    environment: dsh_npm_publish
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dsh-maker-release
+          path: artifacts/dsh-maker
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Upgrade npm for trusted publishing
+        run: |
+          npm install -g npm@11.5.1
+          node --version
+          npm --version
+
+      - name: Publish stable package to npm
+        shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          tarball="artifacts/dsh-maker/taptap-dsh-maker-${RELEASE_VERSION}.tgz"
+          local_shasum="$(sha1sum "$tarball" | awk '{print $1}')"
+          view_error_file="$RUNNER_TEMP/dsh-maker-npm-view-error.txt"
+
+          set +e
+          published_shasum="$(npm view "@taptap/dsh-maker@${RELEASE_VERSION}" dist.shasum 2>"$view_error_file")"
+          view_status=$?
+          set -e
+
+          if [[ $view_status -eq 0 ]]; then
+            published_shasum="$(printf '%s' "$published_shasum" | tr -d '[:space:]')"
+            if [[ "$published_shasum" != "$local_shasum" ]]; then
+              echo "::error::@taptap/dsh-maker@$RELEASE_VERSION already exists with different contents."
+              exit 1
+            fi
+            echo "@taptap/dsh-maker@$RELEASE_VERSION already matches the packaged artifact."
+            exit 0
+          fi
+
+          view_error="$(cat "$view_error_file")"
+          if [[ "$view_error" != *"E404"* ]]; then
+            echo "::error::Unable to verify @taptap/dsh-maker@$RELEASE_VERSION on npm."
+            printf '%s\n' "$view_error"
+            exit 1
+          fi
+
+          npm publish "$tarball" --access public --tag latest --provenance
+          echo "Published @taptap/dsh-maker@$RELEASE_VERSION"
+
+  publish-release:
+    name: Publish TapTap Maker DSH GitHub Release
+    needs: [prepare, publish-npm]
+    if: >-
+      always() &&
+      needs.prepare.result == 'success' &&
+      (needs.publish-npm.result == 'success' || needs.publish-npm.result == 'skipped')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dsh-maker-release
+          path: artifacts/dsh-maker
+
       - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_CHANNEL: ${{ steps.version.outputs.channel }}
-          RELEASE_TAG: ${{ steps.version.outputs.tag }}
-          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          RELEASE_CHANNEL: ${{ needs.prepare.outputs.channel }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
           TARGET_SHA: ${{ github.sha }}
         shell: bash
         run: |

--- a/.github/workflows/publish-dsh-maker-plugin.yml
+++ b/.github/workflows/publish-dsh-maker-plugin.yml
@@ -64,6 +64,9 @@ jobs:
           node-version: 22
           cache: npm
 
+      - name: Pin npm for reproducible packaging
+        run: npm install -g npm@11.5.1
+
       - name: Install dependencies
         run: npm ci
 
@@ -213,6 +216,7 @@ jobs:
           RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
         run: |
           set -euo pipefail
+          (cd artifacts/dsh-maker && sha256sum -c SHA256SUMS)
           tarball="artifacts/dsh-maker/taptap-dsh-maker-${RELEASE_VERSION}.tgz"
           local_shasum="$(sha1sum "$tarball" | awk '{print $1}')"
           view_error_file="$RUNNER_TEMP/dsh-maker-npm-view-error.txt"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -356,12 +356,19 @@ Maker 本地开发的默认路径是 CLI-first + PAT-first：
   WorkBuddy 插件的 `init` 和 `dev-kit update` 必须逐项检查
   `.workbuddy/skills/taptap-maker-*`，只从 `.installer/skills` 补齐缺失的项目 Skill，不得覆盖已有
   同名 Skill。该同步不得影响独立 Maker MCP、Codex 插件或其他客户端；目录链接不可用时才复制。
-- 客户端插件发布只使用 `Prepare Maker Plugin Release` 和 `Publish Maker Plugin` workflows。
+- Codex/WorkBuddy 客户端插件发布只使用 `Prepare Maker Plugin Release` 和
+  `Publish Maker Plugin` workflows。
   前者按最新 `maker-plugin-v*` tag 自动递增 patch 并创建版本 PR；后者在 PR 合并后发布两份完整
   marketplace ZIP、`INSTALL.md`、`SHA256SUMS` 和 `maker-plugin-release.json`。插件发布不得调用
   npm publish、不得复用 Maker npm 或主包 release workflow。插件专属安装页固定为
   `plugins/taptap-maker/README.md`；对外安装使用对应渠道的 GitHub Release 页面和 ZIP。直接从
   仓库添加 marketplace 只用于源码验证，并且必须在添加前用生成目录中的 CLI 完成旧 MCP 检查。
+- DSH bundle 插件 `@taptap/dsh-maker` 位于 `packages/dsh-maker/`，使用独立版本并精确依赖
+  `@taptap/maker`。`Publish DSH Maker Plugin` 从 `develop` 只发布 GitHub prerelease，从 `main`
+  同时发布 npm `latest` 和 GitHub Release；1024Store 使用 npm 包名作为市场入口。DSH 发布不得
+  复用 Codex/WorkBuddy 插件版本、ZIP workflow 或 Maker 主包发布 workflow。DSH npm job 必须独占
+  仅允许 `main` 的 `dsh_npm_publish` environment；不得复用需要支持 Maker develop beta 的
+  `npm_publish` environment。
 - 客户端专属源文件必须放在 `plugin-sources/taptap-maker/<client>/`；生成产物必须按客户端隔离。
   不得把 WorkBuddy manifest、commands、Skills 或 MCP 配置写入 Codex 插件目录。新增客户端时复用
   `src/maker/` 的 runtime/CLI，不复制 Maker tools、resources 或 proxy 业务逻辑。

--- a/README.md
+++ b/README.md
@@ -181,10 +181,9 @@ DSH 使用 `@deepseek-ai/dsh-mcp-client` 插件，不使用 `mcp.json`。检测�
 两者都可由 DSH HMR 热重载。配置不写项目 `cwd`；DSH 当前
 不广播 MCP Roots，因此 AI 必须在具体 Maker tool 调用中把当前游戏项目作为 `target_dir` 传入。
 需要把 Maker 技能（工作流 + 广告/云存档/排行榜指南）一并打包进 DSH 时，可用 bundle 插件
-`@taptap/dsh-maker`（源码 `packages/dsh-maker/`），通过 1024Store 或 GitHub 子目录源
-`github:taptap/instant-games-open-mcp#path:packages/dsh-maker` 一键安装，详见
-[docs/DSH_PLUGIN.md](docs/DSH_PLUGIN.md)。该无 ref 源跟随 `main`；固定版本使用 `dsh-maker-v*`
-GitHub Release tarball。该插件与 L1 的裸 MCP 行不要同时启用。
+`@taptap/dsh-maker`（源码 `packages/dsh-maker/`），通过 1024Store 对应的公开 npm 包一键安装，
+详见 [docs/DSH_PLUGIN.md](docs/DSH_PLUGIN.md)。稳定版从 npm 获取；`dsh-maker-v*` GitHub Release
+继续提供预览版和离线安装 tarball。该插件与 L1 的裸 MCP 行不要同时启用。
 其它 AI 编辑器应优先让本地 AI 复用 `taptap-maker mcp install` 已验证的绝对 command/args。
 只有无法复用安装器时，才使用下面固定精确版本的 npx 兼容片段：
 

--- a/docs/DSH_PLUGIN.md
+++ b/docs/DSH_PLUGIN.md
@@ -78,9 +78,8 @@ packages/dsh-maker/
 前置：已装 DSH（`dsh`）与 pnpm。
 
 ```bash
-# 从 1024Store 使用的 GitHub 子目录源安装（web profile；headless 同理）
-dsh plugin --profile web add \
-  'github:taptap/instant-games-open-mcp#path:packages/dsh-maker'
+# 从 1024Store 使用的 npm 包安装（web profile；headless 同理）
+dsh plugin --profile web add @taptap/dsh-maker
 
 # 验证
 dsh --profile web --dump-config | grep -A 20 'mcp-taptap-maker\|taptap-maker'
@@ -120,19 +119,21 @@ dsh plugin --profile web remove @taptap/dsh-maker
 
 DSH 插件有两条互补的分发入口：
 
-- **1024Store / GitHub 子目录源**：市场条目指向
-  `github:taptap/instant-games-open-mcp#path:packages/dsh-maker`，用于市场安装和更新。该无 ref 源按
-  1024Store 规范跟随仓库 `main`。
-- **GitHub Release tarball**：用于分享固定版本链接。用户把发版页链接交给 AI，AI 按页面下载、
-  校验 SHA-256 后安装。
+- **1024Store / npm**：市场条目使用公开包 `@taptap/dsh-maker`，稳定版安装和更新跟随 npm
+  `latest`；固定版本可使用 `@taptap/dsh-maker@<version>`。
+- **GitHub Release tarball**：用于 develop 预览、离线安装和排障。用户把发版页链接交给 AI，AI
+  按页面下载、校验 SHA-256 后安装。
 
 - **发版页**：`packages/dsh-maker/INSTALL.md`（稳定页，含“给安装 AI 的强制执行指令”、下载链接、
   安装步骤、排障与回滚）。
 - **产物**：`npm run maker:dsh-plugin:package` 生成 `taptap-dsh-maker-<version>.tgz`、
   `SHA256SUMS`、`INSTALL.md`、`dsh-maker-release.json` 到 `artifacts/dsh-maker/`。
 - **发版**：只手动运行 `.github/workflows/publish-dsh-maker-plugin.yml`。选择 `develop` 发布预览版，
-  选择 `main` 发布稳定版；工作流创建 tag `dsh-maker-v<version>` 的 GitHub Release，把 tarball、
-  `SHA256SUMS` 上传为附件，`INSTALL.md` 作为 Release 说明。
+  只创建 GitHub prerelease；选择 `main` 发布稳定版时，先把相同 tarball 发布到 npm `latest`，再创建
+  tag `dsh-maker-v<version>` 的 GitHub Release，把 tarball、`SHA256SUMS` 上传为附件，
+  `INSTALL.md` 作为 Release 说明。npm 发布使用仅允许 `main` 的专用
+  `dsh_npm_publish` environment；首次创建包可用仓库 `NPM_TOKEN`，配置 Trusted Publisher 后切换为
+  OIDC，并把 Trusted Publisher 的 Environment 设为 `dsh_npm_publish`。
 
 本地（未发版）分发：跑一次 `npm run maker:dsh-plugin:package`，把
 `taptap-dsh-maker-<version>.tgz` 和 `SHA256SUMS` 交给测试用户，用户（或其 AI）执行
@@ -145,10 +146,9 @@ DSH 插件有两条互补的分发入口：
   发布，避免安装时依赖不存在。
 - `packages/dsh-maker/` 与 `docs/DSH_PLUGIN.md` 已纳入 `scripts/release-scope.cjs` 的 maker
   归属，只改本插件的提交不会误触发主包发布。
-- 不发布 `@taptap/dsh-maker` npm 包；稳定包只通过 `Publish DSH Maker Plugin` workflow 发布到
-  GitHub Release。
-- 1024Store catalog 只登记 GitHub 仓库和 `packages/dsh-maker` 子目录；插件仍保持标准 bundle
-  形态，并使用 `assets/taptap-maker.png` 作为市场图标。
+- 稳定版发布公开 npm 包 `@taptap/dsh-maker`；develop 预览版不写入 npm registry。
+- 1024Store catalog 登记 npm 包名；插件保持标准 bundle 形态，并使用
+  `assets/taptap-maker.png` 作为市场图标。
 
 ## 相关文档
 

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -105,8 +105,8 @@ WorkBuddy 插件位于 `plugins/workbuddy/taptap-maker`，通过
 
 DeepSeek Harness（DSH）的 Maker 集成分两层：L1 是 `taptap-maker install --ide dsh` 写入的
 裸 `mcp-client` 行（见下文“环境变量”与 DSH 配置小节）；L2 是 bundle 插件 `@taptap/dsh-maker`，
-位于 `packages/dsh-maker/`，通过 1024Store 的 GitHub 子目录源或 GitHub Release tarball 分发，把
-**Maker MCP + 技能** 打包成可一键安装、可 HMR 的 DSH bundle；不单独发布 DSH npm 包。
+位于 `packages/dsh-maker/`，通过 1024Store 对应的公开 npm 包分发，把 **Maker MCP + 技能**
+打包成可一键安装、可 HMR 的 DSH bundle；GitHub Release tarball 保留为预览版和离线备用入口。
 
 插件由一个 bundle patch 行（`id: taptap-maker`）在激活时挂两个子插件并注册一个 shell 环境变量：
 宿主平面 `skill-filesystem` 实例（`providerName: maker` + `bundledSkillDir: skills/`，只读挂本包
@@ -116,12 +116,12 @@ DeepSeek Harness（DSH）的 Maker 集成分两层：L1 是 `taptap-maker instal
 三个功能指南，均
 内置“以工程内 `engine-docs` 为准、禁止网上搜错文档”的防错引导。
 
-与 Codex/WorkBuddy 的 ZIP marketplace 分发不同，DSH 使用标准 bundle 包：`dsh plugin add` 由 pnpm
-安装 GitHub 子目录源或本地 tarball，但不从 npm registry 获取 `@taptap/dsh-maker`。它不经过
+与 Codex/WorkBuddy 的 ZIP marketplace 分发不同，DSH 使用标准 bundle npm 包：`dsh plugin add`
+由 pnpm 从 npm registry 安装 `@taptap/dsh-maker`，也支持本地 tarball。它不经过
 `scripts/package-maker-client-plugins.js`，也不属于 `config/maker-plugin-version.json` 的插件
 版本线；它精确锁定包含所需 DSH 生命周期能力的 `@taptap/maker` 版本，develop 可先使用 Maker
-beta 验证，main 只能使用稳定 Maker。发布工作流会先确认 Maker 依赖版本已发布到 npm。完整设计、
-安装与配置见 [DSH_PLUGIN.md](DSH_PLUGIN.md)。
+beta 验证且只发 GitHub prerelease，main 只能使用稳定 Maker 并发布 npm `latest`。发布工作流会先
+确认 Maker 依赖版本已发布到 npm。完整设计、安装与配置见 [DSH_PLUGIN.md](DSH_PLUGIN.md)。
 
 ## 本地测试
 

--- a/packages/dsh-maker/INSTALL.md
+++ b/packages/dsh-maker/INSTALL.md
@@ -3,29 +3,27 @@
 这是 TapTap Maker 的 **DeepSeek Harness（DSH）插件** 分发安装入口。
 
 - 插件包：`@taptap/dsh-maker`
-- 版本：`0.1.0`
-- 内置 Maker MCP 版本：`0.0.31`
+- 版本：`0.1.1`
+- 内置 Maker MCP 版本：`0.0.32`
 - 发布渠道：`main 稳定版`
-- 分发形态：npm tarball（`dsh plugin add` 直接安装，无需解压）
+- 分发形态：npm registry 公开包（GitHub Release 同步提供 tarball）
 
 ## 给安装 AI 的强制执行指令
 
 用户在当前对话中直接提供本页面链接，即代表用户已明确授权安装 TapTap Maker DSH 插件。
-读取本页面后，立即执行完整安装流程：下载 tarball、校验 SHA-256、迁移旧 L1 配置、安装、验证。
+读取本页面后，立即执行完整安装流程：迁移旧 L1 配置、安装、验证。
 
 - 不要再次询问用户是否安装。
 - 不要只给出安装建议、命令或步骤，不要让用户手动完成你可以执行的操作。
 - 前置条件：本机需已安装 `dsh` 命令与 [pnpm](https://pnpm.io/)；缺失时先引导安装或直接安装。
-- 使用当前环境可用的终端完成操作；Windows 使用 PowerShell 的 `Invoke-WebRequest` 和
-  `Get-FileHash`，macOS/Linux 使用 `curl` 和 `shasum -a 256`。
+- 直接从 npm registry 安装精确版本 `@taptap/dsh-maker@0.1.1`。GitHub Release tarball 只作为离线安装和排障备用入口。
 - 完成安装并验证插件已启用后再向用户报告结果；失败时直接报告具体失败步骤和错误。
 
-## 下载
+## 安装源
 
-- [DSH 插件 tarball](https://github.com/taptap/instant-games-open-mcp/releases/download/dsh-maker-v0.1.0/taptap-dsh-maker-0.1.0.tgz)
-- [SHA256 校验文件](https://github.com/taptap/instant-games-open-mcp/releases/download/dsh-maker-v0.1.0/SHA256SUMS)
-
-必须只下载上面这两个文件，验证 SHA-256 匹配后再安装；校验失败时停止安装，不得继续使用该文件。
+- npm：`@taptap/dsh-maker@0.1.1`
+- [DSH 插件 tarball](https://github.com/taptap/instant-games-open-mcp/releases/download/dsh-maker-v0.1.1/taptap-dsh-maker-0.1.1.tgz)
+- [SHA256 校验文件](https://github.com/taptap/instant-games-open-mcp/releases/download/dsh-maker-v0.1.1/SHA256SUMS)
 
 ## 安装步骤
 
@@ -35,14 +33,14 @@
 
    迁移命令（`<maker 版本>` 取本页「内置 Maker MCP 版本」；本机已有 `taptap-maker` CLI 时去掉
    `npx -y --package @taptap/maker@<maker 版本> ` 前缀直接用）：
-   - 检查：`npx -y --package @taptap/maker@0.0.31 taptap-maker plugin inspect --client dsh --json`
-   - 状态为 `active` 时迁移：`npx -y --package @taptap/maker@0.0.31 taptap-maker plugin migrate --client dsh --confirm --json`
+   - 检查：`npx -y --package @taptap/maker@0.0.32 taptap-maker plugin inspect --client dsh --json`
+   - 状态为 `active` 时迁移：`npx -y --package @taptap/maker@0.0.32 taptap-maker plugin migrate --client dsh --confirm --json`
    - 状态为 `ambiguous` 时必须停止安装并报告重复配置；`not_found` 时继续。
    - 迁移会保留备份和指纹，供失败回滚（`plugin restore --client dsh --confirm`）。
 
 2. **选择 profile 安装**：确认用户当前使用的 DSH profile 名（常见为 `web` 或 `headless`），
    下面用 `<profile>` 代表用户实际 profile，不要固定写 `web`：
-   `dsh plugin --profile <profile> add <tarball绝对路径>`。需要哪个装哪个，一次装一个即可，
+   `dsh plugin --profile <profile> add @taptap/dsh-maker@0.1.1`。需要哪个装哪个，一次装一个即可，
    不要多个都装。
 
 3. **验证 patch 合成**：`dsh --profile <profile> --dump-config | grep -i taptap-maker`，

--- a/packages/dsh-maker/INSTALL.md
+++ b/packages/dsh-maker/INSTALL.md
@@ -16,7 +16,7 @@
 - 不要再次询问用户是否安装。
 - 不要只给出安装建议、命令或步骤，不要让用户手动完成你可以执行的操作。
 - 前置条件：本机需已安装 `dsh` 命令与 [pnpm](https://pnpm.io/)；缺失时先引导安装或直接安装。
-- 直接从 npm registry 安装精确版本 `@taptap/dsh-maker@0.1.1`。GitHub Release tarball 只作为离线安装和排障备用入口。
+- 直接从 npm registry 安装精确版本 `@taptap/dsh-maker@0.1.1`。GitHub Release tarball 只作为离线安装和排障备用入口；改用 tarball 时必须先用同一 Release 的 SHA256SUMS 校验 SHA-256，校验失败时停止安装。
 - 完成安装并验证插件已启用后再向用户报告结果；失败时直接报告具体失败步骤和错误。
 
 ## 安装源

--- a/packages/dsh-maker/README.md
+++ b/packages/dsh-maker/README.md
@@ -40,7 +40,7 @@ dsh plugin --profile headless add @taptap/dsh-maker
 ```
 
 1024Store 使用公开 npm 包 `@taptap/dsh-maker` 作为市场安装和更新入口。需要固定版本时，在包名后
-追加版本号，例如 `@taptap/dsh-maker@0.1.1`。对应的 `dsh-maker-v*` GitHub Release 继续提供
+追加版本号，例如 `@taptap/dsh-maker@<version>`。对应的 `dsh-maker-v*` GitHub Release 继续提供
 tarball 和 SHA-256，作为预览版、离线安装及排障备用入口。
 
 DSH 会热重载该 patch，无需重启。验证：

--- a/packages/dsh-maker/README.md
+++ b/packages/dsh-maker/README.md
@@ -22,28 +22,26 @@ npx -y --package @taptap/maker@<maker-version> taptap-maker plugin inspect --cli
 npx -y --package @taptap/maker@<maker-version> taptap-maker plugin migrate --client dsh --confirm --json
 ```
 
-`<maker-version>` 使用本包 `package.json` 中 `dependencies["@taptap/maker"]` 的精确值；通过 GitHub
-Release 安装时直接执行 Release `INSTALL.md` 中已写入对应版本的命令。
+`<maker-version>` 使用本包 `package.json` 中 `dependencies["@taptap/maker"]` 的精确值；固定版本
+安装时直接使用对应 npm 包版本或 Release `INSTALL.md` 中已写入的命令。
 
 ## 安装
 
 前置：已安装 DSH（`dsh` 命令）与 [pnpm](https://pnpm.io/)。
 
 ```bash
-dsh plugin --profile web add \
-  'github:taptap/instant-games-open-mcp#path:packages/dsh-maker'
+dsh plugin --profile web add @taptap/dsh-maker
 ```
 
 headless profile 同理：
 
 ```bash
-dsh plugin --profile headless add \
-  'github:taptap/instant-games-open-mcp#path:packages/dsh-maker'
+dsh plugin --profile headless add @taptap/dsh-maker
 ```
 
-上面的无 ref GitHub 子目录源是 1024Store 使用的市场安装入口，会跟随仓库 `main`。需要安装固定
-版本或把链接交给 AI 自动安装时，使用仓库对应的 `dsh-maker-v*` GitHub Release，并按 Release 内的
-`INSTALL.md` 下载和校验 tarball。
+1024Store 使用公开 npm 包 `@taptap/dsh-maker` 作为市场安装和更新入口。需要固定版本时，在包名后
+追加版本号，例如 `@taptap/dsh-maker@0.1.1`。对应的 `dsh-maker-v*` GitHub Release 继续提供
+tarball 和 SHA-256，作为预览版、离线安装及排障备用入口。
 
 DSH 会热重载该 patch，无需重启。验证：
 
@@ -126,8 +124,6 @@ dsh plugin --profile web remove @taptap/dsh-maker
 
 ## 发布与市场
 
-- 正式包由仓库的 `Publish DSH Maker Plugin` workflow 发布到 GitHub Release，不单独发布
-  `@taptap/dsh-maker` npm 包。
-- 1024Store 使用 GitHub 子目录源
-  `github:taptap/instant-games-open-mcp#path:packages/dsh-maker` 安装；对外仓库链接在
-  `package.json.repository`。
+- 正式包由仓库的 `Publish DSH Maker Plugin` workflow 同时发布到 npm `latest` 和 GitHub Release。
+- `develop` 预览版只发布 GitHub prerelease，不写入 npm；`main` 稳定版才发布公开 npm 包。
+- 1024Store 使用 npm 包名 `@taptap/dsh-maker`；源码和问题反馈入口由 `package.json` 提供。

--- a/packages/dsh-maker/package.json
+++ b/packages/dsh-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@taptap/dsh-maker",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "DeepSeek Harness plugin: registers the TapTap Maker MCP server and installs Maker workflow + feature skills.",
   "main": "lib/index.js",
@@ -43,7 +43,7 @@
     "@deepseek-ai/dsh-skill-filesystem": "^0.1.0-rc.6"
   },
   "dependencies": {
-    "@taptap/maker": "0.0.31"
+    "@taptap/maker": "0.0.32"
   },
   "repository": {
     "type": "git",

--- a/scripts/package-maker-dsh-plugin.js
+++ b/scripts/package-maker-dsh-plugin.js
@@ -20,6 +20,7 @@ import {
   createWriteStream,
   mkdirSync,
   readFileSync,
+  realpathSync,
   renameSync,
   statSync,
   writeFileSync,
@@ -216,7 +217,7 @@ async function main() {
   );
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === scriptPath) {
+if (process.argv[1] && realpathSync(process.argv[1]) === realpathSync(scriptPath)) {
   main().catch((error) => {
     process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
     process.exit(1);

--- a/scripts/package-maker-dsh-plugin.js
+++ b/scripts/package-maker-dsh-plugin.js
@@ -42,15 +42,22 @@ const VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/
 
 function parseArgs(argv) {
   let outputDir = join(projectRoot, 'artifacts', 'dsh-maker');
+  let skipCommittedInstallMd = false;
   for (let index = 0; index < argv.length; index += 1) {
     if (argv[index] === '--output-dir' && argv[index + 1]) {
       outputDir = resolve(argv[index + 1]);
       index += 1;
       continue;
     }
-    throw new Error('Usage: node scripts/package-maker-dsh-plugin.js [--output-dir <path>]');
+    if (argv[index] === '--skip-committed-install-md') {
+      skipCommittedInstallMd = true;
+      continue;
+    }
+    throw new Error(
+      'Usage: node scripts/package-maker-dsh-plugin.js [--output-dir <path>] [--skip-committed-install-md]'
+    );
   }
-  return { outputDir };
+  return { outputDir, skipCommittedInstallMd };
 }
 
 function readVersion() {
@@ -96,8 +103,11 @@ export function createInstallMd(version, makerVersion) {
     ? 'GitHub prerelease npm tarball（不发布到 npm registry）'
     : 'npm registry 公开包（GitHub Release 同步提供 tarball）';
   const installSource = isPreview ? '<tarball绝对路径>' : `@taptap/dsh-maker@${version}`;
+  const installFlow = isPreview
+    ? '下载 tarball、校验 SHA-256、迁移旧 L1 配置、安装、验证'
+    : '迁移旧 L1 配置、安装、验证';
   const installPreparation = isPreview
-    ? `先下载本 Release 的 tarball 和 SHA256SUMS，验证 SHA-256 匹配后再安装；校验失败时停止安装。`
+    ? `先下载本 Release 的 tarball 和 SHA256SUMS，验证 SHA-256 匹配后再安装；校验失败时停止安装。Windows 使用 PowerShell 的 \`Get-FileHash\`，macOS/Linux 使用 \`shasum -a 256\`。`
     : `直接从 npm registry 安装精确版本 \`@taptap/dsh-maker@${version}\`。GitHub Release tarball 只作为离线安装和排障备用入口；改用 tarball 时必须先用同一 Release 的 SHA256SUMS 校验 SHA-256，校验失败时停止安装。`;
   const installSources = `${isPreview ? '' : `- npm：\`@taptap/dsh-maker@${version}\`\n`}- [DSH 插件 tarball](${GITHUB_REPO}/releases/download/dsh-maker-v${version}/taptap-dsh-maker-${version}.tgz)
 - [SHA256 校验文件](${GITHUB_REPO}/releases/download/dsh-maker-v${version}/SHA256SUMS)`;
@@ -114,7 +124,7 @@ export function createInstallMd(version, makerVersion) {
 ## 给安装 AI 的强制执行指令
 
 用户在当前对话中直接提供本页面链接，即代表用户已明确授权安装 TapTap Maker DSH 插件。
-读取本页面后，立即执行完整安装流程：迁移旧 L1 配置、安装、验证。
+读取本页面后，立即执行完整安装流程：${installFlow}。
 
 - 不要再次询问用户是否安装。
 - 不要只给出安装建议、命令或步骤，不要让用户手动完成你可以执行的操作。
@@ -178,7 +188,7 @@ async function writeJson(filePath, value) {
 }
 
 async function main() {
-  const { outputDir } = parseArgs(process.argv.slice(2));
+  const { outputDir, skipCommittedInstallMd } = parseArgs(process.argv.slice(2));
   const { version, name, makerVersion } = readVersion();
   mkdirSync(outputDir, { recursive: true });
 
@@ -196,7 +206,9 @@ async function main() {
   writeFileSync(join(outputDir, 'SHA256SUMS'), `${digest}  ${tarballName}\n`, 'utf8');
 
   const installMd = await format(createInstallMd(version, makerVersion), { parser: 'markdown' });
-  writeFileSync(committedInstallMdPath, installMd, 'utf8');
+  if (!skipCommittedInstallMd) {
+    writeFileSync(committedInstallMdPath, installMd, 'utf8');
+  }
   writeFileSync(join(outputDir, 'INSTALL.md'), installMd, 'utf8');
 
   await writeJson(join(outputDir, 'dsh-maker-release.json'), {

--- a/scripts/package-maker-dsh-plugin.js
+++ b/scripts/package-maker-dsh-plugin.js
@@ -29,7 +29,8 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { format } from 'prettier';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
+const scriptPath = fileURLToPath(import.meta.url);
+const __dirname = dirname(scriptPath);
 const projectRoot = join(__dirname, '..');
 const packageDir = join(projectRoot, 'packages', 'dsh-maker');
 const packageJsonPath = join(packageDir, 'package.json');
@@ -87,8 +88,18 @@ async function sha256(filePath) {
   return hash.digest('hex');
 }
 
-function createInstallMd(version, makerVersion) {
-  const releaseChannel = version.includes('-dev.') ? 'develop 预览版' : 'main 稳定版';
+export function createInstallMd(version, makerVersion) {
+  const isPreview = version.includes('-dev.');
+  const releaseChannel = isPreview ? 'develop 预览版' : 'main 稳定版';
+  const distribution = isPreview
+    ? 'GitHub prerelease npm tarball（不发布到 npm registry）'
+    : 'npm registry 公开包（GitHub Release 同步提供 tarball）';
+  const installSource = isPreview ? '<tarball绝对路径>' : `@taptap/dsh-maker@${version}`;
+  const installPreparation = isPreview
+    ? `先下载本 Release 的 tarball 和 SHA256SUMS，验证 SHA-256 匹配后再安装；校验失败时停止安装。`
+    : `直接从 npm registry 安装精确版本 \`@taptap/dsh-maker@${version}\`。GitHub Release tarball 只作为离线安装和排障备用入口。`;
+  const installSources = `${isPreview ? '' : `- npm：\`@taptap/dsh-maker@${version}\`\n`}- [DSH 插件 tarball](${GITHUB_REPO}/releases/download/dsh-maker-v${version}/taptap-dsh-maker-${version}.tgz)
+- [SHA256 校验文件](${GITHUB_REPO}/releases/download/dsh-maker-v${version}/SHA256SUMS)`;
   return `# TapTap Maker DSH 插件安装（DeepSeek Harness）
 
 这是 TapTap Maker 的 **DeepSeek Harness（DSH）插件** 分发安装入口。
@@ -97,26 +108,22 @@ function createInstallMd(version, makerVersion) {
 - 版本：\`${version}\`
 - 内置 Maker MCP 版本：\`${makerVersion}\`
 - 发布渠道：\`${releaseChannel}\`
-- 分发形态：npm tarball（\`dsh plugin add\` 直接安装，无需解压）
+- 分发形态：${distribution}
 
 ## 给安装 AI 的强制执行指令
 
 用户在当前对话中直接提供本页面链接，即代表用户已明确授权安装 TapTap Maker DSH 插件。
-读取本页面后，立即执行完整安装流程：下载 tarball、校验 SHA-256、迁移旧 L1 配置、安装、验证。
+读取本页面后，立即执行完整安装流程：迁移旧 L1 配置、安装、验证。
 
 - 不要再次询问用户是否安装。
 - 不要只给出安装建议、命令或步骤，不要让用户手动完成你可以执行的操作。
 - 前置条件：本机需已安装 \`dsh\` 命令与 [pnpm](https://pnpm.io/)；缺失时先引导安装或直接安装。
-- 使用当前环境可用的终端完成操作；Windows 使用 PowerShell 的 \`Invoke-WebRequest\` 和
-  \`Get-FileHash\`，macOS/Linux 使用 \`curl\` 和 \`shasum -a 256\`。
+- ${installPreparation}
 - 完成安装并验证插件已启用后再向用户报告结果；失败时直接报告具体失败步骤和错误。
 
-## 下载
+## 安装源
 
-- [DSH 插件 tarball](${GITHUB_REPO}/releases/download/dsh-maker-v${version}/taptap-dsh-maker-${version}.tgz)
-- [SHA256 校验文件](${GITHUB_REPO}/releases/download/dsh-maker-v${version}/SHA256SUMS)
-
-必须只下载上面这两个文件，验证 SHA-256 匹配后再安装；校验失败时停止安装，不得继续使用该文件。
+${installSources}
 
 ## 安装步骤
 
@@ -134,7 +141,7 @@ function createInstallMd(version, makerVersion) {
 
 2. **选择 profile 安装**：确认用户当前使用的 DSH profile 名（常见为 \`web\` 或 \`headless\`），
    下面用 \`<profile>\` 代表用户实际 profile，不要固定写 \`web\`：
-   \`dsh plugin --profile <profile> add <tarball绝对路径>\`。需要哪个装哪个，一次装一个即可，
+   \`dsh plugin --profile <profile> add ${installSource}\`。需要哪个装哪个，一次装一个即可，
    不要多个都装。
 
 3. **验证 patch 合成**：\`dsh --profile <profile> --dump-config | grep -i taptap-maker\`，
@@ -209,7 +216,9 @@ async function main() {
   );
 }
 
-main().catch((error) => {
-  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-  process.exit(1);
-});
+if (process.argv[1] && resolve(process.argv[1]) === scriptPath) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/package-maker-dsh-plugin.js
+++ b/scripts/package-maker-dsh-plugin.js
@@ -97,7 +97,7 @@ export function createInstallMd(version, makerVersion) {
   const installSource = isPreview ? '<tarball绝对路径>' : `@taptap/dsh-maker@${version}`;
   const installPreparation = isPreview
     ? `先下载本 Release 的 tarball 和 SHA256SUMS，验证 SHA-256 匹配后再安装；校验失败时停止安装。`
-    : `直接从 npm registry 安装精确版本 \`@taptap/dsh-maker@${version}\`。GitHub Release tarball 只作为离线安装和排障备用入口。`;
+    : `直接从 npm registry 安装精确版本 \`@taptap/dsh-maker@${version}\`。GitHub Release tarball 只作为离线安装和排障备用入口；改用 tarball 时必须先用同一 Release 的 SHA256SUMS 校验 SHA-256，校验失败时停止安装。`;
   const installSources = `${isPreview ? '' : `- npm：\`@taptap/dsh-maker@${version}\`\n`}- [DSH 插件 tarball](${GITHUB_REPO}/releases/download/dsh-maker-v${version}/taptap-dsh-maker-${version}.tgz)
 - [SHA256 校验文件](${GITHUB_REPO}/releases/download/dsh-maker-v${version}/SHA256SUMS)`;
   return `# TapTap Maker DSH 插件安装（DeepSeek Harness）

--- a/src/__tests__/makerDshManifest.test.ts
+++ b/src/__tests__/makerDshManifest.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, symlinkSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, statSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
@@ -136,6 +136,9 @@ describe('@taptap/dsh-maker manifest', () => {
     expect(guides.stable).toContain(
       '改用 tarball 时必须先用同一 Release 的 SHA256SUMS 校验 SHA-256，校验失败时停止安装'
     );
+    expect(guides.preview).toContain('下载 tarball、校验 SHA-256、迁移旧 L1 配置、安装、验证');
+    expect(guides.preview).toContain('Get-FileHash');
+    expect(guides.preview).toContain('shasum -a 256');
     expect(guides.preview).toContain('dsh plugin --profile <profile> add <tarball绝对路径>');
     expect(guides.preview).not.toContain('- npm：`@taptap/dsh-maker@0.1.2-dev.7`');
   });
@@ -144,16 +147,23 @@ describe('@taptap/dsh-maker manifest', () => {
     const temporaryDir = mkdtempSync(join(tmpdir(), 'dsh-maker-package-symlink-'));
     const scriptLink = join(temporaryDir, 'package-maker-dsh-plugin.js');
     const outputDir = join(temporaryDir, 'output');
+    const committedInstallMd = join(REPO_ROOT, 'packages', 'dsh-maker', 'INSTALL.md');
 
     try {
       symlinkSync(join(REPO_ROOT, 'scripts', 'package-maker-dsh-plugin.js'), scriptLink);
-      const result = spawnSync(process.execPath, [scriptLink, '--output-dir', outputDir], {
-        cwd: REPO_ROOT,
-        encoding: 'utf8',
-      });
+      const installMtime = statSync(committedInstallMd, { bigint: true }).mtimeNs;
+      const result = spawnSync(
+        process.execPath,
+        [scriptLink, '--output-dir', outputDir, '--skip-committed-install-md'],
+        {
+          cwd: REPO_ROOT,
+          encoding: 'utf8',
+        }
+      );
 
       expect(result.status).toBe(0);
       expect(result.stdout).toContain('Packaged @taptap/dsh-maker');
+      expect(statSync(committedInstallMd, { bigint: true }).mtimeNs).toBe(installMtime);
     } finally {
       rmSync(temporaryDir, { recursive: true, force: true });
     }

--- a/src/__tests__/makerDshManifest.test.ts
+++ b/src/__tests__/makerDshManifest.test.ts
@@ -28,13 +28,12 @@ describe('@taptap/dsh-maker manifest', () => {
   it('pins the stable package source to an exact stable Maker version', () => {
     const manifest = readJson('packages/dsh-maker/package.json');
     expect(manifest.dependencies['@taptap/maker']).toMatch(/^\d+\.\d+\.\d+$/);
-    expect(manifest.dependencies['@taptap/maker']).toBe('0.0.32');
   });
 
   it('uses the published npm package as the DSH marketplace install source', () => {
     const readme = readFileSync(join(REPO_ROOT, 'packages', 'dsh-maker', 'README.md'), 'utf8');
     expect(readme).toContain('dsh plugin --profile web add @taptap/dsh-maker');
-    expect(readme).toContain('npm');
+    expect(readme).toContain('1024Store 使用公开 npm 包 `@taptap/dsh-maker`');
     expect(readme).not.toContain("'github:taptap/instant-games-open-mcp#path:packages/dsh-maker'");
   });
 
@@ -133,6 +132,9 @@ describe('@taptap/dsh-maker manifest', () => {
     expect(result.status).toBe(0);
     const guides = JSON.parse(result.stdout);
     expect(guides.stable).toContain('dsh plugin --profile <profile> add @taptap/dsh-maker@0.1.1');
+    expect(guides.stable).toContain(
+      '改用 tarball 时必须先用同一 Release 的 SHA256SUMS 校验 SHA-256，校验失败时停止安装'
+    );
     expect(guides.preview).toContain('dsh plugin --profile <profile> add <tarball绝对路径>');
     expect(guides.preview).not.toContain('- npm：`@taptap/dsh-maker@0.1.2-dev.7`');
   });

--- a/src/__tests__/makerDshManifest.test.ts
+++ b/src/__tests__/makerDshManifest.test.ts
@@ -1,4 +1,5 @@
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -137,5 +138,24 @@ describe('@taptap/dsh-maker manifest', () => {
     );
     expect(guides.preview).toContain('dsh plugin --profile <profile> add <tarball绝对路径>');
     expect(guides.preview).not.toContain('- npm：`@taptap/dsh-maker@0.1.2-dev.7`');
+  });
+
+  it('packages when the entry script is invoked through a symlink', () => {
+    const temporaryDir = mkdtempSync(join(tmpdir(), 'dsh-maker-package-symlink-'));
+    const scriptLink = join(temporaryDir, 'package-maker-dsh-plugin.js');
+    const outputDir = join(temporaryDir, 'output');
+
+    try {
+      symlinkSync(join(REPO_ROOT, 'scripts', 'package-maker-dsh-plugin.js'), scriptLink);
+      const result = spawnSync(process.execPath, [scriptLink, '--output-dir', outputDir], {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('Packaged @taptap/dsh-maker');
+    } finally {
+      rmSync(temporaryDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/__tests__/makerDshManifest.test.ts
+++ b/src/__tests__/makerDshManifest.test.ts
@@ -1,5 +1,7 @@
 import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const REPO_ROOT = process.cwd();
 
@@ -26,6 +28,14 @@ describe('@taptap/dsh-maker manifest', () => {
   it('pins the stable package source to an exact stable Maker version', () => {
     const manifest = readJson('packages/dsh-maker/package.json');
     expect(manifest.dependencies['@taptap/maker']).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(manifest.dependencies['@taptap/maker']).toBe('0.0.32');
+  });
+
+  it('uses the published npm package as the DSH marketplace install source', () => {
+    const readme = readFileSync(join(REPO_ROOT, 'packages', 'dsh-maker', 'README.md'), 'utf8');
+    expect(readme).toContain('dsh plugin --profile web add @taptap/dsh-maker');
+    expect(readme).toContain('npm');
+    expect(readme).not.toContain("'github:taptap/instant-games-open-mcp#path:packages/dsh-maker'");
   });
 
   it('declares the DSH rc.6 peer surface', () => {
@@ -104,5 +114,26 @@ describe('@taptap/dsh-maker manifest', () => {
     expect(packageScript).toContain('develop 预览版');
     expect(packageScript).toContain('main 稳定版');
     expect(packageScript).toContain('- 发布渠道：\\`${releaseChannel}\\`');
+  });
+
+  it('renders npm installation only for stable releases', () => {
+    const moduleUrl = pathToFileURL(join(REPO_ROOT, 'scripts', 'package-maker-dsh-plugin.js')).href;
+    const source = `
+      const { createInstallMd } = await import(${JSON.stringify(moduleUrl)});
+      process.stdout.write(JSON.stringify({
+        stable: createInstallMd('0.1.1', '0.0.32'),
+        preview: createInstallMd('0.1.2-dev.7', '0.0.32-beta.3')
+      }));
+    `;
+    const result = spawnSync(process.execPath, ['--input-type=module', '--eval', source], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    const guides = JSON.parse(result.stdout);
+    expect(guides.stable).toContain('dsh plugin --profile <profile> add @taptap/dsh-maker@0.1.1');
+    expect(guides.preview).toContain('dsh plugin --profile <profile> add <tarball绝对路径>');
+    expect(guides.preview).not.toContain('- npm：`@taptap/dsh-maker@0.1.2-dev.7`');
   });
 });

--- a/src/__tests__/makerPluginReleaseWorkflow.test.ts
+++ b/src/__tests__/makerPluginReleaseWorkflow.test.ts
@@ -13,7 +13,17 @@ function readWorkflowDocument(name: string) {
       pull_request?: { branches?: string[] };
       workflow_dispatch?: { inputs?: Record<string, unknown> };
     };
-    jobs?: Record<string, { steps?: Array<{ run?: string }> }>;
+    jobs?: Record<
+      string,
+      {
+        environment?: string;
+        if?: string;
+        needs?: string | string[];
+        outputs?: Record<string, string>;
+        permissions?: Record<string, string>;
+        steps?: Array<{ name?: string; if?: string; run?: string }>;
+      }
+    >;
   };
 }
 
@@ -109,7 +119,16 @@ describe('Maker plugin release workflows', () => {
     expect(prepare).not.toContain('contents: write');
     expect(prepare).not.toContain('pull-requests: write');
     expect(publish).toContain('permissions:\n      contents: write');
-    expect(publishDsh).toContain('permissions:\n      contents: write');
+    const dshWorkflow = readWorkflowDocument('publish-dsh-maker-plugin.yml');
+    expect(dshWorkflow.jobs?.prepare?.environment).toBeUndefined();
+    expect(dshWorkflow.jobs?.prepare?.permissions?.['id-token']).toBeUndefined();
+    expect(dshWorkflow.jobs?.['publish-npm']?.permissions).toEqual({
+      contents: 'read',
+      'id-token': 'write',
+    });
+    expect(dshWorkflow.jobs?.['publish-release']?.permissions).toEqual({
+      contents: 'write',
+    });
   });
 
   it('keeps DSH publishing manual and separates develop previews from stable releases', () => {
@@ -124,6 +143,42 @@ describe('Maker plugin release workflows', () => {
     expect(publishDsh).toContain('develop previews require a prerelease @taptap/maker version.');
     expect(publishDsh).toContain('Stable DSH releases cannot depend on prerelease');
     expect(publishDsh).toContain('npm view "@taptap/maker@${MAKER_VERSION}" version');
+  });
+
+  it('publishes stable DSH releases to npm without publishing develop previews', () => {
+    const workflow = readWorkflowDocument('publish-dsh-maker-plugin.yml');
+    const prepareJob = workflow.jobs?.prepare;
+    const npmPublishJob = workflow.jobs?.['publish-npm'];
+    const releaseJob = workflow.jobs?.['publish-release'];
+    const upgradeStep = npmPublishJob?.steps?.find(
+      (step) => step.name === 'Upgrade npm for trusted publishing'
+    );
+    const npmPublishStep = npmPublishJob?.steps?.find(
+      (step) => step.name === 'Publish stable package to npm'
+    );
+
+    expect(prepareJob?.outputs).toEqual(
+      expect.objectContaining({
+        channel: '${{ steps.version.outputs.channel }}',
+        version: '${{ steps.version.outputs.version }}',
+        tag: '${{ steps.version.outputs.tag }}',
+      })
+    );
+    expect(npmPublishJob?.environment).toBe('dsh_npm_publish');
+    expect(npmPublishJob?.if).toContain("github.ref_name == 'main'");
+    expect(npmPublishJob?.if).toContain("needs.prepare.outputs.channel == 'stable'");
+    expect(releaseJob?.needs).toEqual(['prepare', 'publish-npm']);
+    expect(releaseJob?.if).toContain("needs.publish-npm.result == 'success'");
+    expect(releaseJob?.if).toContain("needs.publish-npm.result == 'skipped'");
+    expect(publishDsh).toContain('registry-url: https://registry.npmjs.org');
+    expect(upgradeStep?.run).toContain('npm install -g npm@11.5.1');
+    expect(npmPublishStep?.run).toContain(
+      'npm publish "$tarball" --access public --tag latest --provenance'
+    );
+    expect(publishDsh).toContain('NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}');
+    expect(npmPublishStep?.run).toContain('npm view "@taptap/dsh-maker@${RELEASE_VERSION}"');
+
+    expect(releaseJob?.steps?.some((step) => step.name === 'Publish GitHub Release')).toBe(true);
   });
 
   it('detects tracked and untracked generated changes and uses one package entry point', () => {

--- a/src/__tests__/makerPluginReleaseWorkflow.test.ts
+++ b/src/__tests__/makerPluginReleaseWorkflow.test.ts
@@ -150,6 +150,9 @@ describe('Maker plugin release workflows', () => {
     const prepareJob = workflow.jobs?.prepare;
     const npmPublishJob = workflow.jobs?.['publish-npm'];
     const releaseJob = workflow.jobs?.['publish-release'];
+    const prepareNpmStep = prepareJob?.steps?.find(
+      (step) => step.name === 'Pin npm for reproducible packaging'
+    );
     const upgradeStep = npmPublishJob?.steps?.find(
       (step) => step.name === 'Upgrade npm for trusted publishing'
     );
@@ -171,12 +174,14 @@ describe('Maker plugin release workflows', () => {
     expect(releaseJob?.if).toContain("needs.publish-npm.result == 'success'");
     expect(releaseJob?.if).toContain("needs.publish-npm.result == 'skipped'");
     expect(publishDsh).toContain('registry-url: https://registry.npmjs.org');
+    expect(prepareNpmStep?.run).toContain('npm install -g npm@11.5.1');
     expect(upgradeStep?.run).toContain('npm install -g npm@11.5.1');
     expect(npmPublishStep?.run).toContain(
       'npm publish "$tarball" --access public --tag latest --provenance'
     );
     expect(publishDsh).toContain('NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}');
     expect(npmPublishStep?.run).toContain('npm view "@taptap/dsh-maker@${RELEASE_VERSION}"');
+    expect(npmPublishStep?.run).toContain('(cd artifacts/dsh-maker && sha256sum -c SHA256SUMS)');
 
     expect(releaseJob?.steps?.some((step) => step.name === 'Publish GitHub Release')).toBe(true);
   });

--- a/src/__tests__/makerPluginReleaseWorkflow.test.ts
+++ b/src/__tests__/makerPluginReleaseWorkflow.test.ts
@@ -182,6 +182,14 @@ describe('Maker plugin release workflows', () => {
     expect(publishDsh).toContain('NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}');
     expect(npmPublishStep?.run).toContain('npm view "@taptap/dsh-maker@${RELEASE_VERSION}"');
     expect(npmPublishStep?.run).toContain('(cd artifacts/dsh-maker && sha256sum -c SHA256SUMS)');
+    for (const requiredPath of [
+      'package/lib/index.js',
+      'package/cordis.patch.yml',
+      'package/skills/taptap-maker-dsh/SKILL.md',
+      'package/assets/taptap-maker.png',
+    ]) {
+      expect(npmPublishStep?.run).toContain(requiredPath);
+    }
 
     expect(releaseJob?.steps?.some((step) => step.name === 'Publish GitHub Release')).toBe(true);
   });


### PR DESCRIPTION
## 改动内容

- 将 `@taptap/dsh-maker` 升级到 `0.1.1`，并固定依赖已发布的 `@taptap/maker@0.0.32`
- 将 DSH/1024Store 稳定版安装入口切换为公开 npm 包；develop 预览版继续使用 GitHub prerelease tarball
- 拆分 DSH 插件打包、npm 发布和 GitHub Release job，三者复用同一 tarball artifact
- 支持首次发布使用现有 `NPM_TOKEN`，后续可切换 npm Trusted Publisher/OIDC provenance
- 新增 npm 重跑 SHA-1 校验、main-only 发布边界及发布契约测试
- 更新 README、Maker/DSH 发布文档和生成的安装说明

## 发布边界

- 新建独立 GitHub Environment：`dsh_npm_publish`
- Environment 仅允许 `main` 分支部署，避免复用 Maker 主包的 `npm_publish`
- 本 PR 合并到 `develop` 不会发布 npm
- 只有后续晋升到 `main` 并手动运行 `Publish DSH Maker Plugin` workflow，才会首次发布 `@taptap/dsh-maker@0.1.1`

## 验证

- Jest：63 suites / 922 tests passed
- ESLint passed
- Prettier passed
- Workflow YAML parse passed
- `git diff --check` passed
- `INSTALL.md` 与打包生成结果一致
- `npm publish --dry-run` passed
- 已确认 `@taptap/maker@0.0.32` 存在，`@taptap/dsh-maker@0.1.1` 尚未发布
- 独立代码审查未发现 Critical、Important 或 Minor 问题