### PR TITLE
fix(maker): 支持主动拉取并安装用户 Skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -396,6 +396,11 @@ Maker 本地开发的默认路径是 CLI-first + PAT-first：
   `docs/MAKER_ENVIRONMENT_VARIABLES.md`；面向团队介绍的功能总览在
   `docs/MAKER_CLI_MCP_SKILL_REWORK_OVERVIEW.md`。上下文压缩或长时间中断后，先读这些文档再继续。
 - 用户说“我要开发maker游戏 / 本地maker开发 / 拉取maker游戏到本地 / 把maker游戏代码拉到本地 / clone maker项目 / 下载maker游戏代码 / 初始化maker开发目录 / 配置maker本地开发 / 继续开发maker项目”时，应触发 `taptap-maker init`，由该 CLI 展示 app 列表并让用户选择已有 app 或 `0`/`new`。只有用户明确说“创建/新建项目或游戏”时，才使用 `taptap-maker init --create`。
+- `taptap-maker user-skills pull --target-dir <PROJECT_DIR>` 只用于用户明确要求拉取个人 Maker
+  Skill 的边缘场景。正常开发、状态检查和初始化不得主动调用；该能力保持为 CLI，不得新增 MCP tool。
+  命令只覆盖服务端 ZIP 中出现的 `.installer/skills/<skill-name>`，并以原始名称安装到项目内
+  `.codex/skills`、`.cursor/skills` 和 `.workbuddy/skills`；其它本地 Skill 保持不变，暂不接入
+  `taptap-maker init`。客户端安装优先链接到 `.installer/skills`，链接不可用时回退复制。
 - 如果本地没有当前环境的 Maker PAT，CLI 默认运行 CLI 登录：生成满足 `^[A-Za-z0-9_-]{16,128}$` 的临时 code，按需打开当前环境的 `/pat-tokens?code=<code>`，用户登录并点击“创建 token”后，CLI 轮询 `/api/v1/cli-auth/result?code=<code>`，拿到授权结果后完成本地鉴权配置。
 - Maker 鉴权文件必须沿用线上已发布版本的原始本地保存路径，不要新建环境子目录；不要在用户文档或普通用户说明里暴露具体凭证缓存路径。
 - 用户可运行 `taptap-maker login` 主动刷新当前环境鉴权；`taptap-maker init` 和无参数 `taptap-maker pat set` 缺 PAT 时也走 CLI 登录。兼容写法 `taptap-maker pat set <PAT>`、`--pat PAT` 或 `--pat-stdin` 仅用于 CI / 应急联调，其中 argv 形式会让 PAT 进入 `ps`/shell history。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -400,7 +400,8 @@ Maker 本地开发的默认路径是 CLI-first + PAT-first：
   Skill 的边缘场景。正常开发、状态检查和初始化不得主动调用；该能力保持为 CLI，不得新增 MCP tool。
   命令只覆盖服务端 ZIP 中出现的 `.installer/skills/<skill-name>`，并以原始名称安装到项目内
   `.codex/skills`、`.cursor/skills` 和 `.workbuddy/skills`；其它本地 Skill 保持不变，暂不接入
-  `taptap-maker init`。客户端安装优先链接到 `.installer/skills`，链接不可用时回退复制。
+  `taptap-maker init`。客户端安装优先链接到 `.installer/skills`，链接不可用时回退复制，失败时
+  回滚本次客户端替换。归档限制为下载 64 MiB、1000 个条目和解压后 128 MiB。
 - 如果本地没有当前环境的 Maker PAT，CLI 默认运行 CLI 登录：生成满足 `^[A-Za-z0-9_-]{16,128}$` 的临时 code，按需打开当前环境的 `/pat-tokens?code=<code>`，用户登录并点击“创建 token”后，CLI 轮询 `/api/v1/cli-auth/result?code=<code>`，拿到授权结果后完成本地鉴权配置。
 - Maker 鉴权文件必须沿用线上已发布版本的原始本地保存路径，不要新建环境子目录；不要在用户文档或普通用户说明里暴露具体凭证缓存路径。
 - 用户可运行 `taptap-maker login` 主动刷新当前环境鉴权；`taptap-maker init` 和无参数 `taptap-maker pat set` 缺 PAT 时也走 CLI 登录。兼容写法 `taptap-maker pat set <PAT>`、`--pat PAT` 或 `--pat-stdin` 仅用于 CI / 应急联调，其中 argv 形式会让 PAT 进入 `ps`/shell history。

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ taptap-maker upgrade
 taptap-maker mcp verify
 npx -y --package @taptap/maker@<exact-version> taptap-maker mcp report --ide <client> --target-dir <project> --context-stdin --consent --json
 taptap-maker dev-kit update
+taptap-maker user-skills pull --target-dir <project>
 ```
 
 普通初始化、clone、下载或拉取远端项目的标准命令是 `taptap-maker init`，CLI 会展示 app 列表，
@@ -215,6 +216,10 @@ MCP 进程自身的 cwd 只作为最后兜底和诊断信息，不应通过重�
 和 `taptap-maker doctor` 会检查老项目 `AGENTS.md` 是否缺失或过期，并提示运行
 `taptap-maker agents update` 或 `taptap-maker upgrade`。
 `taptap-maker dev-kit update` 会检查当前环境可用的最新 AI dev kit 并更新当前目录。
+`taptap-maker user-skills pull` 是可选的边缘命令，仅在用户明确要求时从 Maker Server 下载个人
+Skill，并覆盖项目 `.installer/skills/` 中 ZIP 包含的同名目录，再以原始 Skill 名称安装到项目内
+`.codex/skills/`、`.cursor/skills/` 和 `.workbuddy/skills/`；其它本地 Skill 保持不变。
+该命令不属于正常开发或初始化流程，也不会增加 MCP tool。
 
 如果 Maker MCP tools 缺失或出现 `-32000` / `Connection closed`，先按
 [TapTap Maker MCP 本地连接自检与修复指引](docs/MAKER_MCP_CONNECTION_TROUBLESHOOTING.md)

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ MCP 进程自身的 cwd 只作为最后兜底和诊断信息，不应通过重�
 `taptap-maker user-skills pull` 是可选的边缘命令，仅在用户明确要求时从 Maker Server 下载个人
 Skill，并覆盖项目 `.installer/skills/` 中 ZIP 包含的同名目录，再以原始 Skill 名称安装到项目内
 `.codex/skills/`、`.cursor/skills/` 和 `.workbuddy/skills/`；其它本地 Skill 保持不变。
+归档下载限制为 64 MiB，最多 1000 个条目、解压后最多 128 MiB。
 该命令不属于正常开发或初始化流程，也不会增加 MCP tool。
 
 如果 Maker MCP tools 缺失或出现 `-32000` / `Connection closed`，先按

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -357,6 +357,11 @@ Python 运行时策略：
   不由 MCP 自己执行；MCP 只做版本检查并输出 `required_upgrade`、`update_available`、
   `current`、`unavailable` 或 `skipped`。
 - `taptap-maker dev-kit update`：检查当前环境可用的最新 AI dev kit，恢复或更新当前目录。
+- `taptap-maker user-skills pull`：可选地下载当前用户的 Skill ZIP，校验后只覆盖
+  `.installer/skills/` 中 ZIP 包含的同名 Skill，并以原始名称安装到项目内 `.codex/skills/`、
+  `.cursor/skills/` 和 `.workbuddy/skills/`，保留其它本地 Skill。安装优先链接到统一源目录，
+  链接不可用时回退复制。ZIP 使用随 Maker bundle 打包的 `yauzl` 解压，不依赖系统 `unzip`、
+  PowerShell 或 Python。该命令不接入正常开发流程，也不提供 MCP tool。
 
 MCP 运行期能力：
 

--- a/docs/MAKER.md
+++ b/docs/MAKER.md
@@ -360,8 +360,9 @@ Python 运行时策略：
 - `taptap-maker user-skills pull`：可选地下载当前用户的 Skill ZIP，校验后只覆盖
   `.installer/skills/` 中 ZIP 包含的同名 Skill，并以原始名称安装到项目内 `.codex/skills/`、
   `.cursor/skills/` 和 `.workbuddy/skills/`，保留其它本地 Skill。安装优先链接到统一源目录，
-  链接不可用时回退复制。ZIP 使用随 Maker bundle 打包的 `yauzl` 解压，不依赖系统 `unzip`、
-  PowerShell 或 Python。该命令不接入正常开发流程，也不提供 MCP tool。
+  链接不可用时回退复制；任一客户端安装失败时恢复本次替换的客户端目录。归档下载限制为
+  64 MiB，最多 1000 个条目、解压后最多 128 MiB。ZIP 使用随 Maker bundle 打包的 `yauzl`
+  解压，不依赖系统 `unzip`、PowerShell 或 Python。该命令不接入正常开发流程，也不提供 MCP tool。
 
 MCP 运行期能力：
 

--- a/docs/MAKER_CLI_MCP_SKILL_REWORK_OVERVIEW.md
+++ b/docs/MAKER_CLI_MCP_SKILL_REWORK_OVERVIEW.md
@@ -30,24 +30,25 @@ Skill 负责 Agent 决策和失败恢复
 
 CLI 负责所有与本机环境、账号、项目绑定相关的低频动作：
 
-| 命令                          | 作用                                                                          |
-| ----------------------------- | ----------------------------------------------------------------------------- |
-| `taptap-maker init`           | 一站式初始化：Git 检查、PAT、TapTap token、app 选择、dev-kit、clone、MCP 配置 |
-| `taptap-maker doctor`         | 检查 Git、PAT、TapTap token、项目绑定、dev-kit、skill 状态                    |
-| `taptap-maker apps`           | 使用 PAT 获取 Maker app 列表                                                  |
-| `taptap-maker login`          | CLI 登录入口：打开 Maker 授权页，授权完成后自动保存本地鉴权                   |
-| `taptap-maker pat set`        | 兼容入口，仅用于 CI 或应急联调                                                |
-| `taptap-maker python doctor`  | 检查 Maker 本地 Python 运行时，识别 Windows Store alias 等不可用环境          |
-| `taptap-maker python setup`   | 自动准备本地 Lua 诊断环境；准备 Python 后 best-effort 安装 maker-lua-lsp      |
-| `taptap-maker python path`    | 输出 Maker 诊断脚本应使用的真实 Python 可执行文件路径                         |
-| `taptap-maker lua-lsp doctor` | 检查 maker-lua-lsp 是否可用于本地 Lua 诊断                                    |
-| `taptap-maker lua-lsp setup`  | 安装/升级 maker-lua-lsp 并执行 `install --ide codex,cursor,claude`            |
-| `taptap-maker install`        | `taptap-maker mcp install` 的快捷别名，写入 AI 客户端 MCP 配置                |
-| `taptap-maker mcp install`    | 写入默认客户端，并自动检测 Trae/OpenCode/WorkBuddy/DSH                        |
-| `taptap-maker mcp verify`     | 用最终 launcher 完成 MCP 握手与 tools/list；`--mode self` 验证当前 CLI        |
-| `taptap-maker agents update`  | 更新当前项目 `AGENTS.md` 中 TapTap Maker 管理的策略块                         |
-| `taptap-maker upgrade`        | 刷新当前机器 MCP 配置，并更新当前绑定项目的 `AGENTS.md` 受管策略块            |
-| `taptap-maker dev-kit update` | 恢复或更新本地 AI dev-kit                                                     |
+| 命令                            | 作用                                                                          |
+| ------------------------------- | ----------------------------------------------------------------------------- |
+| `taptap-maker init`             | 一站式初始化：Git 检查、PAT、TapTap token、app 选择、dev-kit、clone、MCP 配置 |
+| `taptap-maker doctor`           | 检查 Git、PAT、TapTap token、项目绑定、dev-kit、skill 状态                    |
+| `taptap-maker apps`             | 使用 PAT 获取 Maker app 列表                                                  |
+| `taptap-maker login`            | CLI 登录入口：打开 Maker 授权页，授权完成后自动保存本地鉴权                   |
+| `taptap-maker pat set`          | 兼容入口，仅用于 CI 或应急联调                                                |
+| `taptap-maker python doctor`    | 检查 Maker 本地 Python 运行时，识别 Windows Store alias 等不可用环境          |
+| `taptap-maker python setup`     | 自动准备本地 Lua 诊断环境；准备 Python 后 best-effort 安装 maker-lua-lsp      |
+| `taptap-maker python path`      | 输出 Maker 诊断脚本应使用的真实 Python 可执行文件路径                         |
+| `taptap-maker lua-lsp doctor`   | 检查 maker-lua-lsp 是否可用于本地 Lua 诊断                                    |
+| `taptap-maker lua-lsp setup`    | 安装/升级 maker-lua-lsp 并执行 `install --ide codex,cursor,claude`            |
+| `taptap-maker install`          | `taptap-maker mcp install` 的快捷别名，写入 AI 客户端 MCP 配置                |
+| `taptap-maker mcp install`      | 写入默认客户端，并自动检测 Trae/OpenCode/WorkBuddy/DSH                        |
+| `taptap-maker mcp verify`       | 用最终 launcher 完成 MCP 握手与 tools/list；`--mode self` 验证当前 CLI        |
+| `taptap-maker agents update`    | 更新当前项目 `AGENTS.md` 中 TapTap Maker 管理的策略块                         |
+| `taptap-maker upgrade`          | 刷新当前机器 MCP 配置，并更新当前绑定项目的 `AGENTS.md` 受管策略块            |
+| `taptap-maker dev-kit update`   | 恢复或更新本地 AI dev-kit                                                     |
+| `taptap-maker user-skills pull` | 下载个人 Skill，并安装到项目内 Codex、Cursor、WorkBuddy；不接入 init          |
 
 设计原则：
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "crypto-js": "^4.2.0",
         "dotenv": "17.2.3",
         "qrcode": "1.5.4",
-        "yaml": "2.8.2"
+        "yaml": "2.8.2",
+        "yauzl": "3.4.0"
       },
       "bin": {
         "instant-games-open-mcp": "bin/instant-games-open-mcp",
@@ -34,6 +35,7 @@
         "@types/jest": "^29.0.0",
         "@types/node": "^20.0.0",
         "@types/qrcode": "1.5.6",
+        "@types/yauzl": "3.4.0",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
         "conventional-changelog-cli": "5.0.0",
@@ -3279,6 +3281,16 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-NRPn5w6h8dhcnmx3YIRQcqMywY/+nND/uOkJessedcrowO3C0AssHp3tMJpxKAwOhFOo0OV1y9VtsC5hbKKBAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.21.0",
@@ -12491,6 +12503,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -15818,6 +15836,18 @@
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      },
       "engines": {
         "node": ">=12"
       }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "crypto-js": "^4.2.0",
     "dotenv": "17.2.3",
     "qrcode": "1.5.4",
-    "yaml": "2.8.2"
+    "yaml": "2.8.2",
+    "yauzl": "3.4.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^18.4.3",
@@ -80,6 +81,7 @@
     "@types/jest": "^29.0.0",
     "@types/node": "^20.0.0",
     "@types/qrcode": "1.5.6",
+    "@types/yauzl": "3.4.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "conventional-changelog-cli": "5.0.0",

--- a/src/__tests__/makerCliCommands.test.ts
+++ b/src/__tests__/makerCliCommands.test.ts
@@ -19,6 +19,7 @@ import {
   installAiDevKitSkills,
 } from '../maker/cli/devKit';
 import { syncWorkBuddyProjectSkills } from '../maker/cli/workBuddyProjectSkills';
+import { pullMakerUserSkills } from '../maker/cli/userSkills';
 import { formatMakerPackageUpdateStatus, getMakerPackageUpdateStatus } from '../maker/versionCheck';
 import { runMakerCli } from '../maker/cli/commands';
 import {
@@ -155,6 +156,16 @@ jest.mock('../maker/cli/workBuddyProjectSkills', () => ({
     targetDir: '/project/.workbuddy/skills',
     installedSkills: ['taptap-maker-materials'],
     skippedSkills: [],
+  })),
+}));
+
+jest.mock('../maker/cli/userSkills', () => ({
+  pullMakerUserSkills: jest.fn(async (options) => ({
+    targetDir: path.resolve(options.targetDir),
+    sourceDir: path.join(path.resolve(options.targetDir), '.installer', 'skills'),
+    environment: options.environment || 'production',
+    installedSkills: ['materials'],
+    preservedSkills: ['local-only'],
   })),
 }));
 
@@ -2999,6 +3010,30 @@ describe('Maker CLI commands', () => {
     await runMakerCli(['dev-kit', 'update', '--target-dir', tempDir]);
 
     expect(syncWorkBuddyProjectSkills).toHaveBeenCalledWith(tempDir);
+  });
+
+  test('user-skills pull routes to the lightweight downloader and prints one JSON result', async () => {
+    await runMakerCli(['user-skills', 'pull', '--target-dir', tempDir, '--env', 'rnd', '--json']);
+
+    expect(pullMakerUserSkills).toHaveBeenCalledWith({
+      targetDir: tempDir,
+      environment: 'rnd',
+    });
+    expect(JSON.parse(stdoutSpy.mock.calls.join(''))).toEqual({
+      targetDir: tempDir,
+      sourceDir: path.join(tempDir, '.installer', 'skills'),
+      environment: 'rnd',
+      installedSkills: ['materials'],
+      preservedSkills: ['local-only'],
+    });
+  });
+
+  test('help documents the optional user Skill pull command', async () => {
+    await runMakerCli(['help']);
+
+    expect(stdoutSpy.mock.calls.join('')).toContain(
+      'taptap-maker user-skills pull [--target-dir DIR] [--json]'
+    );
   });
 
   test('doctor includes AI dev kit update state in json output', async () => {

--- a/src/__tests__/makerUserSkills.test.ts
+++ b/src/__tests__/makerUserSkills.test.ts
@@ -2,7 +2,7 @@ import archiver from 'archiver';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { PassThrough } from 'node:stream';
+import { PassThrough, Readable } from 'node:stream';
 
 import { pullMakerUserSkills, validateUserSkillArchivePath } from '../maker/cli/userSkills';
 
@@ -140,6 +140,112 @@ describe('Maker user Skill pull', () => {
     ).toContain('keep me');
   });
 
+  test('restores every client Skill when a later client installation fails', async () => {
+    addLocalSkill('materials', 'old source');
+    for (const clientDir of ['.codex', '.cursor', '.workbuddy']) {
+      addClientSkill(clientDir, 'materials', `old ${clientDir}`);
+    }
+    const zip = await createZip({ 'materials/SKILL.md': '# new materials\n' });
+    const originalSymlinkSync = fs.symlinkSync;
+    const originalCpSync = fs.cpSync;
+    const failingTarget = path.join(projectDir, '.cursor', 'skills', 'materials');
+    const symlinkSpy = jest.spyOn(fs, 'symlinkSync').mockImplementation((source, target, type) => {
+      if (path.resolve(String(target)) === failingTarget) {
+        throw Object.assign(new Error('simulated symlink failure'), { code: 'EACCES' });
+      }
+      return originalSymlinkSync(source, target, type);
+    });
+    const copySpy = jest.spyOn(fs, 'cpSync').mockImplementation((source, target, options) => {
+      if (path.resolve(String(target)) === failingTarget) {
+        throw Object.assign(new Error('simulated copy failure'), { code: 'ENOSPC' });
+      }
+      return originalCpSync(source, target, options);
+    });
+
+    try {
+      await expect(
+        pullMakerUserSkills({
+          targetDir: projectDir,
+          fetchImpl: (async () => zipResponse(zip)) as typeof fetch,
+        })
+      ).rejects.toThrow('Failed to install Maker user Skills for AI clients');
+    } finally {
+      symlinkSpy.mockRestore();
+      copySpy.mockRestore();
+    }
+
+    for (const clientDir of ['.codex', '.cursor', '.workbuddy']) {
+      expect(
+        fs.readFileSync(path.join(projectDir, clientDir, 'skills', 'materials', 'SKILL.md'), 'utf8')
+      ).toContain(`old ${clientDir}`);
+    }
+  });
+
+  test('rejects a download whose declared size exceeds the archive limit', async () => {
+    const response = new Response(new Uint8Array([1]), {
+      status: 200,
+      headers: { 'Content-Length': String(64 * 1024 * 1024 + 1) },
+    });
+
+    await expect(
+      pullMakerUserSkills({
+        targetDir: projectDir,
+        fetchImpl: (async () => response) as typeof fetch,
+      })
+    ).rejects.toThrow('64 MiB');
+  });
+
+  test('stops a streamed download that exceeds the archive limit without a size header', async () => {
+    const chunk = new Uint8Array(1024 * 1024);
+    let emittedChunks = 0;
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (emittedChunks >= 65) {
+            controller.close();
+            return;
+          }
+          emittedChunks += 1;
+          controller.enqueue(chunk);
+        },
+      }),
+      { status: 200 }
+    );
+
+    await expect(
+      pullMakerUserSkills({
+        targetDir: projectDir,
+        fetchImpl: (async () => response) as typeof fetch,
+      })
+    ).rejects.toThrow('64 MiB');
+  });
+
+  test('rejects an archive with more than 1000 entries', async () => {
+    const entries: Record<string, string> = { 'bulk/SKILL.md': '# bulk\n' };
+    for (let index = 0; index < 1000; index += 1) {
+      entries[`bulk/references/${index}.md`] = '';
+    }
+    const zip = await createZip(entries);
+
+    await expect(
+      pullMakerUserSkills({
+        targetDir: projectDir,
+        fetchImpl: (async () => zipResponse(zip)) as typeof fetch,
+      })
+    ).rejects.toThrow('1000 entries');
+  });
+
+  test('rejects an archive larger than 128 MiB after extraction', async () => {
+    const zip = await createRepeatedZip('large/SKILL.md', 129 * 1024 * 1024);
+
+    await expect(
+      pullMakerUserSkills({
+        targetDir: projectDir,
+        fetchImpl: (async () => zipResponse(zip)) as typeof fetch,
+      })
+    ).rejects.toThrow('128 MiB');
+  });
+
   test.each(['../escape/SKILL.md', '/absolute/SKILL.md', 'skill/../escape.md'])(
     'rejects unsafe archive path %s',
     (entryPath) => {
@@ -169,6 +275,32 @@ async function createZip(entries: Record<string, string>): Promise<Buffer> {
   for (const [name, content] of Object.entries(entries)) {
     archive.append(content, { name });
   }
+  const completed = new Promise<Buffer>((resolve, reject) => {
+    output.on('end', () => resolve(Buffer.concat(chunks)));
+    output.on('error', reject);
+    archive.on('error', reject);
+  });
+  await archive.finalize();
+  return completed;
+}
+
+async function createRepeatedZip(entryName: string, size: number): Promise<Buffer> {
+  const archive = archiver('zip', { zlib: { level: 9 } });
+  const output = new PassThrough();
+  const chunks: Buffer[] = [];
+  output.on('data', (chunk: Buffer) => chunks.push(chunk));
+  archive.pipe(output);
+  const chunk = Buffer.alloc(1024 * 1024);
+  archive.append(
+    Readable.from(
+      (function* (): Generator<Buffer> {
+        for (let emitted = 0; emitted < size; emitted += chunk.length) {
+          yield chunk.subarray(0, Math.min(chunk.length, size - emitted));
+        }
+      })()
+    ),
+    { name: entryName }
+  );
   const completed = new Promise<Buffer>((resolve, reject) => {
     output.on('end', () => resolve(Buffer.concat(chunks)));
     output.on('error', reject);

--- a/src/__tests__/makerUserSkills.test.ts
+++ b/src/__tests__/makerUserSkills.test.ts
@@ -1,0 +1,194 @@
+import archiver from 'archiver';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { PassThrough } from 'node:stream';
+
+import { pullMakerUserSkills, validateUserSkillArchivePath } from '../maker/cli/userSkills';
+
+describe('Maker user Skill pull', () => {
+  const originalMakerHome = process.env.TAPTAP_MAKER_HOME;
+  const originalApiBase = process.env.TAPTAP_MAKER_API_BASE;
+  let tempDir: string;
+  let projectDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'maker-user-skills-'));
+    projectDir = path.join(tempDir, 'project');
+    fs.mkdirSync(path.join(projectDir, '.maker-mcp'), { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDir, '.maker-mcp', 'config.json'),
+      JSON.stringify({ project_id: 'project-1' }),
+      'utf8'
+    );
+    process.env.TAPTAP_MAKER_HOME = path.join(tempDir, 'maker-home');
+    process.env.TAPTAP_MAKER_API_BASE = 'https://maker.example/api/v1';
+    fs.mkdirSync(process.env.TAPTAP_MAKER_HOME, { recursive: true });
+    fs.writeFileSync(
+      path.join(process.env.TAPTAP_MAKER_HOME, 'pat.json'),
+      JSON.stringify({ token: 'test-pat' }),
+      'utf8'
+    );
+  });
+
+  afterEach(() => {
+    restoreEnv('TAPTAP_MAKER_HOME', originalMakerHome);
+    restoreEnv('TAPTAP_MAKER_API_BASE', originalApiBase);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('downloads and replaces included Skills while preserving other local Skills', async () => {
+    addLocalSkill('materials', 'old materials');
+    addLocalSkill('local-only', 'keep me');
+    addClientSkill('.codex', 'codex-only', 'keep codex');
+    addClientSkill('.cursor', 'materials', 'stale cursor copy');
+    addClientSkill('.workbuddy', 'workbuddy-only', 'keep workbuddy');
+    const zip = await createZip({
+      'materials/SKILL.md': '# new materials\n',
+      'materials/references/guide.md': 'new guide\n',
+      'ui-helper/SKILL.md': '# ui helper\n',
+    });
+    const fetchImpl = jest.fn(async () => zipResponse(zip)) as jest.MockedFunction<typeof fetch>;
+
+    const result = await pullMakerUserSkills({ targetDir: projectDir, fetchImpl });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://maker.example/api/v1/user/skills/archive',
+      expect.objectContaining({
+        method: 'GET',
+        headers: {
+          Accept: 'application/zip',
+          Authorization: 'Bearer test-pat',
+        },
+      })
+    );
+    expect(result.installedSkills).toEqual(['materials', 'ui-helper']);
+    expect(result.preservedSkills).toEqual(['local-only']);
+    expect(
+      fs.readFileSync(
+        path.join(projectDir, '.installer', 'skills', 'materials', 'SKILL.md'),
+        'utf8'
+      )
+    ).toBe('# new materials\n');
+    expect(
+      fs.readFileSync(
+        path.join(projectDir, '.installer', 'skills', 'materials', 'references', 'guide.md'),
+        'utf8'
+      )
+    ).toBe('new guide\n');
+    expect(
+      fs.readFileSync(
+        path.join(projectDir, '.installer', 'skills', 'local-only', 'SKILL.md'),
+        'utf8'
+      )
+    ).toContain('keep me');
+
+    for (const clientDir of ['.codex', '.cursor', '.workbuddy']) {
+      expect(
+        fs.readFileSync(path.join(projectDir, clientDir, 'skills', 'materials', 'SKILL.md'), 'utf8')
+      ).toBe('# new materials\n');
+      expect(
+        fs.readFileSync(path.join(projectDir, clientDir, 'skills', 'ui-helper', 'SKILL.md'), 'utf8')
+      ).toBe('# ui helper\n');
+    }
+    expect(
+      fs.readFileSync(path.join(projectDir, '.codex', 'skills', 'codex-only', 'SKILL.md'), 'utf8')
+    ).toContain('keep codex');
+    expect(
+      fs.readFileSync(
+        path.join(projectDir, '.workbuddy', 'skills', 'workbuddy-only', 'SKILL.md'),
+        'utf8'
+      )
+    ).toContain('keep workbuddy');
+  });
+
+  test('rejects an archive without SKILL.md before changing existing Skills', async () => {
+    addLocalSkill('materials', 'old materials');
+    const zip = await createZip({ 'materials/README.md': 'missing definition\n' });
+
+    await expect(
+      pullMakerUserSkills({
+        targetDir: projectDir,
+        fetchImpl: (async () => zipResponse(zip)) as typeof fetch,
+      })
+    ).rejects.toThrow('SKILL.md');
+
+    expect(
+      fs.readFileSync(
+        path.join(projectDir, '.installer', 'skills', 'materials', 'SKILL.md'),
+        'utf8'
+      )
+    ).toContain('old materials');
+  });
+
+  test('accepts an empty ZIP without deleting local Skills', async () => {
+    addLocalSkill('local-only', 'keep me');
+    const zip = await createZip({});
+
+    const result = await pullMakerUserSkills({
+      targetDir: projectDir,
+      fetchImpl: (async () => zipResponse(zip)) as typeof fetch,
+    });
+
+    expect(result.installedSkills).toEqual([]);
+    expect(result.preservedSkills).toEqual(['local-only']);
+    expect(
+      fs.readFileSync(
+        path.join(projectDir, '.installer', 'skills', 'local-only', 'SKILL.md'),
+        'utf8'
+      )
+    ).toContain('keep me');
+  });
+
+  test.each(['../escape/SKILL.md', '/absolute/SKILL.md', 'skill/../escape.md'])(
+    'rejects unsafe archive path %s',
+    (entryPath) => {
+      expect(() => validateUserSkillArchivePath(entryPath)).toThrow('unsafe');
+    }
+  );
+
+  function addLocalSkill(name: string, body: string): void {
+    const skillDir = path.join(projectDir, '.installer', 'skills', name);
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), `# ${name}\n\n${body}\n`, 'utf8');
+  }
+
+  function addClientSkill(clientDir: string, name: string, body: string): void {
+    const skillDir = path.join(projectDir, clientDir, 'skills', name);
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), `# ${name}\n\n${body}\n`, 'utf8');
+  }
+});
+
+async function createZip(entries: Record<string, string>): Promise<Buffer> {
+  const archive = archiver('zip', { zlib: { level: 9 } });
+  const output = new PassThrough();
+  const chunks: Buffer[] = [];
+  output.on('data', (chunk: Buffer) => chunks.push(chunk));
+  archive.pipe(output);
+  for (const [name, content] of Object.entries(entries)) {
+    archive.append(content, { name });
+  }
+  const completed = new Promise<Buffer>((resolve, reject) => {
+    output.on('end', () => resolve(Buffer.concat(chunks)));
+    output.on('error', reject);
+    archive.on('error', reject);
+  });
+  await archive.finalize();
+  return completed;
+}
+
+function zipResponse(zip: Buffer): Response {
+  return new Response(new Uint8Array(zip), {
+    status: 200,
+    headers: { 'Content-Type': 'application/zip' },
+  });
+}
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+  process.env[key] = value;
+}

--- a/src/__tests__/makerUserSkills.test.ts
+++ b/src/__tests__/makerUserSkills.test.ts
@@ -187,6 +187,72 @@ describe('Maker user Skill pull', () => {
     ).toContain('old source');
   });
 
+  test('preserves source and client backups when rollback fails', async () => {
+    addLocalSkill('materials', 'old source');
+    for (const clientDir of ['.codex', '.cursor', '.workbuddy']) {
+      addClientSkill(clientDir, 'materials', `old ${clientDir}`);
+    }
+    const zip = await createZip({ 'materials/SKILL.md': '# new materials\n' });
+    const originalSymlinkSync = fs.symlinkSync;
+    const originalCpSync = fs.cpSync;
+    const originalRenameSync = fs.renameSync;
+    const failingClientTarget = path.join(projectDir, '.cursor', 'skills', 'materials');
+    const sourceTarget = path.join(projectDir, '.installer', 'skills', 'materials');
+    const symlinkSpy = jest.spyOn(fs, 'symlinkSync').mockImplementation((source, target, type) => {
+      if (path.resolve(String(target)) === failingClientTarget) {
+        throw Object.assign(new Error('simulated symlink failure'), { code: 'EACCES' });
+      }
+      return originalSymlinkSync(source, target, type);
+    });
+    const copySpy = jest.spyOn(fs, 'cpSync').mockImplementation((source, target, options) => {
+      if (path.resolve(String(target)) === failingClientTarget) {
+        throw Object.assign(new Error('simulated copy failure'), { code: 'ENOSPC' });
+      }
+      return originalCpSync(source, target, options);
+    });
+    const renameSpy = jest.spyOn(fs, 'renameSync').mockImplementation((source, target) => {
+      const sourcePath = String(source);
+      const targetPath = path.resolve(String(target));
+      const isBackupRestore = sourcePath.includes(`${path.sep}backup${path.sep}`);
+      if (
+        isBackupRestore &&
+        sourcePath.includes('.user-skill-clients-') &&
+        targetPath === failingClientTarget
+      ) {
+        throw Object.assign(new Error('simulated client rollback failure'), { code: 'EACCES' });
+      }
+      if (isBackupRestore && sourcePath.includes('.user-skills-') && targetPath === sourceTarget) {
+        throw Object.assign(new Error('simulated source rollback failure'), { code: 'EBUSY' });
+      }
+      return originalRenameSync(source, target);
+    });
+
+    try {
+      await expect(
+        pullMakerUserSkills({
+          targetDir: projectDir,
+          fetchImpl: (async () => zipResponse(zip)) as typeof fetch,
+        })
+      ).rejects.toThrow('backups were preserved');
+    } finally {
+      symlinkSpy.mockRestore();
+      copySpy.mockRestore();
+      renameSpy.mockRestore();
+    }
+
+    const sourceTransactionDir = findInstallerTransaction('.user-skills-');
+    expect(
+      fs.readFileSync(path.join(sourceTransactionDir, 'backup', 'materials', 'SKILL.md'), 'utf8')
+    ).toContain('old source');
+    const clientTransactionDir = findInstallerTransaction('.user-skill-clients-');
+    expect(
+      fs.readFileSync(
+        path.join(clientTransactionDir, 'backup', '.cursor', 'materials', 'SKILL.md'),
+        'utf8'
+      )
+    ).toContain('old .cursor');
+  });
+
   test('rejects a download whose declared size exceeds the archive limit', async () => {
     const response = new Response(new Uint8Array([1]), {
       status: 200,
@@ -269,6 +335,13 @@ describe('Maker user Skill pull', () => {
     const skillDir = path.join(projectDir, clientDir, 'skills', name);
     fs.mkdirSync(skillDir, { recursive: true });
     fs.writeFileSync(path.join(skillDir, 'SKILL.md'), `# ${name}\n\n${body}\n`, 'utf8');
+  }
+
+  function findInstallerTransaction(prefix: string): string {
+    const installerDir = path.join(projectDir, '.installer');
+    const entries = fs.readdirSync(installerDir).filter((entry) => entry.startsWith(prefix));
+    expect(entries).toHaveLength(1);
+    return path.join(installerDir, entries[0]);
   }
 });
 

--- a/src/__tests__/makerUserSkills.test.ts
+++ b/src/__tests__/makerUserSkills.test.ts
@@ -179,6 +179,12 @@ describe('Maker user Skill pull', () => {
         fs.readFileSync(path.join(projectDir, clientDir, 'skills', 'materials', 'SKILL.md'), 'utf8')
       ).toContain(`old ${clientDir}`);
     }
+    expect(
+      fs.readFileSync(
+        path.join(projectDir, '.installer', 'skills', 'materials', 'SKILL.md'),
+        'utf8'
+      )
+    ).toContain('old source');
   });
 
   test('rejects a download whose declared size exceeds the archive limit', async () => {

--- a/src/maker/cli/commands.ts
+++ b/src/maker/cli/commands.ts
@@ -128,6 +128,7 @@ import {
 } from './dshPluginMigration.js';
 import { writeConfigWithTapTapBackupIfChanged } from './configWrite.js';
 import { syncWorkBuddyProjectSkills } from './workBuddyProjectSkills.js';
+import { pullMakerUserSkills } from './userSkills.js';
 import {
   escapeTomlString,
   findCodexMcpTableDuplicates,
@@ -149,6 +150,7 @@ const TWO_PART_COMMANDS = new Set([
   'lua-lsp',
   'agents',
   'plugin',
+  'user-skills',
 ]);
 const BOOLEAN_OPTIONS = new Set([
   'json',
@@ -345,6 +347,11 @@ export async function runMakerCli(argv: string[]): Promise<void> {
 
   if (command === 'dev-kit' && subcommand === 'update') {
     await runDevKitUpdate(parsed, ctx);
+    return;
+  }
+
+  if (command === 'user-skills' && subcommand === 'pull') {
+    await runUserSkillsPull(parsed, ctx);
     return;
   }
 
@@ -1620,6 +1627,28 @@ async function runDevKitUpdate(parsed: ParsedArgs, ctx: CliContext): Promise<voi
   finalizeStagedDevKitGitignore(targetDir);
   emit(ctx, 'dev_kit', formatDevKitInstallMessage('AI dev kit updated', result), result);
   emitDevKitSkillInstallerFailure(ctx, result.skillInstaller, 'AI skills install failed');
+}
+
+async function runUserSkillsPull(parsed: ParsedArgs, ctx: CliContext): Promise<void> {
+  const result = await pullMakerUserSkills({
+    targetDir: path.resolve(stringOption(parsed, 'target_dir') || process.cwd()),
+    environment: makerEnvOption(parsed),
+  });
+  if (ctx.json) {
+    writeJson(result);
+    return;
+  }
+
+  process.stdout.write(
+    [
+      'Maker user Skills downloaded',
+      `- project: ${result.targetDir}`,
+      `- installed: ${result.installedSkills.length}`,
+      `- preserved: ${result.preservedSkills.length}`,
+      `- source: ${result.sourceDir}`,
+      '',
+    ].join('\n')
+  );
 }
 
 async function runLogsWatch(parsed: ParsedArgs, ctx: CliContext): Promise<void> {
@@ -3043,6 +3072,7 @@ function isKnownSubcommand(command: string, subcommand: string): boolean {
     (command === 'mcp' &&
       (subcommand === 'install' || subcommand === 'verify' || subcommand === 'report')) ||
     (command === 'agents' && subcommand === 'update') ||
+    (command === 'user-skills' && subcommand === 'pull') ||
     command === 'upgrade' ||
     (command === 'dev-kit' && subcommand === 'update') ||
     (command === 'logs' && subcommand === 'watch') ||
@@ -3194,6 +3224,7 @@ function printHelp(): void {
       '  taptap-maker plugin restore --client codex|workbuddy|dsh --confirm [--json]',
       '  taptap-maker upgrade [--launcher self|npx] [--target-dir DIR] [--json]',
       '  taptap-maker dev-kit update [--target-dir DIR] [--json]',
+      '  taptap-maker user-skills pull [--target-dir DIR] [--json]',
       '  taptap-maker logs watch [--target-dir DIR] [--interval 5s] [--reset] [--json]',
       '',
       'MCP install and verify default to a stable self runtime under the Maker home directory.',

--- a/src/maker/cli/userSkills.ts
+++ b/src/maker/cli/userSkills.ts
@@ -1,0 +1,345 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { pipeline } from 'node:stream/promises';
+import yauzl, { type Entry } from 'yauzl';
+
+import { getMakerApiBaseUrl, getMakerEnvironment, type MakerEnvironment } from '../config.js';
+import { DEFAULT_DOWNLOAD_FETCH_TIMEOUT_MS, fetchWithTimeout } from '../fetchTimeout.js';
+import { identifyMakerProject } from '../server/identify.js';
+import { loadJwt, loadPat } from '../storage.js';
+
+const USER_SKILL_CLIENT_DIRS = ['.codex', '.cursor', '.workbuddy'] as const;
+
+export interface PullMakerUserSkillsOptions {
+  targetDir?: string;
+  environment?: MakerEnvironment;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+export interface PullMakerUserSkillsResult {
+  targetDir: string;
+  sourceDir: string;
+  environment: MakerEnvironment;
+  installedSkills: string[];
+  preservedSkills: string[];
+}
+
+export async function pullMakerUserSkills(
+  options: PullMakerUserSkillsOptions = {}
+): Promise<PullMakerUserSkillsResult> {
+  const requestedDir = path.resolve(options.targetDir || process.cwd());
+  const project = identifyMakerProject({ cwd: requestedDir });
+  if (!project.projectRoot) {
+    throw new Error(
+      'Maker project not found. Run this command inside a bound Maker project or pass --target-dir.'
+    );
+  }
+
+  const environment = getMakerEnvironment(options.environment, project.projectRoot);
+  const token = loadPat()?.token || loadJwt()?.token;
+  if (!token) {
+    throw new Error('Maker authentication not found. Run `taptap-maker login` and try again.');
+  }
+
+  const sourceDir = path.join(project.projectRoot, '.installer', 'skills');
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'taptap-maker-user-skills-'));
+  const archivePath = path.join(tempDir, 'user-skills.zip');
+  const stagingDir = path.join(tempDir, 'skills');
+
+  try {
+    const response = await fetchWithTimeout(
+      options.fetchImpl || fetch,
+      `${getMakerApiBaseUrl(environment)}/user/skills/archive`,
+      {
+        method: 'GET',
+        headers: {
+          Accept: 'application/zip',
+          Authorization: `Bearer ${token}`,
+        },
+      },
+      options.timeoutMs ?? DEFAULT_DOWNLOAD_FETCH_TIMEOUT_MS,
+      'Maker user Skill download'
+    );
+    if (!response.ok) {
+      throw createDownloadError(response.status);
+    }
+
+    fs.writeFileSync(archivePath, Buffer.from(await response.arrayBuffer()));
+    const installedSkills = await extractUserSkillsArchive(archivePath, stagingDir);
+    const preservedSkills = listLocalSkills(sourceDir).filter(
+      (name) => !installedSkills.includes(name)
+    );
+    installUserSkills(project.projectRoot, stagingDir, installedSkills);
+    installUserSkillsForClients(project.projectRoot, installedSkills);
+
+    return {
+      targetDir: project.projectRoot,
+      sourceDir,
+      environment,
+      installedSkills,
+      preservedSkills,
+    };
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+export function validateUserSkillArchivePath(entryPath: string): string[] {
+  if (
+    !entryPath ||
+    entryPath.includes('\\') ||
+    entryPath.startsWith('/') ||
+    /^[A-Za-z]:/u.test(entryPath) ||
+    hasControlCharacter(entryPath)
+  ) {
+    throw new Error(`Maker user Skill archive contains an unsafe path: ${entryPath}`);
+  }
+
+  const trimmed = entryPath.endsWith('/') ? entryPath.slice(0, -1) : entryPath;
+  const segments = trimmed.split('/');
+  if (segments.some((segment) => !segment || segment === '.' || segment === '..')) {
+    throw new Error(`Maker user Skill archive contains an unsafe path: ${entryPath}`);
+  }
+  return segments;
+}
+
+async function extractUserSkillsArchive(
+  archivePath: string,
+  stagingDir: string
+): Promise<string[]> {
+  fs.mkdirSync(stagingDir, { recursive: true });
+  const zipFile = await yauzl.openPromise(archivePath, {
+    lazyEntries: true,
+    decodeStrings: true,
+    validateEntrySizes: true,
+    strictFileNames: true,
+  });
+  const skillNames = new Set<string>();
+  const seenPaths = new Set<string>();
+
+  try {
+    for await (const entry of zipFile.eachEntry()) {
+      const segments = validateUserSkillArchivePath(entry.fileName);
+      if (segments.some((segment) => path.basename(segment).startsWith('.nfs'))) {
+        continue;
+      }
+
+      const isDirectory = isZipDirectory(entry);
+      validateZipEntryType(entry, isDirectory);
+      if (!isDirectory && segments.length < 2) {
+        throw new Error(
+          `Maker user Skill archive contains a file outside a Skill: ${entry.fileName}`
+        );
+      }
+
+      const collisionKey = segments.join('/').normalize('NFC').toLocaleLowerCase('en-US');
+      if (seenPaths.has(collisionKey)) {
+        throw new Error(`Maker user Skill archive contains a duplicate path: ${entry.fileName}`);
+      }
+      seenPaths.add(collisionKey);
+      skillNames.add(segments[0]);
+
+      const destination = path.join(stagingDir, ...segments);
+      if (isDirectory) {
+        fs.mkdirSync(destination, { recursive: true });
+        continue;
+      }
+
+      fs.mkdirSync(path.dirname(destination), { recursive: true });
+      const input = await zipFile.openReadStreamPromise(entry);
+      await pipeline(input, fs.createWriteStream(destination, { flags: 'wx' }));
+    }
+  } finally {
+    zipFile.close();
+  }
+
+  const installedSkills = [...skillNames].sort();
+  for (const skillName of installedSkills) {
+    const definitionPath = path.join(stagingDir, skillName, 'SKILL.md');
+    let definition: fs.Stats;
+    try {
+      definition = fs.lstatSync(definitionPath);
+    } catch {
+      throw new Error(`Maker user Skill "${skillName}" is missing SKILL.md.`);
+    }
+    if (!definition.isFile() || definition.isSymbolicLink()) {
+      throw new Error(`Maker user Skill "${skillName}" must contain a regular SKILL.md file.`);
+    }
+  }
+  return installedSkills;
+}
+
+function validateZipEntryType(entry: Entry, isDirectory: boolean): void {
+  if (entry.isEncrypted() || !entry.canDecodeFileData()) {
+    throw new Error(`Maker user Skill archive contains an unsupported entry: ${entry.fileName}`);
+  }
+  if (entry.compressionMethod !== 0 && entry.compressionMethod !== 8) {
+    throw new Error(`Maker user Skill archive contains an unsupported entry: ${entry.fileName}`);
+  }
+
+  const unixMode = (entry.externalFileAttributes >>> 16) & 0xffff;
+  const fileType = unixMode & 0o170000;
+  if (fileType !== 0 && fileType !== 0o100000 && fileType !== 0o040000) {
+    throw new Error(`Maker user Skill archive contains a non-file entry: ${entry.fileName}`);
+  }
+  if (fileType === 0o040000 && !isDirectory) {
+    throw new Error(`Maker user Skill archive contains an invalid directory: ${entry.fileName}`);
+  }
+}
+
+function isZipDirectory(entry: Entry): boolean {
+  const unixMode = (entry.externalFileAttributes >>> 16) & 0xffff;
+  return entry.fileName.endsWith('/') || (unixMode & 0o170000) === 0o040000;
+}
+
+function installUserSkills(projectRoot: string, stagingDir: string, skillNames: string[]): void {
+  if (skillNames.length === 0) {
+    return;
+  }
+
+  const installerDir = path.join(projectRoot, '.installer');
+  const sourceDir = path.join(installerDir, 'skills');
+  const transactionDir = path.join(installerDir, `.user-skills-${randomUUID()}`);
+  const preparedDir = path.join(transactionDir, 'prepared');
+  const backupDir = path.join(transactionDir, 'backup');
+  const completed: Array<{ target: string; backup: string; hadExisting: boolean }> = [];
+  fs.mkdirSync(preparedDir, { recursive: true });
+  fs.mkdirSync(sourceDir, { recursive: true });
+
+  try {
+    for (const skillName of skillNames) {
+      fs.cpSync(path.join(stagingDir, skillName), path.join(preparedDir, skillName), {
+        recursive: true,
+      });
+    }
+
+    for (const skillName of skillNames) {
+      const target = path.join(sourceDir, skillName);
+      const backup = path.join(backupDir, skillName);
+      const hadExisting = pathExists(target);
+      if (hadExisting) {
+        fs.mkdirSync(path.dirname(backup), { recursive: true });
+        fs.renameSync(target, backup);
+      }
+      try {
+        fs.renameSync(path.join(preparedDir, skillName), target);
+        completed.push({ target, backup, hadExisting });
+      } catch (error) {
+        if (hadExisting && pathExists(backup) && !pathExists(target)) {
+          fs.renameSync(backup, target);
+        }
+        throw error;
+      }
+    }
+  } catch (error) {
+    for (const item of completed.reverse()) {
+      fs.rmSync(item.target, { recursive: true, force: true });
+      if (item.hadExisting && pathExists(item.backup)) {
+        fs.renameSync(item.backup, item.target);
+      }
+    }
+    throw new Error(`Failed to install Maker user Skills: ${formatError(error)}`);
+  } finally {
+    fs.rmSync(transactionDir, { recursive: true, force: true });
+  }
+}
+
+function installUserSkillsForClients(projectRoot: string, skillNames: string[]): void {
+  if (skillNames.length === 0) {
+    return;
+  }
+
+  const sourceRoot = path.join(projectRoot, '.installer', 'skills');
+  try {
+    for (const clientDir of USER_SKILL_CLIENT_DIRS) {
+      const targetRoot = path.join(projectRoot, clientDir, 'skills');
+      fs.mkdirSync(targetRoot, { recursive: true });
+
+      for (const skillName of skillNames) {
+        const source = path.join(sourceRoot, skillName);
+        const target = path.join(targetRoot, skillName);
+        removePathEntry(target);
+        linkOrCopySkill(source, target);
+      }
+    }
+  } catch (error) {
+    throw new Error(`Failed to install Maker user Skills for AI clients: ${formatError(error)}`);
+  }
+}
+
+function linkOrCopySkill(source: string, target: string): void {
+  try {
+    const linkTarget =
+      process.platform === 'win32' ? source : path.relative(path.dirname(target), source);
+    fs.symlinkSync(linkTarget, target, process.platform === 'win32' ? 'junction' : 'dir');
+  } catch (linkError) {
+    removePathEntry(target);
+    try {
+      fs.cpSync(source, target, { recursive: true });
+    } catch (copyError) {
+      throw new Error(
+        `Failed to link ${source}: ${formatError(linkError)}; copy fallback: ${formatError(copyError)}`
+      );
+    }
+  }
+}
+
+function removePathEntry(value: string): void {
+  try {
+    const stat = fs.lstatSync(value);
+    if (stat.isSymbolicLink()) {
+      fs.unlinkSync(value);
+      return;
+    }
+    fs.rmSync(value, { recursive: true, force: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+  }
+}
+
+function listLocalSkills(sourceDir: string): string[] {
+  try {
+    return fs
+      .readdirSync(sourceDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+function createDownloadError(status: number): Error {
+  if (status === 401 || status === 403) {
+    return new Error('Maker authentication was rejected. Run `taptap-maker login` and try again.');
+  }
+  if (status === 413) {
+    return new Error('Maker user Skill archive is too large to download.');
+  }
+  return new Error(`Maker user Skill download failed with HTTP ${status}.`);
+}
+
+function pathExists(value: string): boolean {
+  try {
+    fs.lstatSync(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function hasControlCharacter(value: string): boolean {
+  return [...value].some((character) => {
+    const code = character.charCodeAt(0);
+    return code <= 0x1f || code === 0x7f;
+  });
+}

--- a/src/maker/cli/userSkills.ts
+++ b/src/maker/cli/userSkills.ts
@@ -77,7 +77,6 @@ export async function pullMakerUserSkills(
       (name) => !installedSkills.includes(name)
     );
     installUserSkills(project.projectRoot, stagingDir, installedSkills);
-    installUserSkillsForClients(project.projectRoot, installedSkills);
 
     return {
       targetDir: project.projectRoot,
@@ -280,6 +279,8 @@ function installUserSkills(projectRoot: string, stagingDir: string, skillNames: 
         throw error;
       }
     }
+
+    installUserSkillsForClients(projectRoot, skillNames);
   } catch (error) {
     for (const item of completed.reverse()) {
       fs.rmSync(item.target, { recursive: true, force: true });

--- a/src/maker/cli/userSkills.ts
+++ b/src/maker/cli/userSkills.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
+import { Readable, Transform } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import yauzl, { type Entry } from 'yauzl';
 
@@ -11,6 +12,9 @@ import { identifyMakerProject } from '../server/identify.js';
 import { loadJwt, loadPat } from '../storage.js';
 
 const USER_SKILL_CLIENT_DIRS = ['.codex', '.cursor', '.workbuddy'] as const;
+const MAX_ARCHIVE_DOWNLOAD_BYTES = 64 * 1024 * 1024;
+const MAX_ARCHIVE_ENTRIES = 1000;
+const MAX_ARCHIVE_EXTRACTED_BYTES = 128 * 1024 * 1024;
 
 export interface PullMakerUserSkillsOptions {
   targetDir?: string;
@@ -67,7 +71,7 @@ export async function pullMakerUserSkills(
       throw createDownloadError(response.status);
     }
 
-    fs.writeFileSync(archivePath, Buffer.from(await response.arrayBuffer()));
+    await writeArchiveResponse(response, archivePath);
     const installedSkills = await extractUserSkillsArchive(archivePath, stagingDir);
     const preservedSkills = listLocalSkills(sourceDir).filter(
       (name) => !installedSkills.includes(name)
@@ -85,6 +89,33 @@ export async function pullMakerUserSkills(
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
+}
+
+async function writeArchiveResponse(response: Response, archivePath: string): Promise<void> {
+  const declaredSize = Number(response.headers.get('content-length'));
+  if (Number.isFinite(declaredSize) && declaredSize > MAX_ARCHIVE_DOWNLOAD_BYTES) {
+    throw new Error('Maker user Skill archive exceeds the 64 MiB download limit.');
+  }
+  if (!response.body) {
+    throw new Error('Maker user Skill download returned an empty response body.');
+  }
+
+  let downloadedBytes = 0;
+  const limit = new Transform({
+    transform(chunk: Buffer, _encoding, callback) {
+      downloadedBytes += chunk.length;
+      if (downloadedBytes > MAX_ARCHIVE_DOWNLOAD_BYTES) {
+        callback(new Error('Maker user Skill archive exceeds the 64 MiB download limit.'));
+        return;
+      }
+      callback(null, chunk);
+    },
+  });
+  await pipeline(
+    Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]),
+    limit,
+    fs.createWriteStream(archivePath, { flags: 'wx' })
+  );
 }
 
 export function validateUserSkillArchivePath(entryPath: string): string[] {
@@ -119,9 +150,18 @@ async function extractUserSkillsArchive(
   });
   const skillNames = new Set<string>();
   const seenPaths = new Set<string>();
+  let entryCount = 0;
+  let extractedBytes = 0;
 
   try {
     for await (const entry of zipFile.eachEntry()) {
+      entryCount += 1;
+      if (entryCount > MAX_ARCHIVE_ENTRIES) {
+        throw new Error(
+          `Maker user Skill archive exceeds the ${MAX_ARCHIVE_ENTRIES} entries limit.`
+        );
+      }
+
       const segments = validateUserSkillArchivePath(entry.fileName);
       if (segments.some((segment) => path.basename(segment).startsWith('.nfs'))) {
         continue;
@@ -133,6 +173,12 @@ async function extractUserSkillsArchive(
         throw new Error(
           `Maker user Skill archive contains a file outside a Skill: ${entry.fileName}`
         );
+      }
+      if (!isDirectory) {
+        extractedBytes += entry.uncompressedSize;
+        if (extractedBytes > MAX_ARCHIVE_EXTRACTED_BYTES) {
+          throw new Error('Maker user Skill archive exceeds the 128 MiB extracted size limit.');
+        }
       }
 
       const collisionKey = segments.join('/').normalize('NFC').toLocaleLowerCase('en-US');
@@ -253,6 +299,13 @@ function installUserSkillsForClients(projectRoot: string, skillNames: string[]):
   }
 
   const sourceRoot = path.join(projectRoot, '.installer', 'skills');
+  const transactionDir = path.join(
+    projectRoot,
+    '.installer',
+    `.user-skill-clients-${randomUUID()}`
+  );
+  const backupRoot = path.join(transactionDir, 'backup');
+  const changed: Array<{ target: string; backup: string; hadExisting: boolean }> = [];
   try {
     for (const clientDir of USER_SKILL_CLIENT_DIRS) {
       const targetRoot = path.join(projectRoot, clientDir, 'skills');
@@ -261,12 +314,26 @@ function installUserSkillsForClients(projectRoot: string, skillNames: string[]):
       for (const skillName of skillNames) {
         const source = path.join(sourceRoot, skillName);
         const target = path.join(targetRoot, skillName);
-        removePathEntry(target);
+        const backup = path.join(backupRoot, clientDir, skillName);
+        const hadExisting = pathExists(target);
+        if (hadExisting) {
+          fs.mkdirSync(path.dirname(backup), { recursive: true });
+          fs.renameSync(target, backup);
+        }
+        changed.push({ target, backup, hadExisting });
         linkOrCopySkill(source, target);
       }
     }
   } catch (error) {
+    for (const item of changed.reverse()) {
+      removePathEntry(item.target);
+      if (item.hadExisting && pathExists(item.backup)) {
+        fs.renameSync(item.backup, item.target);
+      }
+    }
     throw new Error(`Failed to install Maker user Skills for AI clients: ${formatError(error)}`);
+  } finally {
+    fs.rmSync(transactionDir, { recursive: true, force: true });
   }
 }
 

--- a/src/maker/cli/userSkills.ts
+++ b/src/maker/cli/userSkills.ts
@@ -16,6 +16,12 @@ const MAX_ARCHIVE_DOWNLOAD_BYTES = 64 * 1024 * 1024;
 const MAX_ARCHIVE_ENTRIES = 1000;
 const MAX_ARCHIVE_EXTRACTED_BYTES = 128 * 1024 * 1024;
 
+interface SkillInstallChange {
+  target: string;
+  backup: string;
+  hadExisting: boolean;
+}
+
 export interface PullMakerUserSkillsOptions {
   targetDir?: string;
   environment?: MakerEnvironment;
@@ -250,7 +256,8 @@ function installUserSkills(projectRoot: string, stagingDir: string, skillNames: 
   const transactionDir = path.join(installerDir, `.user-skills-${randomUUID()}`);
   const preparedDir = path.join(transactionDir, 'prepared');
   const backupDir = path.join(transactionDir, 'backup');
-  const completed: Array<{ target: string; backup: string; hadExisting: boolean }> = [];
+  const completed: SkillInstallChange[] = [];
+  let preserveTransaction = false;
   fs.mkdirSync(preparedDir, { recursive: true });
   fs.mkdirSync(sourceDir, { recursive: true });
 
@@ -269,28 +276,25 @@ function installUserSkills(projectRoot: string, stagingDir: string, skillNames: 
         fs.mkdirSync(path.dirname(backup), { recursive: true });
         fs.renameSync(target, backup);
       }
-      try {
-        fs.renameSync(path.join(preparedDir, skillName), target);
-        completed.push({ target, backup, hadExisting });
-      } catch (error) {
-        if (hadExisting && pathExists(backup) && !pathExists(target)) {
-          fs.renameSync(backup, target);
-        }
-        throw error;
-      }
+      completed.push({ target, backup, hadExisting });
+      fs.renameSync(path.join(preparedDir, skillName), target);
     }
 
     installUserSkillsForClients(projectRoot, skillNames);
   } catch (error) {
-    for (const item of completed.reverse()) {
-      fs.rmSync(item.target, { recursive: true, force: true });
-      if (item.hadExisting && pathExists(item.backup)) {
-        fs.renameSync(item.backup, item.target);
-      }
+    const rollbackErrors = rollbackSkillChanges(completed);
+    if (rollbackErrors.length > 0) {
+      preserveTransaction = true;
+      throw new Error(
+        `Failed to install Maker user Skills: ${formatError(error)}; rollback incomplete, ` +
+          `backups were preserved at ${transactionDir}: ${rollbackErrors.join('; ')}`
+      );
     }
     throw new Error(`Failed to install Maker user Skills: ${formatError(error)}`);
   } finally {
-    fs.rmSync(transactionDir, { recursive: true, force: true });
+    if (!preserveTransaction) {
+      fs.rmSync(transactionDir, { recursive: true, force: true });
+    }
   }
 }
 
@@ -306,7 +310,8 @@ function installUserSkillsForClients(projectRoot: string, skillNames: string[]):
     `.user-skill-clients-${randomUUID()}`
   );
   const backupRoot = path.join(transactionDir, 'backup');
-  const changed: Array<{ target: string; backup: string; hadExisting: boolean }> = [];
+  const changed: SkillInstallChange[] = [];
+  let preserveTransaction = false;
   try {
     for (const clientDir of USER_SKILL_CLIENT_DIRS) {
       const targetRoot = path.join(projectRoot, clientDir, 'skills');
@@ -326,16 +331,37 @@ function installUserSkillsForClients(projectRoot: string, skillNames: string[]):
       }
     }
   } catch (error) {
-    for (const item of changed.reverse()) {
+    const rollbackErrors = rollbackSkillChanges(changed);
+    if (rollbackErrors.length > 0) {
+      preserveTransaction = true;
+      throw new Error(
+        `Failed to install Maker user Skills for AI clients: ${formatError(error)}; ` +
+          `rollback incomplete, backups were preserved at ${transactionDir}: ` +
+          rollbackErrors.join('; ')
+      );
+    }
+    throw new Error(`Failed to install Maker user Skills for AI clients: ${formatError(error)}`);
+  } finally {
+    if (!preserveTransaction) {
+      fs.rmSync(transactionDir, { recursive: true, force: true });
+    }
+  }
+}
+
+function rollbackSkillChanges(changes: SkillInstallChange[]): string[] {
+  const errors: string[] = [];
+  for (let index = changes.length - 1; index >= 0; index -= 1) {
+    const item = changes[index];
+    try {
       removePathEntry(item.target);
       if (item.hadExisting && pathExists(item.backup)) {
         fs.renameSync(item.backup, item.target);
       }
+    } catch (error) {
+      errors.push(`${item.target}: ${formatError(error)}`);
     }
-    throw new Error(`Failed to install Maker user Skills for AI clients: ${formatError(error)}`);
-  } finally {
-    fs.rmSync(transactionDir, { recursive: true, force: true });
   }
+  return errors;
 }
 
 function linkOrCopySkill(source: string, target: string): void {

--- a/src/maker/index.ts
+++ b/src/maker/index.ts
@@ -97,6 +97,7 @@ function printHelp(): void {
       '  taptap-maker plugin restore --client codex|workbuddy --confirm [--json]',
       '  taptap-maker upgrade [--launcher self|npx] [--target-dir DIR] [--json]',
       '  taptap-maker dev-kit update [--target-dir DIR] [--json]',
+      '  taptap-maker user-skills pull [--target-dir DIR] [--json]',
       '  taptap-maker logs watch [--target-dir DIR] [--interval 5s] [--reset] [--json]',
       '',
       'MCP install and verify default to a stable self runtime under the Maker home directory.',


### PR DESCRIPTION
## 改动内容
- 新增 `taptap-maker user-skills pull`，按需从 Maker Server 下载个人 Skill ZIP
- 使用 bundled `yauzl` 完成跨平台解压和安全校验
- 以 `.installer/skills` 为统一源目录，安装到项目内 Codex、Cursor 和 WorkBuddy
- 只覆盖归档中出现的同名 Skill，保留其它本地 Skill

## 影响面
- 仅用户明确运行命令时访问新增接口
- 不接入 `init`、`doctor`、`upgrade` 或 MCP 启动流程
- 不新增 MCP tool；服务端接口未发布时不影响其它 Maker MCP 能力

## 验证
- `npm run format:check`
- `npm run lint`
- `npm test -- --runInBand`（64 suites，931 tests）
- `npm run build -- --skip-server --skip-proxy`
- RND 项目实拉并验证 `.codex`、`.cursor`、`.workbuddy` 安装结果
- 不可达 API 地址下 MCP `initialize` 和 `tools/list` 验证通过