### PR TITLE
fix(dsh): support first package publication token

### DIFF
--- a/.github/workflows/publish-dsh-maker-plugin.yml
+++ b/.github/workflows/publish-dsh-maker-plugin.yml
@@ -7,6 +7,11 @@ on:
         description: 'Exact @taptap/maker version for a develop preview, for example 0.0.32-beta.1'
         required: false
         type: string
+      use_create_package_token:
+        description: 'Use NPM_CREATE_PKG_TOKEN for the first @taptap/dsh-maker publication only'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -212,7 +217,9 @@ jobs:
         shell: bash
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CREATE_PKG_TOKEN: ${{ secrets.NPM_CREATE_PKG_TOKEN }}
           RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+          USE_CREATE_PACKAGE_TOKEN: ${{ inputs.use_create_package_token }}
         run: |
           set -euo pipefail
           (cd artifacts/dsh-maker && sha256sum -c SHA256SUMS)
@@ -256,7 +263,33 @@ jobs:
             exit 1
           fi
 
-          npm publish "$tarball" --access public --tag latest
+          if [[ "$USE_CREATE_PACKAGE_TOKEN" == "true" ]]; then
+            if [[ -z "$NPM_CREATE_PKG_TOKEN" ]]; then
+              echo "::error::NPM_CREATE_PKG_TOKEN is not configured."
+              exit 1
+            fi
+
+            package_view_error_file="$RUNNER_TEMP/dsh-maker-package-view-error.txt"
+            set +e
+            npm view "@taptap/dsh-maker" version >/dev/null 2>"$package_view_error_file"
+            package_view_status=$?
+            set -e
+
+            if [[ $package_view_status -eq 0 ]]; then
+              echo "::error::@taptap/dsh-maker already exists; use the normal NPM_TOKEN."
+              exit 1
+            fi
+            if ! grep -q "E404" "$package_view_error_file"; then
+              echo "::error::Unable to confirm that @taptap/dsh-maker is unpublished."
+              cat "$package_view_error_file"
+              exit 1
+            fi
+
+            NODE_AUTH_TOKEN="$NPM_CREATE_PKG_TOKEN" npm publish \
+              "$tarball" --access public --tag latest
+          else
+            npm publish "$tarball" --access public --tag latest
+          fi
           echo "Published @taptap/dsh-maker@$RELEASE_VERSION"
 
   publish-release:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -368,8 +368,9 @@ Maker 本地开发的默认路径是 CLI-first + PAT-first：
   同时发布 npm `latest` 和 GitHub Release；1024Store 使用 npm 包名作为市场入口。DSH 发布不得
   复用 Codex/WorkBuddy 插件版本、ZIP workflow 或 Maker 主包发布 workflow。DSH npm job 必须独占
   仅允许 `main` 的 `dsh_npm_publish` environment；不得复用需要支持 Maker develop beta 的
-  `npm_publish` environment。DSH npm 发布只使用仓库 `NPM_TOKEN`，不使用 OIDC/provenance；OIDC
-  仅用于 Maker MCP 主包发布。
+  `npm_publish` environment。DSH npm 常规发布使用仓库 `NPM_TOKEN`，不使用 OIDC/provenance；仅首次
+  创建 `@taptap/dsh-maker` 时手动传 `use_create_package_token=true` 使用仓库
+  `NPM_CREATE_PKG_TOKEN`，workflow 会先确认包名尚不存在。OIDC 仅用于 Maker MCP 主包发布。
 - 客户端专属源文件必须放在 `plugin-sources/taptap-maker/<client>/`；生成产物必须按客户端隔离。
   不得把 WorkBuddy manifest、commands、Skills 或 MCP 配置写入 Codex 插件目录。新增客户端时复用
   `src/maker/` 的 runtime/CLI，不复制 Maker tools、resources 或 proxy 业务逻辑。

--- a/docs/DSH_PLUGIN.md
+++ b/docs/DSH_PLUGIN.md
@@ -132,8 +132,10 @@ DSH 插件有两条互补的分发入口：
   只创建 GitHub prerelease；选择 `main` 发布稳定版时，先把相同 tarball 发布到 npm `latest`，再创建
   tag `dsh-maker-v<version>` 的 GitHub Release，把 tarball、`SHA256SUMS` 上传为附件，
   `INSTALL.md` 作为 Release 说明。npm 发布使用仅允许 `main` 的专用
-  `dsh_npm_publish` environment；使用仓库 `NPM_TOKEN` 发布新包，不启用 OIDC/provenance。
-  OIDC 仅用于 Maker MCP 主包发布，不用于 DSH 插件包。
+  `dsh_npm_publish` environment；常规发布使用仓库 `NPM_TOKEN`，不启用 OIDC/provenance。
+  仅首次创建 `@taptap/dsh-maker` 时，手动触发 workflow 并将
+  `use_create_package_token` 设为 `true`，使用仓库 `NPM_CREATE_PKG_TOKEN`；workflow 会先确认
+  包名尚不存在，避免后续版本误用创建 token。OIDC 仅用于 Maker MCP 主包发布，不用于 DSH 插件包。
 
 本地（未发版）分发：跑一次 `npm run maker:dsh-plugin:package`，把
 `taptap-dsh-maker-<version>.tgz` 和 `SHA256SUMS` 交给测试用户，用户（或其 AI）执行

--- a/src/__tests__/makerPluginReleaseWorkflow.test.ts
+++ b/src/__tests__/makerPluginReleaseWorkflow.test.ts
@@ -135,6 +135,12 @@ describe('Maker plugin release workflows', () => {
 
     expect(workflow.on?.push).toBeUndefined();
     expect(workflow.on?.workflow_dispatch?.inputs).toHaveProperty('maker_version');
+    expect(workflow.on?.workflow_dispatch?.inputs?.use_create_package_token).toEqual(
+      expect.objectContaining({
+        default: false,
+        type: 'boolean',
+      })
+    );
     expect(publishDsh).toContain('Manually dispatch from main or develop.');
     expect(publishDsh).toContain('name: Require DSH plugin release support');
     expect(publishDsh).toContain('Selected branch does not contain DSH plugin release support');
@@ -179,7 +185,13 @@ describe('Maker plugin release workflows', () => {
     expect(npmPublishStep?.run).not.toContain('--provenance');
     expect(npmPublishJob?.permissions).toEqual({ contents: 'read' });
     expect(publishDsh).toContain('NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}');
+    expect(publishDsh).toContain('NPM_CREATE_PKG_TOKEN: ${{ secrets.NPM_CREATE_PKG_TOKEN }}');
+    expect(publishDsh).toContain(
+      'USE_CREATE_PACKAGE_TOKEN: ${{ inputs.use_create_package_token }}'
+    );
     expect(npmPublishStep?.run).toContain('npm view "@taptap/dsh-maker@${RELEASE_VERSION}"');
+    expect(npmPublishStep?.run).toContain('npm view "@taptap/dsh-maker" version');
+    expect(npmPublishStep?.run).toContain('NODE_AUTH_TOKEN="$NPM_CREATE_PKG_TOKEN" npm publish');
     expect(npmPublishStep?.run).toContain('(cd artifacts/dsh-maker && sha256sum -c SHA256SUMS)');
     for (const requiredPath of [
       'package/lib/index.js',


### PR DESCRIPTION
## 改动内容
- 新增 `use_create_package_token` workflow 输入
- 首次创建 `@taptap/dsh-maker` 时使用 `NPM_CREATE_PKG_TOKEN`
- 先确认包名尚不存在，后续发布默认继续使用 `NPM_TOKEN`
- 保持 DSH 不使用 OIDC/provenance

## 验证
- `npm test -- --runInBand`（63 suites，923 tests）
- `npm run lint`
- `npm run format:check`
- `git diff --check`

## 本次发布
合并后从 `main` 手动触发 `Publish DSH Maker Plugin`，并设置 `use_create_package_token=true`。