### PR TITLE
fix(h5): 避免短时缓存竞争误报应用状态

### DIFF
--- a/src/__tests__/appCacheMutation.test.ts
+++ b/src/__tests__/appCacheMutation.test.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { spawn } from 'node:child_process';
 import {
   clearAppCache,
   getCachePath,
@@ -46,18 +47,56 @@ describe('app cache mutation recovery', () => {
     expect(fs.existsSync(cachePath)).toBe(false);
   });
 
-  test('readAppCache returns null promptly when another process holds the cache lock', () => {
+  test('readAppCache waits for a short mutation and returns the committed cache', async () => {
     const cacheKey = `/tmp/taptap-cache-mutation-locked-${Date.now()}-${Math.random()}`;
     const cachePath = getCachePath(cacheKey);
     const cacheDir = path.dirname(cachePath);
+    const lockPath = `${cachePath}.lock`;
     cacheDirs.push(cacheDir);
-    fs.mkdirSync(`${cachePath}.lock`, { recursive: true });
+    saveAppCache({ developer_id: 100, app_id: 200 }, cacheKey);
+
+    const holder = spawn(
+      process.execPath,
+      [
+        '-e',
+        `
+          const fs = require('node:fs');
+          const path = require('node:path');
+          const lockPath = process.argv[1];
+          fs.mkdirSync(lockPath, { recursive: true });
+          const ownerPath = path.join(lockPath, 'test-owner');
+          const ownerFd = fs.openSync(ownerPath, 'wx');
+          fs.writeFileSync(ownerFd, JSON.stringify({ pid: process.pid, holds_open: true }), 'utf8');
+          process.stdout.write('ready\\n');
+          setTimeout(() => {
+            fs.closeSync(ownerFd);
+            try { fs.unlinkSync(ownerPath); } catch (error) {
+              if (error.code !== 'ENOENT') throw error;
+            }
+            try { fs.rmdirSync(lockPath); } catch (error) {
+              if (error.code !== 'ENOENT') throw error;
+            }
+          }, 250);
+        `,
+        lockPath,
+      ],
+      { stdio: ['ignore', 'pipe', 'inherit'] }
+    );
+    await new Promise<void>((resolve, reject) => {
+      holder.once('error', reject);
+      holder.stdout.once('data', () => resolve());
+    });
 
     const startedAt = Date.now();
     const cached = readAppCache(cacheKey);
 
-    expect(cached).toBeNull();
+    expect(cached).toEqual(expect.objectContaining({ developer_id: 100, app_id: 200 }));
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(100);
     expect(Date.now() - startedAt).toBeLessThan(1000);
+    await new Promise<void>((resolve, reject) => {
+      holder.once('error', reject);
+      holder.once('exit', (code) => (code === 0 ? resolve() : reject(new Error(`exit ${code}`))));
+    });
   });
 
   test('saveAppCache recovers a lock left by a dead process', () => {

--- a/src/__tests__/appCacheMutation.test.ts
+++ b/src/__tests__/appCacheMutation.test.ts
@@ -63,22 +63,25 @@ describe('app cache mutation recovery', () => {
           const fs = require('node:fs');
           const path = require('node:path');
           const lockPath = process.argv[1];
+          const cachePath = process.argv[2];
           fs.mkdirSync(lockPath, { recursive: true });
           const ownerPath = path.join(lockPath, 'test-owner');
           const ownerFd = fs.openSync(ownerPath, 'wx');
           fs.writeFileSync(ownerFd, JSON.stringify({ pid: process.pid, holds_open: true }), 'utf8');
-          process.stdout.write('ready\\n');
-          setTimeout(() => {
-            fs.closeSync(ownerFd);
-            try { fs.unlinkSync(ownerPath); } catch (error) {
-              if (error.code !== 'ENOENT') throw error;
-            }
-            try { fs.rmdirSync(lockPath); } catch (error) {
-              if (error.code !== 'ENOENT') throw error;
-            }
-          }, 250);
+          fs.writeSync(1, 'ready\\n');
+          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 150);
+          const cache = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+          fs.writeFileSync(cachePath, JSON.stringify({ ...cache, app_id: 201 }, null, 2), 'utf8');
+          fs.closeSync(ownerFd);
+          try { fs.unlinkSync(ownerPath); } catch (error) {
+            if (error.code !== 'ENOENT') throw error;
+          }
+          try { fs.rmdirSync(lockPath); } catch (error) {
+            if (error.code !== 'ENOENT') throw error;
+          }
         `,
         lockPath,
+        cachePath,
       ],
       { stdio: ['ignore', 'pipe', 'inherit'] }
     );
@@ -98,12 +101,9 @@ describe('app cache mutation recovery', () => {
         }),
       ]);
 
-      const startedAt = Date.now();
       const cached = readAppCache(cacheKey);
 
-      expect(cached).toEqual(expect.objectContaining({ developer_id: 100, app_id: 200 }));
-      expect(Date.now() - startedAt).toBeGreaterThanOrEqual(100);
-      expect(Date.now() - startedAt).toBeLessThan(1000);
+      expect(cached).toEqual(expect.objectContaining({ developer_id: 100, app_id: 201 }));
     } finally {
       await holderExited;
     }

--- a/src/__tests__/appCacheMutation.test.ts
+++ b/src/__tests__/appCacheMutation.test.ts
@@ -82,21 +82,31 @@ describe('app cache mutation recovery', () => {
       ],
       { stdio: ['ignore', 'pipe', 'inherit'] }
     );
-    await new Promise<void>((resolve, reject) => {
-      holder.once('error', reject);
-      holder.stdout.once('data', () => resolve());
-    });
-
-    const startedAt = Date.now();
-    const cached = readAppCache(cacheKey);
-
-    expect(cached).toEqual(expect.objectContaining({ developer_id: 100, app_id: 200 }));
-    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(100);
-    expect(Date.now() - startedAt).toBeLessThan(1000);
-    await new Promise<void>((resolve, reject) => {
+    const holderExited = new Promise<void>((resolve, reject) => {
       holder.once('error', reject);
       holder.once('exit', (code) => (code === 0 ? resolve() : reject(new Error(`exit ${code}`))));
     });
+    const holderReady = new Promise<void>((resolve) => {
+      holder.stdout.once('data', () => resolve());
+    });
+
+    try {
+      await Promise.race([
+        holderReady,
+        holderExited.then(() => {
+          throw new Error('cache lock holder exited before signaling ready');
+        }),
+      ]);
+
+      const startedAt = Date.now();
+      const cached = readAppCache(cacheKey);
+
+      expect(cached).toEqual(expect.objectContaining({ developer_id: 100, app_id: 200 }));
+      expect(Date.now() - startedAt).toBeGreaterThanOrEqual(100);
+      expect(Date.now() - startedAt).toBeLessThan(1000);
+    } finally {
+      await holderExited;
+    }
   });
 
   test('saveAppCache recovers a lock left by a dead process', () => {

--- a/src/__tests__/appCacheMutation.test.ts
+++ b/src/__tests__/appCacheMutation.test.ts
@@ -77,7 +77,7 @@ describe('app cache mutation recovery', () => {
             if (error.code !== 'ENOENT') throw error;
           }
           try { fs.rmdirSync(lockPath); } catch (error) {
-            if (error.code !== 'ENOENT') throw error;
+            if (error.code !== 'ENOENT' && error.code !== 'ENOTEMPTY') throw error;
           }
         `,
         lockPath,

--- a/src/core/utils/cache.ts
+++ b/src/core/utils/cache.ts
@@ -24,7 +24,7 @@ import { EnvConfig } from './env.js';
  */
 const CACHE_ROOT = EnvConfig.cacheDir;
 const CACHE_LOCK_RETRY_MS = 10;
-const CACHE_READ_LOCK_TIMEOUT_MS = 100;
+const CACHE_READ_LOCK_TIMEOUT_MS = 500;
 const CACHE_LOCK_TIMEOUT_MS = 5000;
 const CACHE_LOCK_STALE_MS = 30000;
 const CACHE_LOCK_WAIT_BUFFER = new Int32Array(new SharedArrayBuffer(4));


### PR DESCRIPTION
## 改动内容
- 将应用缓存读取等待从 100ms 调整为 500ms，覆盖正常短同步写事务
- 保持写锁、缓存格式、PID 复用和残留锁恢复策略不变
- 新增真实子进程持锁测试，验证读取等待后返回已提交缓存

## 影响面
- 仅影响小游戏/H5 MCP 的应用缓存读取竞争路径
- `src/maker`、Maker npm、Maker 插件和 DSH 均无代码或依赖变更

## 验证
- `npm test -- --runInBand`：66 个测试套件、965 项测试通过
- `npm run build`：通过
- `npm run lint`：通过
- `npm run format:check`：通过
- 三视角最终审查：Clean

## 发布说明
- 本 PR 合并前不会触发任何 npm 发布
- 合并后仅手动触发 `Manual Main Package Release` 发布主包 patch 版本