### PR TITLE
fix(dsh): use repository token for npm publishing

### DIFF
--- a/.github/workflows/publish-dsh-maker-plugin.yml
+++ b/.github/workflows/publish-dsh-maker-plugin.yml
@@ -189,7 +189,6 @@ jobs:
     environment: dsh_npm_publish
     permissions:
       contents: read
-      id-token: write
     steps:
       - name: Download release artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -203,7 +202,7 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
-      - name: Upgrade npm for trusted publishing
+      - name: Upgrade npm for token publishing
         run: |
           npm install -g npm@11.5.1
           node --version
@@ -257,7 +256,7 @@ jobs:
             exit 1
           fi
 
-          npm publish "$tarball" --access public --tag latest --provenance
+          npm publish "$tarball" --access public --tag latest
           echo "Published @taptap/dsh-maker@$RELEASE_VERSION"
 
   publish-release:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -368,7 +368,8 @@ Maker 本地开发的默认路径是 CLI-first + PAT-first：
   同时发布 npm `latest` 和 GitHub Release；1024Store 使用 npm 包名作为市场入口。DSH 发布不得
   复用 Codex/WorkBuddy 插件版本、ZIP workflow 或 Maker 主包发布 workflow。DSH npm job 必须独占
   仅允许 `main` 的 `dsh_npm_publish` environment；不得复用需要支持 Maker develop beta 的
-  `npm_publish` environment。
+  `npm_publish` environment。DSH npm 发布只使用仓库 `NPM_TOKEN`，不使用 OIDC/provenance；OIDC
+  仅用于 Maker MCP 主包发布。
 - 客户端专属源文件必须放在 `plugin-sources/taptap-maker/<client>/`；生成产物必须按客户端隔离。
   不得把 WorkBuddy manifest、commands、Skills 或 MCP 配置写入 Codex 插件目录。新增客户端时复用
   `src/maker/` 的 runtime/CLI，不复制 Maker tools、resources 或 proxy 业务逻辑。

--- a/docs/DSH_PLUGIN.md
+++ b/docs/DSH_PLUGIN.md
@@ -132,8 +132,8 @@ DSH 插件有两条互补的分发入口：
   只创建 GitHub prerelease；选择 `main` 发布稳定版时，先把相同 tarball 发布到 npm `latest`，再创建
   tag `dsh-maker-v<version>` 的 GitHub Release，把 tarball、`SHA256SUMS` 上传为附件，
   `INSTALL.md` 作为 Release 说明。npm 发布使用仅允许 `main` 的专用
-  `dsh_npm_publish` environment；首次创建包可用仓库 `NPM_TOKEN`，配置 Trusted Publisher 后切换为
-  OIDC，并把 Trusted Publisher 的 Environment 设为 `dsh_npm_publish`。
+  `dsh_npm_publish` environment；使用仓库 `NPM_TOKEN` 发布新包，不启用 OIDC/provenance。
+  OIDC 仅用于 Maker MCP 主包发布，不用于 DSH 插件包。
 
 本地（未发版）分发：跑一次 `npm run maker:dsh-plugin:package`，把
 `taptap-dsh-maker-<version>.tgz` 和 `SHA256SUMS` 交给测试用户，用户（或其 AI）执行

--- a/src/__tests__/makerPluginReleaseWorkflow.test.ts
+++ b/src/__tests__/makerPluginReleaseWorkflow.test.ts
@@ -124,7 +124,6 @@ describe('Maker plugin release workflows', () => {
     expect(dshWorkflow.jobs?.prepare?.permissions?.['id-token']).toBeUndefined();
     expect(dshWorkflow.jobs?.['publish-npm']?.permissions).toEqual({
       contents: 'read',
-      'id-token': 'write',
     });
     expect(dshWorkflow.jobs?.['publish-release']?.permissions).toEqual({
       contents: 'write',
@@ -154,7 +153,7 @@ describe('Maker plugin release workflows', () => {
       (step) => step.name === 'Pin npm for reproducible packaging'
     );
     const upgradeStep = npmPublishJob?.steps?.find(
-      (step) => step.name === 'Upgrade npm for trusted publishing'
+      (step) => step.name === 'Upgrade npm for token publishing'
     );
     const npmPublishStep = npmPublishJob?.steps?.find(
       (step) => step.name === 'Publish stable package to npm'
@@ -176,9 +175,9 @@ describe('Maker plugin release workflows', () => {
     expect(publishDsh).toContain('registry-url: https://registry.npmjs.org');
     expect(prepareNpmStep?.run).toContain('npm install -g npm@11.5.1');
     expect(upgradeStep?.run).toContain('npm install -g npm@11.5.1');
-    expect(npmPublishStep?.run).toContain(
-      'npm publish "$tarball" --access public --tag latest --provenance'
-    );
+    expect(npmPublishStep?.run).toContain('npm publish "$tarball" --access public --tag latest');
+    expect(npmPublishStep?.run).not.toContain('--provenance');
+    expect(npmPublishJob?.permissions).toEqual({ contents: 'read' });
     expect(publishDsh).toContain('NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}');
     expect(npmPublishStep?.run).toContain('npm view "@taptap/dsh-maker@${RELEASE_VERSION}"');
     expect(npmPublishStep?.run).toContain('(cd artifacts/dsh-maker && sha256sum -c SHA256SUMS)');


### PR DESCRIPTION
## 改动内容
- 移除 DSH npm 发布 job 的 OIDC 权限和 `--provenance` 参数
- DSH 插件发布明确使用仓库 `NPM_TOKEN`
- 保持 Maker MCP 主包的 OIDC 发布流程不变
- 更新 workflow 测试断言和发布文档

## 验证
- `npm test -- --runInBand`（63 suites，923 tests）
- `npm run lint`
- `npm run format:check`
- `git diff --check`

## 风险控制
- 仅修改 DSH 发布 workflow、对应测试和说明文档
- 不读取或替换 `NPM_TOKEN`
- 不涉及其他 npm 包发布