### PR TITLE
fix(release): isolate and stabilize main native artifacts

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -54,7 +54,7 @@ jobs:
               export PATH="$HOME/.cargo/bin:$PATH"
               echo "cargo version: $(cargo --version)"
               cd native
-              npm run build
+              npm run build -- --target x86_64-apple-darwin
               strip -x *.node
 
           # macOS Apple Silicon (ARM64)
@@ -98,11 +98,14 @@ jobs:
             artifact: taptap-signer.linux-arm64-musl.node
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
             build: |
+              set -euo pipefail
               # 安装 zig 用于交叉编译
               apk add --no-cache zig
-              # 更新 Rust 并添加 ARM64 target
-              rustup update stable && rustup default stable
-              rustup target add aarch64-unknown-linux-musl
+              # Rust 1.98 新增的链接参数尚不受当前 Zig 工具链支持。
+              rustup toolchain install 1.97.0 --profile minimal --target aarch64-unknown-linux-musl
+              export RUSTUP_TOOLCHAIN=1.97.0
+              rustc --version
+              zig version
               cd native
               # 使用 zig 作为链接器进行交叉编译
               npm run build -- --target aarch64-unknown-linux-musl --zig

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,19 +144,18 @@ jobs:
       - name: Check native changes
         id: native_check
         run: |
-          # 获取上次发布的 tag
-          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          MAIN_RELEASE_TAG="v${{ steps.version.outputs.current_version }}"
 
-          echo "Last tag: $LAST_TAG"
+          echo "Current main package release tag: $MAIN_RELEASE_TAG"
 
-          if [ -z "$LAST_TAG" ]; then
-            echo "No previous tag found, need to build native"
+          if ! git rev-parse "refs/tags/$MAIN_RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Main package tag $MAIN_RELEASE_TAG not found, need to build native"
             echo "changed=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
           # 检查 native/ 目录是否有变更（包括 Cargo.toml, Cargo.lock, src/, build.rs）
-          CHANGED_FILES=$(git diff --name-only "$LAST_TAG" HEAD -- \
+          CHANGED_FILES=$(git diff --name-only "$MAIN_RELEASE_TAG" HEAD -- \
             native/Cargo.toml \
             native/Cargo.lock \
             native/src/ \
@@ -169,7 +168,7 @@ jobs:
             echo "$CHANGED_FILES"
             echo "changed=true" >> $GITHUB_OUTPUT
           else
-            echo "No native files changed since $LAST_TAG"
+            echo "No native files changed since $MAIN_RELEASE_TAG"
             echo "changed=false" >> $GITHUB_OUTPUT
           fi
 
@@ -186,24 +185,37 @@ jobs:
             exit 0
           fi
 
-          # 获取最新 Release
-          LATEST_RELEASE=$(gh release list --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null || echo "")
+          MAIN_RELEASE_TAG="v${{ steps.version.outputs.current_version }}"
 
-          if [ -z "$LATEST_RELEASE" ]; then
-            echo "No existing release found, need to build native"
+          if ! gh release view "$MAIN_RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Main package release $MAIN_RELEASE_TAG not found, need to build native"
             echo "has_assets=false" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          # 检查是否有 native binaries
-          ASSETS=$(gh release view "$LATEST_RELEASE" --json assets --jq '.assets[].name' 2>/dev/null | grep "\.node$" || echo "")
+          REQUIRED_NATIVE_ASSETS=(
+            taptap-signer.darwin-x64.node
+            taptap-signer.darwin-arm64.node
+            taptap-signer.linux-x64-gnu.node
+            taptap-signer.linux-x64-musl.node
+            taptap-signer.linux-arm64-musl.node
+            taptap-signer.win32-x64-msvc.node
+          )
+          ASSETS=$(gh release view "$MAIN_RELEASE_TAG" --json assets --jq '.assets[].name')
+          MISSING_ASSETS=()
 
-          if [ -z "$ASSETS" ]; then
-            echo "No native binaries in release $LATEST_RELEASE, need to build"
+          for asset in "${REQUIRED_NATIVE_ASSETS[@]}"; do
+            if ! grep -Fxq "$asset" <<< "$ASSETS"; then
+              MISSING_ASSETS+=("$asset")
+            fi
+          done
+
+          if [ "${#MISSING_ASSETS[@]}" -gt 0 ]; then
+            echo "Release $MAIN_RELEASE_TAG is missing required native binaries:"
+            printf '  - %s\n' "${MISSING_ASSETS[@]}"
             echo "has_assets=false" >> $GITHUB_OUTPUT
           else
-            echo "Found native binaries in $LATEST_RELEASE:"
-            echo "$ASSETS"
+            echo "Found all required native binaries in $MAIN_RELEASE_TAG"
             echo "has_assets=true" >> $GITHUB_OUTPUT
           fi
 
@@ -242,7 +254,7 @@ jobs:
               export PATH="$HOME/.cargo/bin:$PATH"
               echo "cargo version: $(cargo --version)"
               cd native
-              npm run build
+              npm run build -- --target x86_64-apple-darwin
               strip -x *.node
 
           # macOS Apple Silicon (ARM64)
@@ -280,11 +292,14 @@ jobs:
             target: aarch64-unknown-linux-musl
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
             build: |
+              set -euo pipefail
               # 安装 zig 用于交叉编译
               apk add --no-cache zig
-              # 更新 Rust 并添加 ARM64 target
-              rustup update stable && rustup default stable
-              rustup target add aarch64-unknown-linux-musl
+              # Rust 1.98 新增的链接参数尚不受当前 Zig 工具链支持。
+              rustup toolchain install 1.97.0 --profile minimal --target aarch64-unknown-linux-musl
+              export RUSTUP_TOOLCHAIN=1.97.0
+              rustc --version
+              zig version
               cd native
               # 使用 zig 作为链接器进行交叉编译
               npm run build -- --target aarch64-unknown-linux-musl --zig
@@ -377,18 +392,17 @@ jobs:
       needs.analyze.outputs.has_native_assets == 'true'
 
     steps:
-      - name: Download native binaries from latest release
+      - name: Download native binaries from main package release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir -p native
 
-          # 获取最新 Release
-          LATEST_RELEASE=$(gh release list --repo ${{ github.repository }} --limit 1 --json tagName --jq '.[0].tagName')
-          echo "Downloading native binaries from release: $LATEST_RELEASE"
+          MAIN_RELEASE_TAG="v${{ needs.analyze.outputs.current_version }}"
+          echo "Downloading native binaries from release: $MAIN_RELEASE_TAG"
 
           # 下载所有 .node 文件
-          gh release download "$LATEST_RELEASE" \
+          gh release download "$MAIN_RELEASE_TAG" \
             --repo ${{ github.repository }} \
             --pattern "*.node" \
             --dir native/
@@ -593,6 +607,7 @@ jobs:
           cp release-notes.md "$RUNNER_TEMP/main-release-notes.md"
         env:
           RELEASE_VERSION: ${{ steps.release_version.outputs.version }}
+          LAST_RELEASE_TAG: v${{ needs.analyze.outputs.current_version }}
 
       - name: Verify package contents before publish
         run: |
@@ -730,6 +745,7 @@ jobs:
           PR_URL="${{ steps.pr.outputs.pr_url || steps.release_pr.outputs.url }}"
           PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
           STATE="${{ steps.release_pr.outputs.state }}"
+          INITIAL_PR_STATE="${{ steps.release_pr.outputs.state }}"
 
           # 等待 PR 合并（auto-merge 是异步的）
           if [ "$STATE" != "MERGED" ]; then
@@ -755,12 +771,26 @@ jobs:
           fi
 
           echo "state=${STATE}" >> "$GITHUB_OUTPUT"
-          MERGE_COMMIT=$(gh pr view "$PR_NUMBER" --json mergeCommit --jq '.mergeCommit.oid // ""')
-          if [ -z "$MERGE_COMMIT" ]; then
-            echo "Release PR #${PR_NUMBER} is merged but merge commit is unavailable"
+          PR_COMMITS=$(gh pr view "$PR_NUMBER" \
+            --json mergeCommit,headRefOid \
+            --jq '[(.mergeCommit.oid // ""), (.headRefOid // "")] | @tsv')
+          IFS=$'\t' read -r MERGE_COMMIT PR_HEAD_COMMIT <<< "$PR_COMMITS"
+
+          if [ -z "$MERGE_COMMIT" ] || [ -z "$PR_HEAD_COMMIT" ]; then
+            echo "Release PR #${PR_NUMBER} commit information is unavailable"
             exit 1
           fi
+
+          if [ "$INITIAL_PR_STATE" = "MERGED" ]; then
+            RELEASE_COMMIT="$MERGE_COMMIT"
+          else
+            RELEASE_COMMIT="$PR_HEAD_COMMIT"
+          fi
+
           echo "merge_commit=${MERGE_COMMIT}" >> "$GITHUB_OUTPUT"
+          echo "release_commit=${RELEASE_COMMIT}" >> "$GITHUB_OUTPUT"
+          echo "pr_head_commit=${PR_HEAD_COMMIT}" >> "$GITHUB_OUTPUT"
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
 
       - name: Generate final release app token
         id: final-app-token
@@ -777,33 +807,71 @@ jobs:
           GH_TOKEN: ${{ steps.final-app-token.outputs.token }}
         run: |
           VERSION=${{ steps.release_version.outputs.version }}
+          PR_NUMBER=${{ steps.wait_for_merge.outputs.pr_number }}
+          RELEASE_COMMIT=${{ steps.wait_for_merge.outputs.release_commit }}
+          PR_HEAD_COMMIT=${{ steps.wait_for_merge.outputs.pr_head_commit }}
           MERGE_COMMIT=${{ steps.wait_for_merge.outputs.merge_commit }}
+          WORKFLOW_COMMIT=${{ github.sha }}
+          SOURCE_COMMIT="$RELEASE_COMMIT"
 
-          # PR 已合并，检出该 release PR 的 merge commit，避免 main 后续推进影响 tag 目标。
+          # PR 已合并，重新获取 PR head 与 main，确保 tag 目标仍可验证。
           GIT_AUTH_HEADER=$(printf "x-access-token:%s" "$GH_TOKEN" | base64 | tr -d '\n')
           echo "::add-mask::${GIT_AUTH_HEADER}"
           git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic ${GIT_AUTH_HEADER}"
           git fetch origin main
-          git checkout -B main "$MERGE_COMMIT"
+          git fetch origin "refs/pull/${PR_NUMBER}/head"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           test -s "$RUNNER_TEMP/main-release-notes.md"
 
-          # 在 main 最新 commit 上创建 tag（即 squash merge 后的 release commit）
+          TAG_EXISTS=false
           if git ls-remote --exit-code --tags origin "v${VERSION}" >/dev/null 2>&1; then
             git fetch --force origin "refs/tags/v${VERSION}:refs/tags/v${VERSION}"
             TAG_TARGET=$(git rev-list -n 1 "v${VERSION}")
-            MAIN_TARGET=$(git rev-parse HEAD)
 
-            if [ "$TAG_TARGET" != "$MAIN_TARGET" ]; then
-              echo "Existing tag v${VERSION} points to ${TAG_TARGET}, expected ${MAIN_TARGET}"
+            if [ "$TAG_TARGET" != "$PR_HEAD_COMMIT" ] && [ "$TAG_TARGET" != "$MERGE_COMMIT" ]; then
+              echo "Existing tag v${VERSION} points to unexpected commit ${TAG_TARGET}"
               exit 1
             fi
 
+            SOURCE_COMMIT="$TAG_TARGET"
+            TAG_EXISTS=true
+          fi
+
+          if ! git cat-file -e "${SOURCE_COMMIT}^{commit}"; then
+            echo "Release source commit ${SOURCE_COMMIT} is unavailable"
+            exit 1
+          fi
+
+          if ! git diff --quiet "$WORKFLOW_COMMIT" "$SOURCE_COMMIT" -- \
+            native/Cargo.toml \
+            native/Cargo.lock \
+            native/src/ \
+            native/build.rs \
+            native/package.json; then
+            echo "Native source changed after workflow dispatch:"
+            git diff --name-only "$WORKFLOW_COMMIT" "$SOURCE_COMMIT" -- \
+              native/Cargo.toml \
+              native/Cargo.lock \
+              native/src/ \
+              native/build.rs \
+              native/package.json
+            exit 1
+          fi
+
+          git show "${SOURCE_COMMIT}:package.json" > "$RUNNER_TEMP/release-package.json"
+          PACKAGE_VERSION=$(node -p "require(process.argv[1]).version" "$RUNNER_TEMP/release-package.json")
+          if [ "$PACKAGE_VERSION" != "$VERSION" ]; then
+            echo "Release source package version ${PACKAGE_VERSION} does not match ${VERSION}"
+            exit 1
+          fi
+
+          # tag 指向实际发布源码，确保源码中的 Native 与本次构建资产一致。
+          if [ "$TAG_EXISTS" = "true" ]; then
             echo "Existing tag v${VERSION} points to ${TAG_TARGET}"
           else
-            git tag -a "v${VERSION}" -m "Release v${VERSION}"
+            git tag -a "v${VERSION}" "$RELEASE_COMMIT" -m "Release v${VERSION}"
             git push origin "v${VERSION}"
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,12 @@ Closes #123
 - ✅ 分支前缀和 commit type 都必须反映实际改动；`feature/` 通常对应 `feat:`，会使中版本号 +1
 - ❌ **PR 合并后不会自动发布 npm**
 - ✅ **主包 npm 发布只能手动运行 GitHub Actions workflow**
+- ✅ 主包 Native 复用必须绑定 npm 当前线上版本对应的 `v<version>` tag 和 Release，并校验
+  6 个平台资产完整；不得读取仓库最新 Release，以免混入 Maker、DSH 或客户端插件版本。
+- ✅ 主包 release tag 必须指向实际发布源码提交；创建 tag 前比较 workflow 启动提交与 tag
+  目标的 Native 源码，存在差异必须停止，禁止让 tag 指向未参与 Native 构建的并发合并。
+- ✅ macOS Intel Native 必须显式传入 `x86_64-apple-darwin` target；ARM64 musl 交叉编译固定
+  Rust `1.97.0` 并启用 fail-fast，直到 Zig 工具链确认兼容 Rust 1.98 的新链接参数。
 
 **工作流程：**
 

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -316,11 +316,16 @@ npx commitlint --from HEAD~1 --to HEAD
 
 1. **解析版本** - 从 npm `latest` 读取当前线上版本，默认只递增 patch。
 2. **预检 Summary** - 展示当前线上版本、目标版本、是否修改 major/minor。
-3. **质量检查** - 运行 lint、format check、build、test。
-4. **生成发布产物** - 更新 `package.json`，生成主包 CHANGELOG / Release notes。
-5. **发布到 npm** - 发布 `@taptap/instant-games-open-mcp@latest`。
-6. **创建 release PR** - 写回 `package.json` / `package-lock.json` / `CHANGELOG.md`。
-7. **创建 GitHub Release** - release PR 合并后创建 tag 和 GitHub Release。
+3. **解析 Native 来源** - 仅使用当前线上主包版本对应的 `v<version>` tag 和 Release；
+   Maker、DSH 和客户端插件的独立 tag / Release 不参与主包 Native 变更比较或产物复用。
+   复用前必须确认 6 个受支持平台的 Native 资产全部存在，缺少任一平台都重新构建。
+   新 tag 指向实际发布源码提交；创建 tag 前再次校验该提交与 workflow 启动提交的 Native
+   源码完全一致，防止发布期间并发合并造成 tag 与二进制错位。
+4. **质量检查** - 运行 lint、format check、build、test。
+5. **生成发布产物** - 更新 `package.json`，生成主包 CHANGELOG / Release notes。
+6. **发布到 npm** - 发布 `@taptap/instant-games-open-mcp@latest`。
+7. **创建 release PR** - 写回 `package.json` / `package-lock.json` / `CHANGELOG.md`。
+8. **创建 GitHub Release** - release PR 合并后创建 tag 和 GitHub Release。
 
 **npm 发布策略**：
 

--- a/src/__tests__/releaseWorkflowGuards.test.ts
+++ b/src/__tests__/releaseWorkflowGuards.test.ts
@@ -12,6 +12,15 @@ function getStepBody(workflow: string, stepName: string) {
   return nextStepIndex === -1 ? step : step.slice(0, nextStepIndex);
 }
 
+function getMatrixTargetBody(workflow: string, target: string) {
+  const targetMarker = `target: ${target}`;
+  const targetIndex = workflow.indexOf(targetMarker);
+  const targetBody = workflow.slice(targetIndex);
+  const nextTargetIndex = targetBody.indexOf('\n          - host:', targetMarker.length);
+
+  return nextTargetIndex === -1 ? targetBody : targetBody.slice(0, nextTargetIndex);
+}
+
 describe('release PR required workflow guards', () => {
   it('runs CodeQL for release PRs targeting main', () => {
     const workflow = readWorkflow('codeql.yml');
@@ -47,6 +56,60 @@ describe('release PR required workflow guards', () => {
     expect(workflow).not.toContain('[skip ci]');
     expect(workflow).not.toContain('[ci skip]');
     expect(workflow).not.toContain('[skip actions]');
+  });
+
+  it('reuses native binaries only from the current main package release', () => {
+    const workflow = readWorkflow('release.yml');
+    const nativeCheckStep = getStepBody(workflow, 'Check native changes');
+    const releaseCheckStep = getStepBody(workflow, 'Check existing release assets');
+    const downloadStep = getStepBody(
+      workflow,
+      'Download native binaries from main package release'
+    );
+
+    expect(nativeCheckStep).toContain(
+      'MAIN_RELEASE_TAG="v${{ steps.version.outputs.current_version }}"'
+    );
+    expect(nativeCheckStep).not.toContain('git describe --tags');
+
+    expect(releaseCheckStep).toContain(
+      'MAIN_RELEASE_TAG="v${{ steps.version.outputs.current_version }}"'
+    );
+    expect(releaseCheckStep).not.toContain('gh release list');
+    for (const asset of [
+      'taptap-signer.darwin-x64.node',
+      'taptap-signer.darwin-arm64.node',
+      'taptap-signer.linux-x64-gnu.node',
+      'taptap-signer.linux-x64-musl.node',
+      'taptap-signer.linux-arm64-musl.node',
+      'taptap-signer.win32-x64-msvc.node',
+    ]) {
+      expect(releaseCheckStep).toContain(asset);
+    }
+
+    expect(downloadStep).toContain(
+      'MAIN_RELEASE_TAG="v${{ needs.analyze.outputs.current_version }}"'
+    );
+    expect(downloadStep).not.toContain('gh release list');
+  });
+
+  it('builds native targets with reproducible cross-compilation guards', () => {
+    for (const workflowName of ['release.yml', 'build-native.yml']) {
+      const workflow = readWorkflow(workflowName);
+      const macX64Target = getMatrixTargetBody(workflow, 'x86_64-apple-darwin');
+      const linuxArm64MuslTarget = getMatrixTargetBody(workflow, 'aarch64-unknown-linux-musl');
+
+      expect(macX64Target).toContain('npm run build -- --target x86_64-apple-darwin');
+
+      expect(linuxArm64MuslTarget).toContain('set -euo pipefail');
+      expect(linuxArm64MuslTarget).toContain(
+        'rustup toolchain install 1.97.0 --profile minimal --target aarch64-unknown-linux-musl'
+      );
+      expect(linuxArm64MuslTarget).toContain('export RUSTUP_TOOLCHAIN=1.97.0');
+      expect(linuxArm64MuslTarget).toContain('rustc --version');
+      expect(linuxArm64MuslTarget).toContain('zig version');
+      expect(linuxArm64MuslTarget).not.toContain('rustup update stable');
+    }
   });
 
   it('creates generated release PRs with the release GitHub App token', () => {
@@ -107,9 +170,41 @@ describe('release PR required workflow guards', () => {
     expect(releaseStep).toMatch(
       /git config user\.name "github-actions\[bot\]"[\s\S]*git tag -a "v\$\{VERSION\}"/
     );
-    expect(releaseStep).toContain('MERGE_COMMIT=${{ steps.wait_for_merge.outputs.merge_commit }}');
-    expect(releaseStep).toContain('git checkout -B main "$MERGE_COMMIT"');
-    expect(releaseStep).not.toContain('git checkout -B main origin/main');
+    expect(releaseStep).toContain(
+      'RELEASE_COMMIT=${{ steps.wait_for_merge.outputs.release_commit }}'
+    );
+    expect(releaseStep).toContain(
+      'git tag -a "v${VERSION}" "$RELEASE_COMMIT" -m "Release v${VERSION}"'
+    );
+    expect(releaseStep).toContain('git diff --quiet "$WORKFLOW_COMMIT" "$SOURCE_COMMIT" --');
+    expect(releaseStep).not.toContain('git checkout -B main');
+  });
+
+  it('tags the source commit whose native tree produced the release assets', () => {
+    const workflow = readWorkflow('release.yml');
+    const notesStep = getStepBody(workflow, 'Generate filtered main package release notes');
+    const waitStep = getStepBody(workflow, 'Wait for release PR merge');
+    const releaseStep = getStepBody(workflow, 'Create GitHub Release');
+
+    expect(notesStep).toContain('LAST_RELEASE_TAG: v${{ needs.analyze.outputs.current_version }}');
+    expect(waitStep).toContain('--json mergeCommit,headRefOid');
+    expect(waitStep).toContain('INITIAL_PR_STATE="${{ steps.release_pr.outputs.state }}"');
+    expect(waitStep).toContain('RELEASE_COMMIT="$PR_HEAD_COMMIT"');
+    expect(waitStep).toContain('RELEASE_COMMIT="$MERGE_COMMIT"');
+    expect(waitStep).toContain('release_commit=${RELEASE_COMMIT}');
+    expect(waitStep).toContain('pr_head_commit=${PR_HEAD_COMMIT}');
+    expect(waitStep).toContain('pr_number=${PR_NUMBER}');
+
+    expect(releaseStep).toContain('PR_NUMBER=${{ steps.wait_for_merge.outputs.pr_number }}');
+    expect(releaseStep).toContain('git fetch origin "refs/pull/${PR_NUMBER}/head"');
+    expect(releaseStep).toContain('SOURCE_COMMIT="$RELEASE_COMMIT"');
+    expect(releaseStep).toContain('SOURCE_COMMIT="$TAG_TARGET"');
+    expect(releaseStep).toContain(
+      '[ "$TAG_TARGET" != "$PR_HEAD_COMMIT" ] && [ "$TAG_TARGET" != "$MERGE_COMMIT" ]'
+    );
+    expect(releaseStep).toContain('git diff --name-only "$WORKFLOW_COMMIT" "$SOURCE_COMMIT" --');
+    expect(releaseStep).toContain('Native source changed after workflow dispatch');
+    expect(releaseStep).toContain('points to unexpected commit ${TAG_TARGET}');
   });
 
   it('creates a reviewable Maker version policy PR after Maker package publish', () => {


### PR DESCRIPTION
## 问题

主包发布错误读取仓库最新的 `dsh-maker-v0.1.1` Release，导致本应复用的 Native 被全部重建。重建同时暴露了 ARM64 musl 工具链漂移和 macOS x64 隐式构建为 ARM64 的问题。

## 修复

- 主包只使用 npm 当前版本对应的 `v<version>` tag 和 Release
- 复用前校验六个平台 Native 资产完整，避免继续发布缺失平台的包
- macOS Intel 显式构建 `x86_64-apple-darwin`
- ARM64 musl 固定已验证的 Rust 1.97.0，并启用 fail-fast
- 同步独立 Native 验证 workflow、守卫测试和 CI/CD 文档

## 边界

- 不修改 H5、Maker、DSH 或客户端插件运行时
- 不修改 Maker、DSH 或客户端插件发布 workflow
- 旧失败 run 未执行 Release job，没有 npm、release PR、tag 或 GitHub Release 副作用

## 验证

- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm test -- --runInBand`：66 suites / 967 tests
- Build Native Signer：六平台全部通过，run 33058665745
- 下载产物并核验真实架构：darwin x64/arm64、Linux x64/ARM64、Windows x64 均正确