### PR TITLE
docs(workbuddy): 记录插件市场发布包结构

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -400,8 +400,9 @@ Maker 本地开发的默认路径是 CLI-first + PAT-first：
   marketplace ZIP、WorkBuddy 官方市场根级 ZIP、`INSTALL.md`、`SHA256SUMS` 和
   `maker-plugin-release.json`。插件发布不得调用
   npm publish、不得复用 Maker npm 或主包 release workflow。插件专属安装页固定为
-  `plugins/taptap-maker/README.md`；对外安装使用对应渠道的 GitHub Release 页面和 ZIP。直接从
-  仓库添加 marketplace 只用于源码验证，并且必须在添加前用生成目录中的 CLI 完成旧 MCP 检查。
+  `plugins/taptap-maker/README.md`；Codex 对外安装使用对应渠道的 GitHub Release 页面和 ZIP，
+  WorkBuddy 对外安装使用官方插件市场。直接从仓库添加 marketplace 只用于源码或 develop 预览版
+  验证，并且必须在添加前用生成目录中的 CLI 完成旧 MCP 检查。
 - DSH bundle 插件 `@taptap/dsh-maker` 位于 `packages/dsh-maker/`，使用独立版本并精确依赖
   `@taptap/maker`。`Publish DSH Maker Plugin` 从 `develop` 只发布 GitHub prerelease，从 `main`
   同时发布 npm `latest` 和 GitHub Release；1024Store 使用 npm 包名作为市场入口。DSH 发布不得

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -385,14 +385,20 @@ Maker 本地开发的默认路径是 CLI-first + PAT-first：
   `${CODEBUDDY_PLUGIN_ROOT}/dist/maker.js`；启动器优先 `WORKBUDDY_EXTRA_PATHS` 和 WorkBuddy
   managed Node 目录，再回退系统 PATH。Windows 必须同时支持版本目录根和 `bin` 子目录中的
   `node.exe`。插件不依赖 npm/npx，也不固定项目 `cwd`。
+  WorkBuddy 官方市场 ZIP 必须直接压缩插件根目录内容，不得包含 `taptap-maker/` 或
+  `plugins/workbuddy/taptap-maker/` 外层目录；ZIP 根必须包含 `.codebuddy-plugin/plugin.json`、
+  `.mcp.json`、`README.md` 和 `SKILL.md`，所有文件的父目录深度最多为两层，并拒绝
+  `__MACOSX`、`.DS_Store` 等系统元数据。`.codebuddy-plugin/marketplace.json` 只用于仓库源码验证，
+  不得放入 WorkBuddy 官方市场 ZIP。
   `create-project` 和 `sync-project` 是仅有的两个快捷命令，执行前必须要求空 workspace。
   WorkBuddy 插件的 `init` 和 `dev-kit update` 必须逐项检查
   `.workbuddy/skills/taptap-maker-*`，只从 `.installer/skills` 补齐缺失的项目 Skill，不得覆盖已有
   同名 Skill。该同步不得影响独立 Maker MCP、Codex 插件或其他客户端；目录链接不可用时才复制。
 - Codex/WorkBuddy 客户端插件发布只使用 `Prepare Maker Plugin Release` 和
   `Publish Maker Plugin` workflows。
-  前者按最新 `maker-plugin-v*` tag 自动递增 patch 并创建版本 PR；后者在 PR 合并后发布两份完整
-  marketplace ZIP、`INSTALL.md`、`SHA256SUMS` 和 `maker-plugin-release.json`。插件发布不得调用
+  前者按最新 `maker-plugin-v*` tag 自动递增 patch 并创建版本 PR；后者在 PR 合并后发布 Codex
+  marketplace ZIP、WorkBuddy 官方市场根级 ZIP、`INSTALL.md`、`SHA256SUMS` 和
+  `maker-plugin-release.json`。插件发布不得调用
   npm publish、不得复用 Maker npm 或主包 release workflow。插件专属安装页固定为
   `plugins/taptap-maker/README.md`；对外安装使用对应渠道的 GitHub Release 页面和 ZIP。直接从
   仓库添加 marketplace 只用于源码验证，并且必须在添加前用生成目录中的 CLI 完成旧 MCP 检查。

--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ Node.js（包括 Windows 上未加入 PATH 的 `node.exe`），必要时才回�
 /reload-plugins
 ```
 
+上述 marketplace 只用于从仓库源码验证。正式 WorkBuddy 市场发布 ZIP 直接以插件内容为根，
+不包含额外的 `taptap-maker/` 或 `plugins/workbuddy/taptap-maker/` 目录；根目录包含
+`.codebuddy-plugin/plugin.json`、`.mcp.json`、`README.md` 和 `SKILL.md`，所有文件的父目录深度
+最多为两层。普通用户通过 WorkBuddy 官方插件市场安装，不把发布 ZIP 当成本地 marketplace。
+
 WorkBuddy 旧独立 MCP 的迁移使用 `--client workbuddy`，只把旧注册的 `disabled` 设为 `true`，
 同时支持幂等检查和确认式恢复。插件更新通过 WorkBuddy `/plugin` 完成。
 

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -419,6 +419,11 @@ Codex 和 WorkBuddy 插件共用独立插件版本，不复用 `@taptap/maker` n
 2. 版本 PR 通过普通 PR Check 并合入 `main` 后，`Publish Maker Plugin` 自动校验生成物，打包
    Codex 与 WorkBuddy ZIP、校验和及机器可读元数据，并创建 `maker-plugin-v<version>` Release。
 
+Codex ZIP 保持离线 marketplace 结构。WorkBuddy ZIP 直接以插件根目录内容为压缩包根，不包含
+`taptap-maker/`、`plugins/workbuddy/taptap-maker/` 或仓库级 marketplace 外壳；根目录必须包含
+`.codebuddy-plugin/plugin.json`、`.mcp.json`、`README.md` 和 `SKILL.md`，所有文件的父目录深度
+最多为两层。打包脚本会拒绝超深目录、`__MACOSX` 和 `.DS_Store`，避免官方市场上传失败。
+
 公开测试版只能从 `develop` 手动运行 `Publish Maker Plugin`，版本格式为下一个稳定 patch 加
 `-dev.<run_number>`，并标记为 GitHub Prerelease。`develop` push 不自动发版。测试通过后，代码通过
 PR 合入 `main`，再走稳定版准备流程。


### PR DESCRIPTION
## 改动内容
- 记录 WorkBuddy 官方市场 ZIP 的根级目录结构
- 说明必需根文件、两层父目录限制和系统元数据禁用规则
- 区分仓库源码 marketplace 验证与官方插件市场安装流程
- 区分 Codex Release ZIP 与 WorkBuddy 官方市场安装渠道

## 合并前置
- 依赖实现 PR #435，必须在 #435 合并到 main 后再合并本 PR
- 两个 PR 分离是为了避免 Maker 与共享文档路径混合触发 release scope 拒绝

## 影响面
- 仅更新 AGENTS.md、README.md 和 docs/CI_CD.md
- 不修改插件运行时、打包逻辑或发布 workflow
- 与 Maker 实现 PR #435 分离，避免混合 release scope

## 验证
- release scope 校验通过：0 Maker files、3 Non-Maker files
- git diff --check 通过
- 按用户要求未运行本地测试或打包命令
- pre-commit hook 自动执行 Prettier