### PR TITLE
docs(dsh): 明确插件市场与分发入口

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,7 +365,8 @@ Maker 本地开发的默认路径是 CLI-first + PAT-first：
   仓库添加 marketplace 只用于源码验证，并且必须在添加前用生成目录中的 CLI 完成旧 MCP 检查。
 - DSH bundle 插件 `@taptap/dsh-maker` 位于 `packages/dsh-maker/`，使用独立版本并精确依赖
   `@taptap/maker`。`Publish DSH Maker Plugin` 从 `develop` 只发布 GitHub prerelease，从 `main`
-  同时发布 npm `latest` 和 GitHub Release；1024Store 使用 npm 包名作为市场入口。DSH 发布不得
+  同时发布 npm `latest` 和 GitHub Release；官方 DSH CLI 直接从 npm registry 安装，社区市场入口见
+  `docs/DSH_PLUGIN_MARKETS.md`。DSH 发布不得
   复用 Codex/WorkBuddy 插件版本、ZIP workflow 或 Maker 主包发布 workflow。DSH npm job 必须独占
   仅允许 `main` 的 `dsh_npm_publish` environment；不得复用需要支持 Maker develop beta 的
   `npm_publish` environment。

--- a/README.md
+++ b/README.md
@@ -181,9 +181,11 @@ DSH 使用 `@deepseek-ai/dsh-mcp-client` 插件，不使用 `mcp.json`。检测�
 两者都可由 DSH HMR 热重载。配置不写项目 `cwd`；DSH 当前
 不广播 MCP Roots，因此 AI 必须在具体 Maker tool 调用中把当前游戏项目作为 `target_dir` 传入。
 需要把 Maker 技能（工作流 + 广告/云存档/排行榜指南）一并打包进 DSH 时，可用 bundle 插件
-`@taptap/dsh-maker`（源码 `packages/dsh-maker/`），通过 1024Store 对应的公开 npm 包一键安装，
-详见 [docs/DSH_PLUGIN.md](docs/DSH_PLUGIN.md)。稳定版从 npm 获取；`dsh-maker-v*` GitHub Release
-继续提供预览版和离线安装 tarball。该插件与 L1 的裸 MCP 行不要同时启用。
+`@taptap/dsh-maker`（源码 `packages/dsh-maker/`），通过官方 DSH CLI 从 npm registry 一键安装，
+详见 [docs/DSH_PLUGIN.md](docs/DSH_PLUGIN.md) 和 [docs/DSH_PLUGIN_MARKETS.md](docs/DSH_PLUGIN_MARKETS.md)。
+稳定版从 npm 获取；`dsh-maker-v*` GitHub Release 继续提供预览版和离线安装 tarball。该插件与
+L1 的裸 MCP 行不要同时启用。社区目录和市场 UI 的关系以 `awesome-dsh-plugin` → `dsh-market`
+为准，`deepseek1024.com` 是第三方市场。
 其它 AI 编辑器应优先让本地 AI 复用 `taptap-maker mcp install` 已验证的绝对 command/args。
 只有无法复用安装器时，才使用下面固定精确版本的 npx 兼容片段：
 

--- a/docs/DSH_PLUGIN.md
+++ b/docs/DSH_PLUGIN.md
@@ -78,7 +78,7 @@ packages/dsh-maker/
 前置：已装 DSH（`dsh`）与 pnpm。
 
 ```bash
-# 从 1024Store 使用的 npm 包安装（web profile；headless 同理）
+# 直接从 npm registry 安装（web profile；headless 同理）
 dsh plugin --profile web add @taptap/dsh-maker
 
 # 验证
@@ -119,10 +119,15 @@ dsh plugin --profile web remove @taptap/dsh-maker
 
 DSH 插件有两条互补的分发入口：
 
-- **1024Store / npm**：市场条目使用公开包 `@taptap/dsh-maker`，稳定版安装和更新跟随 npm
+- **npm registry**：官方 DSH CLI 直接安装公开包 `@taptap/dsh-maker`，稳定版安装和更新跟随 npm
   `latest`；固定版本可使用 `@taptap/dsh-maker@<version>`。
 - **GitHub Release tarball**：用于 develop 预览、离线安装和排障。用户把发版页链接交给 AI，AI
   按页面下载、校验 SHA-256 后安装。
+
+社区市场的关系和提交入口见 [`docs/DSH_PLUGIN_MARKETS.md`](DSH_PLUGIN_MARKETS.md)。本插件已向
+[`awesome-dsh-plugin`](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) 提交收录 PR；
+[`dsh-market`](https://github.com/dsh-market/dsh-market) 会读取该目录。`deepseek1024.com` 是
+第三方市场，不能当作 DSH 官方市场或社区主目录的替代入口。
 
 - **发版页**：`packages/dsh-maker/INSTALL.md`（稳定页，含“给安装 AI 的强制执行指令”、下载链接、
   安装步骤、排障与回滚）。
@@ -147,8 +152,8 @@ DSH 插件有两条互补的分发入口：
 - `packages/dsh-maker/` 与 `docs/DSH_PLUGIN.md` 已纳入 `scripts/release-scope.cjs` 的 maker
   归属，只改本插件的提交不会误触发主包发布。
 - 稳定版发布公开 npm 包 `@taptap/dsh-maker`；develop 预览版不写入 npm registry。
-- 1024Store catalog 登记 npm 包名；插件保持标准 bundle 形态，并使用
-  `assets/taptap-maker.png` 作为市场图标。
+- 社区 registry 根据 npm 包的 `repository` 和 `repository.directory` 自动关联包名；插件保持标准
+  bundle 形态，并使用 `assets/taptap-maker.png` 作为市场图标。
 
 ## 相关文档
 

--- a/docs/DSH_PLUGIN.md
+++ b/docs/DSH_PLUGIN.md
@@ -149,8 +149,8 @@ DSH 插件有两条互补的分发入口：
 - `@taptap/maker` 使用精确版本；手动从 develop 发布预览版时可通过 `maker_version` 输入指定精确
   beta runtime，main 稳定版只读取清单中的稳定 runtime。工作流会先通过 npm 校验该版本确实已
   发布，避免安装时依赖不存在。
-- `packages/dsh-maker/` 与 `docs/DSH_PLUGIN.md` 已纳入 `scripts/release-scope.cjs` 的 maker
-  归属，只改本插件的提交不会误触发主包发布。
+- `packages/dsh-maker/`、`docs/DSH_PLUGIN.md` 与 `docs/DSH_PLUGIN_MARKETS.md` 已纳入
+  `scripts/release-scope.cjs` 的 maker 归属，只改本插件的提交不会误触发主包发布。
 - 稳定版发布公开 npm 包 `@taptap/dsh-maker`；develop 预览版不写入 npm registry。
 - 社区 registry 根据 npm 包的 `repository` 和 `repository.directory` 自动关联包名；插件保持标准
   bundle 形态，并使用 `assets/taptap-maker.png` 作为市场图标。
@@ -158,3 +158,4 @@ DSH 插件有两条互补的分发入口：
 ## 相关文档
 
 - L1 配置：[`docs/MAKER.md`](MAKER.md)（DSH 章节）
+- 市场辨识与提交入口：[`docs/DSH_PLUGIN_MARKETS.md`](DSH_PLUGIN_MARKETS.md)

--- a/docs/DSH_PLUGIN_MARKETS.md
+++ b/docs/DSH_PLUGIN_MARKETS.md
@@ -1,0 +1,56 @@
+# DSH 插件市场与分发入口
+
+本文件用于区分 DeepSeek Harness（DSH）官方能力、社区插件目录和第三方市场，避免把不同项目误认为同一个“官方插件市场”。
+
+## 结论先看
+
+- DSH 官方仓库是 [`deepseek-ai/deepseek-harness`](https://github.com/deepseek-ai/deepseek-harness)。官方仓库没有指定唯一的插件市场，也没有把某个社区市场作为官方背书。
+- DSH 官方支持的安装协议是 `dsh plugin --profile <profile> add <npm 包名或 GitHub spec>`。npm 包和 GitHub 仓库都可以直接安装。
+- 当前社区主链路是 [`awesome-dsh-plugin`](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) curated registry，再由 [`dsh-market`](https://github.com/dsh-market/dsh-market) 提供 DSH 内置的可视化市场 UI。
+- [`deepseek1024.com`](https://deepseek1024.com/) 对应的 [`imsai-sh/awesome-deepseek-harness-plugins`](https://github.com/imsai-sh/awesome-deepseek-harness-plugins) 是第三方社区市场，不是 DeepSeek 官方市场，也不是 DSH 官方 CLI 的默认 registry。
+
+## 市场与仓库
+
+| 项目                                                                                                                                                          | 定位                                    | 是否 DeepSeek 官方 | 插件提交/更新方式                                                                                                     |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| [`deepseek-ai/deepseek-harness`](https://github.com/deepseek-ai/deepseek-harness)                                                                             | DSH 官方运行时、CLI 和插件协议          | 是                 | 不向此仓库提交社区插件目录条目；按官方 `dsh.bundle` 规范发布 npm/GitHub 插件                                          |
+| [`awesome-dsh-plugin`](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin)                                                                              | 社区 curated 插件目录和 registry 数据源 | 否                 | 为插件仓库提交一个 `data/plugins/*.yml` PR；npm 包名由 registry 根据 `repository` 元数据自动发现，不要手写 `npm` 字段 |
+| [`dsh-market`](https://github.com/dsh-market/dsh-market)                                                                                                      | DSH 内置可视化插件市场 UI               | 否                 | 不直接向该仓库提交插件条目；它读取 `awesome-dsh-plugin` 的公开 registry                                               |
+| [`imsai-sh/awesome-deepseek-harness-plugins`](https://github.com/imsai-sh/awesome-deepseek-harness-plugins) / [`deepseek1024.com`](https://deepseek1024.com/) | 第三方自动收集目录、市场和 API          | 否                 | 可按其自身规则提交，但这不等于进入 DSH 社区主目录                                                                     |
+| [`zhu1090093659/dsh-web`](https://github.com/zhu1090093659/dsh-web)                                                                                           | 第三方 DSH Web 聚合项目                 | 否                 | 独立项目规则；不是 DSH 官方 registry                                                                                  |
+
+## 本插件的正确路径
+
+本仓库的 DSH 插件是 `packages/dsh-maker`，npm 包为 `@taptap/dsh-maker`。
+
+1. 直接安装或验证：
+
+   ```bash
+   dsh plugin --profile web add @taptap/dsh-maker
+   ```
+
+2. 社区主目录收录 PR：
+   [awesome-dsh-plugin#3296](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/pull/3296)
+
+3. PR 合并后，`dsh-market` 会在其 registry 刷新后自动显示该插件；npm 新版本发布不需要重复提交目录 PR。
+
+4. 1024Store 可以作为额外的第三方分发渠道，但它的收录状态不能代表 DSH 官方或社区主目录状态。
+
+## 本地参考仓库
+
+为方便维护者核对市场机制，相关仓库应 clone 到本仓库同级目录，不放入本仓库 Git 历史：
+
+- `../awesome-dsh-plugin`：社区 curated registry。
+- `../dsh-market`：基于该 registry 的 DSH 内置市场 UI。
+- `../awesome-deepseek-harness-plugins`：第三方 1024Store 目录和市场实现。
+- `../dsh-web`：第三方 DSH Web 聚合项目。
+
+这些 clone 仅用于阅读和验证，不作为本仓库的运行时依赖，也不应提交到本仓库。
+
+## 以后如何判断
+
+- 看到 `deepseek-ai/deepseek-harness`：这是 DSH 官方协议和 CLI 的来源。
+- 看到 `awesome-dsh-plugin`：这是社区目录收录入口。
+- 看到 `dsh-market`：这是社区市场 UI，不是官方运营市场。
+- 看到 `deepseek1024.com`：这是第三方市场，不能替代社区主目录 PR。
+- 只想安装插件时，优先使用 npm 包名或 GitHub spec 直接运行官方 `dsh plugin` 命令。

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -105,8 +105,10 @@ WorkBuddy 插件位于 `plugins/workbuddy/taptap-maker`，通过
 
 DeepSeek Harness（DSH）的 Maker 集成分两层：L1 是 `taptap-maker install --ide dsh` 写入的
 裸 `mcp-client` 行（见下文“环境变量”与 DSH 配置小节）；L2 是 bundle 插件 `@taptap/dsh-maker`，
-位于 `packages/dsh-maker/`，通过 1024Store 对应的公开 npm 包分发，把 **Maker MCP + 技能**
+位于 `packages/dsh-maker/`，通过官方 DSH CLI 从 npm registry 分发，把 **Maker MCP + 技能**
 打包成可一键安装、可 HMR 的 DSH bundle；GitHub Release tarball 保留为预览版和离线备用入口。
+
+社区目录和市场 UI 的关系见 [DSH_PLUGIN_MARKETS.md](DSH_PLUGIN_MARKETS.md)。
 
 插件由一个 bundle patch 行（`id: taptap-maker`）在激活时挂两个子插件并注册一个 shell 环境变量：
 宿主平面 `skill-filesystem` 实例（`providerName: maker` + `bundledSkillDir: skills/`，只读挂本包

--- a/packages/dsh-maker/README.md
+++ b/packages/dsh-maker/README.md
@@ -42,8 +42,9 @@ dsh plugin --profile headless add @taptap/dsh-maker
 官方 DSH CLI 直接从 npm registry 安装公开包 `@taptap/dsh-maker`。需要固定版本时，在包名后追加
 版本号，例如 `@taptap/dsh-maker@<version>`。对应的 `dsh-maker-v*` GitHub Release 继续提供
 tarball 和 SHA-256，作为预览版、离线安装及排障备用入口。社区市场收录关系见源码仓库的
-`docs/DSH_PLUGIN_MARKETS.md`：`awesome-dsh-plugin` 是社区目录，`dsh-market` 是读取该目录的
-市场 UI，`deepseek1024.com` 是第三方市场。
+[DSH 插件市场与分发入口](https://github.com/taptap/instant-games-open-mcp/blob/main/docs/DSH_PLUGIN_MARKETS.md)：
+`awesome-dsh-plugin` 是社区目录，`dsh-market` 是读取该目录的市场 UI，`deepseek1024.com` 是
+第三方市场。
 
 DSH 会热重载该 patch，无需重启。验证：
 

--- a/packages/dsh-maker/README.md
+++ b/packages/dsh-maker/README.md
@@ -39,9 +39,11 @@ headless profile 同理：
 dsh plugin --profile headless add @taptap/dsh-maker
 ```
 
-1024Store 使用公开 npm 包 `@taptap/dsh-maker` 作为市场安装和更新入口。需要固定版本时，在包名后
-追加版本号，例如 `@taptap/dsh-maker@<version>`。对应的 `dsh-maker-v*` GitHub Release 继续提供
-tarball 和 SHA-256，作为预览版、离线安装及排障备用入口。
+官方 DSH CLI 直接从 npm registry 安装公开包 `@taptap/dsh-maker`。需要固定版本时，在包名后追加
+版本号，例如 `@taptap/dsh-maker@<version>`。对应的 `dsh-maker-v*` GitHub Release 继续提供
+tarball 和 SHA-256，作为预览版、离线安装及排障备用入口。社区市场收录关系见源码仓库的
+`docs/DSH_PLUGIN_MARKETS.md`：`awesome-dsh-plugin` 是社区目录，`dsh-market` 是读取该目录的
+市场 UI，`deepseek1024.com` 是第三方市场。
 
 DSH 会热重载该 patch，无需重启。验证：
 
@@ -126,4 +128,4 @@ dsh plugin --profile web remove @taptap/dsh-maker
 
 - 正式包由仓库的 `Publish DSH Maker Plugin` workflow 同时发布到 npm `latest` 和 GitHub Release。
 - `develop` 预览版只发布 GitHub prerelease，不写入 npm；`main` 稳定版才发布公开 npm 包。
-- 1024Store 使用 npm 包名 `@taptap/dsh-maker`；源码和问题反馈入口由 `package.json` 提供。
+- npm 包名为 `@taptap/dsh-maker`；源码和问题反馈入口由 `package.json` 提供。

--- a/scripts/release-scope.cjs
+++ b/scripts/release-scope.cjs
@@ -31,6 +31,7 @@ const MAKER_EXACT_PATHS = new Set([
   'docs/MAKER.md',
   'docs/MAKER_CLI_MCP_SKILL_REWORK_OVERVIEW.md',
   'docs/DSH_PLUGIN.md',
+  'docs/DSH_PLUGIN_MARKETS.md',
   'scripts/bundle-maker.js',
   'scripts/package-maker-client-plugins.js',
   'scripts/package-maker-dsh-plugin.js',

--- a/src/__tests__/makerDshManifest.test.ts
+++ b/src/__tests__/makerDshManifest.test.ts
@@ -34,7 +34,10 @@ describe('@taptap/dsh-maker manifest', () => {
   it('uses the published npm package as the DSH marketplace install source', () => {
     const readme = readFileSync(join(REPO_ROOT, 'packages', 'dsh-maker', 'README.md'), 'utf8');
     expect(readme).toContain('dsh plugin --profile web add @taptap/dsh-maker');
-    expect(readme).toContain('1024Store 使用公开 npm 包 `@taptap/dsh-maker`');
+    expect(readme).toContain('官方 DSH CLI 直接从 npm registry 安装公开包 `@taptap/dsh-maker`');
+    expect(readme).toContain(
+      '[DSH 插件市场与分发入口](https://github.com/taptap/instant-games-open-mcp/blob/main/docs/DSH_PLUGIN_MARKETS.md)'
+    );
     expect(readme).not.toContain("'github:taptap/instant-games-open-mcp#path:packages/dsh-maker'");
   });
 

--- a/src/__tests__/releaseScope.test.ts
+++ b/src/__tests__/releaseScope.test.ts
@@ -39,6 +39,7 @@ describe('release-scope classifier', () => {
       true
     );
     expect(releaseScope.isMakerOwnedPath('docs/DSH_PLUGIN.md')).toBe(true);
+    expect(releaseScope.isMakerOwnedPath('docs/DSH_PLUGIN_MARKETS.md')).toBe(true);
     expect(releaseScope.isMakerOwnedPath('.github/workflows/release.yml')).toBe(false);
     expect(releaseScope.isMakerOwnedPath('package.json')).toBe(false);
   });


### PR DESCRIPTION
## 改动内容

- 新增 DSH 插件市场辨识文档，区分官方 CLI、社区目录、市场 UI 和第三方 1024Store。
- 记录 `awesome-dsh-plugin` 收录 PR #3296 及后续自动同步关系。
- 修正 README、Maker 文档和开发指引中把 1024Store 当作默认市场入口的表述。
- 记录同级参考仓库 clone 位置，避免后续再次混淆市场职责。

## 影响面

- 仅修改文档，不改变 DSH 插件运行时、npm 包内容或发布工作流。
- 同级 clone 的市场仓库只用于维护核对，不纳入当前仓库依赖或提交历史。

## 验证

- `npx prettier --check AGENTS.md README.md docs/DSH_PLUGIN.md docs/DSH_PLUGIN_MARKETS.md docs/MAKER.md packages/dsh-maker/README.md`
- `git diff --check origin/develop...HEAD`
- 已验证相关 GitHub 仓库地址可访问。